### PR TITLE
Fix mean calculation

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/Mean.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Mean.scala
@@ -19,7 +19,7 @@ package com.amazon.deequ.analyzers
 import com.amazon.deequ.analyzers.Preconditions.{hasColumn, isNumeric}
 import org.apache.spark.sql.{Column, Row}
 import org.apache.spark.sql.functions.{count, sum}
-import org.apache.spark.sql.types.{DoubleType, StructType}
+import org.apache.spark.sql.types.{DoubleType, StructType, LongType}
 import Analyzers._
 
 case class MeanState(sum: Double, count: Long) extends DoubleValuedState[MeanState] {
@@ -37,7 +37,8 @@ case class Mean(column: String, where: Option[String] = None)
   extends StandardScanShareableAnalyzer[MeanState]("Mean", column) {
 
   override def aggregationFunctions(): Seq[Column] = {
-    sum(conditionalSelection(column, where)).cast(DoubleType) :: count("*") :: Nil
+    sum(conditionalSelection(column, where)).cast(DoubleType) ::
+      count(conditionalSelection(column, where)).cast(LongType) :: Nil
   }
 
   override def fromAggregationResult(result: Row, offset: Int): Option[MeanState] = {

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
@@ -418,6 +418,11 @@ class AnalyzerTests extends WordSpec with Matchers with SparkContextSpec with Fi
       val df = getDfFull(sparkSession)
       assert(Mean("att1").calculate(df).value.isFailure)
     }
+    "compute mean correctly for numeric data with filtering" in withSparkSession { sparkSession =>
+      val df = getDfWithNumericValues(sparkSession)
+      val result = Mean("att1", where = Some("item != '6'")).calculate(df).value
+      result shouldBe Success(3.0)
+    }
 
     "compute standard deviation correctly for numeric data" in withSparkSession { sparkSession =>
       val df = getDfWithNumericValues(sparkSession)

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
@@ -418,11 +418,12 @@ class AnalyzerTests extends WordSpec with Matchers with SparkContextSpec with Fi
       val df = getDfFull(sparkSession)
       assert(Mean("att1").calculate(df).value.isFailure)
     }
-    "compute mean correctly for numeric data with where predicate" in withSparkSession { sparkSession =>
-      val df = getDfWithNumericValues(sparkSession)
-      val result = Mean("att1", where = Some("item != '6'")).calculate(df).value
-      result shouldBe Success(3.0)
-    }
+    "compute mean correctly for numeric data with where predicate" in
+      withSparkSession { sparkSession =>
+        val df = getDfWithNumericValues(sparkSession)
+        val result = Mean("att1", where = Some("item != '6'")).calculate(df).value
+        result shouldBe Success(3.0)
+      }
 
     "compute standard deviation correctly for numeric data" in withSparkSession { sparkSession =>
       val df = getDfWithNumericValues(sparkSession)

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
@@ -418,7 +418,7 @@ class AnalyzerTests extends WordSpec with Matchers with SparkContextSpec with Fi
       val df = getDfFull(sparkSession)
       assert(Mean("att1").calculate(df).value.isFailure)
     }
-    "compute mean correctly for numeric data with filtering" in withSparkSession { sparkSession =>
+    "compute mean correctly for numeric data with where predicate" in withSparkSession { sparkSession =>
       val df = getDfWithNumericValues(sparkSession)
       val result = Mean("att1", where = Some("item != '6'")).calculate(df).value
       result shouldBe Success(3.0)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The mean was calculated in a wrong way when filtering the result set with a where-clause. Fixed that calculation and wrote a test for it. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
