### PR TITLE
more detailed Applicability results / add metric to ConstraintResult / scoverage

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <encoding>UTF-8</encoding>
         <scala.major.version>2.11</scala.major.version>
         <scala.version>${scala.major.version}.5</scala.version>
+        <scala-maven-plugin.version>3.4.4</scala-maven-plugin.version>
     </properties>
 
     <dependencies>
@@ -118,7 +119,7 @@
             <plugin>
                 <groupId>net.alchim31.maven</groupId>
                 <artifactId>scala-maven-plugin</artifactId>
-                <version>3.2.0</version>
+                <version>${scala-maven-plugin.version}</version>
                 <configuration>
                     <scalaCompatVersion>${scala.major.version}</scalaCompatVersion>
                     <scalaVersion>${scala.version}</scalaVersion>
@@ -240,6 +241,19 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <!-- scoverage -->
+            <plugin>
+                <groupId>org.scoverage</groupId>
+                <artifactId>scoverage-maven-plugin</artifactId>
+                <version>1.3.0</version>
+                <configuration>
+                    <scalaCompatVersion>${scala.major.version}</scalaCompatVersion>
+                    <scalaVersion>${scala.version}</scalaVersion>
+                    <!--<minimumCoverage>80</minimumCoverage>-->
+                    <!--<failOnMinimumCoverage>true</failOnMinimumCoverage>-->
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 
@@ -251,7 +265,7 @@
                     <plugin>
                         <groupId>net.alchim31.maven</groupId>
                         <artifactId>scala-maven-plugin</artifactId>
-                        <version>3.2.0</version>
+                        <version>${scala-maven-plugin.version}</version>
                         <configuration>
                             <scalaCompatVersion>${scala.major.version}</scalaCompatVersion>
                             <scalaVersion>${scala.version}</scalaVersion>

--- a/src/main/scala/com/amazon/deequ/VerificationSuite.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationSuite.scala
@@ -16,16 +16,15 @@
 
 package com.amazon.deequ
 
-import com.amazon.deequ.analyzers.applicability.ApplicabilityResult
-import com.amazon.deequ.analyzers.runners.{AnalysisRunner, AnalysisRunnerRepositoryOptions, AnalyzerContext}
 import com.amazon.deequ.analyzers._
-import com.amazon.deequ.analyzers.applicability.Applicability
+import com.amazon.deequ.analyzers.applicability.{AnalyzersApplicability, Applicability, CheckApplicability}
+import com.amazon.deequ.analyzers.runners.{AnalysisRunner, AnalysisRunnerRepositoryOptions, AnalyzerContext}
 import com.amazon.deequ.checks.{Check, CheckStatus}
 import com.amazon.deequ.io.DfsUtils
 import com.amazon.deequ.metrics.Metric
 import com.amazon.deequ.repository.{MetricsRepository, ResultKey}
-import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{DataFrame, SparkSession}
 
 private[deequ] case class VerificationMetricsRepositoryOptions(
       metricsRepository: Option[MetricsRepository] = None,
@@ -240,7 +239,7 @@ class VerificationSuite {
       check: Check,
       schema: StructType,
       sparkSession: SparkSession)
-    : ApplicabilityResult = {
+    : CheckApplicability = {
 
     new Applicability(sparkSession).isApplicable(check, schema)
   }
@@ -256,7 +255,7 @@ class VerificationSuite {
       analyzers: Seq[Analyzer[_ <: State[_], Metric[_]]],
       schema: StructType,
       sparkSession: SparkSession)
-    : ApplicabilityResult = {
+    : AnalyzersApplicability = {
 
     new Applicability(sparkSession).isApplicable(analyzers, schema)
   }

--- a/src/main/scala/com/amazon/deequ/analyzers/applicability/Applicability.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/applicability/Applicability.scala
@@ -16,19 +16,32 @@
 
 package com.amazon.deequ.analyzers.applicability
 
+import java.sql.Timestamp
+
 import com.amazon.deequ.analyzers.{Analyzer, State}
 import com.amazon.deequ.checks.Check
 import com.amazon.deequ.constraints.{AnalysisBasedConstraint, Constraint, ConstraintDecorator}
 import com.amazon.deequ.metrics.Metric
-import java.sql.Timestamp
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+
 import scala.util.Failure
 
-private[deequ] case class ApplicabilityResult(
+private[deequ] sealed trait ApplicabilityResult {
+  def isApplicable: Boolean
+  def failures: Seq[(String, Exception)]
+}
+
+private[deequ] case class CheckApplicability(
   isApplicable: Boolean,
-  failures: Seq[(String, Throwable)]
-)
+  failures: Seq[(String, Exception)],
+  constraintApplicabilities: Map[Constraint, Boolean]
+) extends ApplicabilityResult
+
+private[deequ] case class AnalyzersApplicability(
+  isApplicable: Boolean,
+  failures: Seq[(String, Exception)]
+) extends ApplicabilityResult
 
 private[deequ] object Applicability {
 
@@ -133,34 +146,38 @@ private[deequ] class Applicability(session: SparkSession) {
     * @param check A check that may be applicable to some data
     * @param schema The schema of the data the checks are for
     */
-  def isApplicable(check: Check, schema: StructType): ApplicabilityResult = {
+  def isApplicable(check: Check, schema: StructType): CheckApplicability = {
 
     val data = generateRandomData(schema, 1000)
 
-    val constraintsByName = check.constraints
+    val namedMetrics = check.constraints
       .map { constraint => constraint.toString -> constraint }
       .map {
         case (name, nc: ConstraintDecorator) => name -> nc.inner
         case (name, c: Constraint) => name -> c
       }
       .collect { case (name, constraint: AnalysisBasedConstraint[_, _, _]) =>
-        (name, constraint)
+        (name, constraint.analyzer.calculate(data).value)
       }
 
+    val constraintApplicabilities = check.constraints.zip(namedMetrics).map {
+      case (constraint, (_, metric)) =>
+        constraint -> metric.isSuccess
+    }.toMap
 
-    val failures = constraintsByName
-      .flatMap { case (name, constraint) =>
-        val maybeValue = constraint.analyzer.calculate(data).value
+    val failures = namedMetrics
+      .flatMap { case (name, metric) =>
 
-        maybeValue match {
+        metric match {
           // An exception occurred during analysis
-          case Failure(exception) => Some(name -> exception)
+          case Failure(exception: Exception) => Some(name -> exception)
           // Analysis done successfully and result metric is there
           case _ => None
         }
       }
 
-    ApplicabilityResult(failures.isEmpty, failures)
+
+    CheckApplicability(failures.isEmpty, failures, constraintApplicabilities)
   }
 
   /**
@@ -170,7 +187,7 @@ private[deequ] class Applicability(session: SparkSession) {
     * @param schema The schema of the data the analyzers are for
     */
   def isApplicable(analyzers: Seq[Analyzer[_ <: State[_], Metric[_]]], schema: StructType)
-    : ApplicabilityResult = {
+    : AnalyzersApplicability = {
 
     val data = generateRandomData(schema, 1000)
 
@@ -183,13 +200,13 @@ private[deequ] class Applicability(session: SparkSession) {
 
         maybeValue match {
           // An exception occurred during analysis
-          case Failure(exception) => Some(name -> exception)
+          case Failure(exception: Exception) => Some(name -> exception)
           // Analysis done successfully and result metric is there
           case _ => None
         }
       }
 
-    ApplicabilityResult(failures.isEmpty, failures)
+    AnalyzersApplicability(failures.isEmpty, failures)
   }
 
 

--- a/src/main/scala/com/amazon/deequ/constraints/AnalysisBasedConstraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/AnalysisBasedConstraint.scala
@@ -46,7 +46,7 @@ private[deequ] case class AnalysisBasedConstraint[S <: State[S], M, V](
     private[deequ] val hint: Option[String] = None)
   extends Constraint {
 
-  private[constraints] def calculateAndEvaluate(data: DataFrame) = {
+  private[deequ] def calculateAndEvaluate(data: DataFrame) = {
     val metric = analyzer.calculate(data)
     evaluate(Map(analyzer -> metric))
   }

--- a/src/main/scala/com/amazon/deequ/constraints/AnalysisBasedConstraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/AnalysisBasedConstraint.scala
@@ -77,7 +77,6 @@ private[deequ] case class AnalysisBasedConstraint[S <: State[S], M, V](
             ConstraintResult(this, ConstraintStatus.Success, metric = Some(metric))
           } else {
             var errorMessage = s"Value: $assertOn does not meet the constraint requirement!"
-
             hint.foreach(hint => errorMessage += s" $hint")
 
             ConstraintResult(this, ConstraintStatus.Failure, Some(errorMessage), Some(metric))

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -50,7 +50,9 @@ class ConstraintDecorator(protected val _inner: Constraint) extends Constraint {
       analysisResults: Map[Analyzer[_, Metric[_]], Metric[_]])
     : ConstraintResult = {
 
-    // constraint = this to keep toString of NamedConstraint
+    // most of the constraints are of type NamedConstraint
+    // having `this` as the constraint of the result to
+    // keep the more informative .toString of NamedConstraint
     _inner.evaluate(analysisResults).copy(constraint = this)
   }
 }
@@ -71,10 +73,6 @@ class NamedConstraint(private[deequ] val constraint: Constraint, name: String)
   * These methods can be used from the unit tests or during creation of Check configuration
   */
 object Constraint {
-
-  def named(constraint: Constraint, name: String): NamedConstraint = {
-    new NamedConstraint(constraint, name)
-  }
 
   /**
     * Runs Size analysis on the given column and executes the assertion

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -29,7 +29,8 @@ object ConstraintStatus extends Enumeration {
 case class ConstraintResult(
     constraint: Constraint,
     status: ConstraintStatus.Value,
-    message: Option[String] = None)
+    message: Option[String] = None,
+    metric: Option[Metric[_]] = None)
 
 /** Common trait for all data quality constraints */
 trait Constraint {
@@ -49,8 +50,7 @@ class ConstraintDecorator(protected val _inner: Constraint) extends Constraint {
       analysisResults: Map[Analyzer[_, Metric[_]], Metric[_]])
     : ConstraintResult = {
 
-    val result = _inner.evaluate(analysisResults)
-    ConstraintResult(this, result.status, result.message)
+    _inner.evaluate(analysisResults)
   }
 }
 

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -50,7 +50,8 @@ class ConstraintDecorator(protected val _inner: Constraint) extends Constraint {
       analysisResults: Map[Analyzer[_, Metric[_]], Metric[_]])
     : ConstraintResult = {
 
-    _inner.evaluate(analysisResults)
+    // constraint = this to keep toString of NamedConstraint
+    _inner.evaluate(analysisResults).copy(constraint = this)
   }
 }
 

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -30,8 +30,6 @@ import com.amazon.deequ.utils.{FixtureSupport, TempFileUtils}
 import org.apache.spark.sql.DataFrame
 import org.scalatest.{Matchers, WordSpec}
 
-import scala.util.Try
-
 
 class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
   with FixtureSupport {
@@ -232,7 +230,7 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
         val expectedAnalyzerContextOnLoadByKey = AnalyzerContext(actualResult.metrics)
 
         val resultWhichShouldBeOverwritten = AnalyzerContext(Map(Size() -> DoubleMetric(
-          Entity.Dataset, "", "", Try(100.0))))
+          Entity.Dataset, "", "", util.Try(100.0))))
 
         repository.save(resultKey, resultWhichShouldBeOverwritten)
 
@@ -347,14 +345,14 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
 
     (1 to 2).foreach { timeStamp =>
       val analyzerContext = new AnalyzerContext(Map(
-        Size() -> DoubleMetric(Entity.Column, "", "", Success(timeStamp))
+        Size() -> DoubleMetric(Entity.Column, "", "", util.Success(timeStamp))
       ))
       repository.save(ResultKey(timeStamp, Map("Region" -> "EU")), analyzerContext)
     }
 
     (3 to 4).foreach { timeStamp =>
       val analyzerContext = new AnalyzerContext(Map(
-        Size() -> DoubleMetric(Entity.Column, "", "", Success(timeStamp))
+        Size() -> DoubleMetric(Entity.Column, "", "", util.Success(timeStamp))
       ))
       repository.save(ResultKey(timeStamp, Map("Region" -> "NA")), analyzerContext)
     }

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -330,7 +330,6 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
 
       val results = VerificationSuite().onData(df)
         .addCheck(check)
-        .useSparkSession(sparkSession)
         .run()
 
       val checkConstraintsWithResultConstraints = check.constraints.zip(

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -61,19 +61,23 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
 
 
         Seq(checkToSucceed, checkToErrorOut).forEachOrder { checks =>
-          assert(VerificationSuite().onData(df).addChecks(checks).run().status == CheckStatus.Error)
+          assert(
+            VerificationSuite().onData(df).addChecks(checks).run().status == CheckStatus.Error)
         }
 
         Seq(checkToSucceed, checkToWarn).forEachOrder { checks =>
-          assert(VerificationSuite().onData(df).addChecks(checks).run().status == CheckStatus.Warning)
+          assert(
+            VerificationSuite().onData(df).addChecks(checks).run().status == CheckStatus.Warning)
         }
 
         Seq(checkToWarn, checkToErrorOut).forEachOrder { checks =>
-          assert(VerificationSuite().onData(df).addChecks(checks).run().status == CheckStatus.Error)
+          assert(
+            VerificationSuite().onData(df).addChecks(checks).run().status == CheckStatus.Error)
         }
 
         Seq(checkToSucceed, checkToWarn, checkToErrorOut).forEachOrder { checks =>
-          assert(VerificationSuite().onData(df).addChecks(checks).run().status == CheckStatus.Error)
+          assert(
+            VerificationSuite().onData(df).addChecks(checks).run().status == CheckStatus.Error)
         }
       }
 

--- a/src/test/scala/com/amazon/deequ/constraints/AnalysisBasedConstraintTest.scala
+++ b/src/test/scala/com/amazon/deequ/constraints/AnalysisBasedConstraintTest.scala
@@ -74,7 +74,7 @@ class AnalysisBasedConstraintTest extends WordSpec with Matchers with SparkConte
 
   "Analysis based constraint" should {
 
-    "should assert correctly on values if analysis is successful" in
+    "assert correctly on values if analysis is successful" in
       withSparkSession { sparkSession =>
         val df = getDfMissing(sparkSession)
 

--- a/src/test/scala/com/amazon/deequ/constraints/ConstraintsTest.scala
+++ b/src/test/scala/com/amazon/deequ/constraints/ConstraintsTest.scala
@@ -59,6 +59,7 @@ class ConstraintsTest extends WordSpec with Matchers with SparkContextSpec with 
       metric match {
         case result =>
           assert(result.status == ConstraintStatus.Failure)
+          assert(result.message.isDefined)
           assert(result.message.get.startsWith(AnalysisBasedConstraint.AssertionException))
       }
     }


### PR DESCRIPTION
*Description of changes:*
* each `ConstraintResult` in `CheckResult` is now linked to the metric that the constraint evaluation was based on
* the result of `Applicability.isApplicable(check)` now contains all constraints and their applicabilities
* adds *scoverage* with optional code coverage requirements, currently we are at a method coverage of 81% (run with `mvn scoverage:report`, https://github.com/scoverage/scoverage-maven-plugin)
* test for constraint assertions that throw exceptions

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
