### PR TITLE
Bugfix: Escape Column Name in Generated Spark SQL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 *.iml
 **/*.iml
 target/.travis/public-signing-key.gpg
+target/

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -837,7 +837,7 @@ case class Check(
       .map { _.replaceAll("'", "''") }
       .mkString("'", "','", "'")
 
-    val predicate = s"$column IS NULL OR $column IN ($valueList)"
+    val predicate = s"`$column` IS NULL OR `$column` IN ($valueList)"
     satisfies(predicate, s"$column contained in ${allowedValues.mkString(",")}", assertion, hint)
   }
 
@@ -864,8 +864,8 @@ case class Check(
     val leftOperand = if (includeLowerBound) ">=" else ">"
     val rightOperand = if (includeUpperBound) "<=" else "<"
 
-    val predicate = s"$column IS NULL OR " +
-      s"($column $leftOperand $lowerBound AND $column $rightOperand $upperBound)"
+    val predicate = s"`$column` IS NULL OR " +
+      s"(`$column` $leftOperand $lowerBound AND `$column` $rightOperand $upperBound)"
 
     satisfies(predicate, s"$column between $lowerBound and $upperBound", hint = hint)
   }

--- a/src/main/scala/com/amazon/deequ/suggestions/rules/CategoricalRangeRule.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/rules/CategoricalRangeRule.scala
@@ -60,7 +60,7 @@ case class CategoricalRangeRule() extends ConstraintRule[ColumnProfile] {
       .mkString(""""""", """", """", """"""")
 
     val description = s"'${profile.column}' has value range $categoriesSql"
-    val columnCondition = s"${profile.column} IN ($categoriesSql)"
+    val columnCondition = s"`${profile.column}` IN ($categoriesSql)"
     val constraint = complianceConstraint(description, columnCondition, Check.IsOne)
 
     ConstraintSuggestion(

--- a/src/main/scala/com/amazon/deequ/suggestions/rules/FractionalCategoricalRangeRule.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/rules/FractionalCategoricalRangeRule.scala
@@ -80,7 +80,7 @@ case class FractionalCategoricalRangeRule(targetDataCoverageFraction: Double = 0
 
     val description = s"'${profile.column}' has value range $categoriesSql for at least " +
       s"${targetCompliance * 100}% of values"
-    val columnCondition = s"${profile.column} IN ($categoriesSql)"
+    val columnCondition = s"`${profile.column}` IN ($categoriesSql)"
     val hint = s"It should be above $targetCompliance!"
     val constraint = complianceConstraint(description, columnCondition, _ >= targetCompliance,
       hint = Some(hint))


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/deequ/issues/84

*Description of changes:*
This PR properly escapes column names in generated Spark SQL code.

Currently, when executing a `isContainedIn` `Check` on any `DataFrame` that contains any column whose name contains any characters that make up any reserved keyword in Spark SQL will cause a runtime failure. Digging into it, the runtime failure will show the root cause is a Spark SQL syntax error (specifically a `org.apache.spark.sql.catalyst.parser.ParseException`) due to incorrectly parsing the column name. 

E.g. if the column name starts with `[`, then the exception will read as:
```
org.apache.spark.sql.catalyst.parser.ParseException:
extraneous input '[' expecting ...
```

The fix for this bug is to wrap all bare column names in generated Spark SQL with backticks: \`\`. I.e. a query such as `$column IS NULL` is unsafe, but it's escaped variant is ok to execute, regardless of the value of `$column`:
```
`$column` IS NULL
```

A new test showcasing this functionality is in the `CheckTest` `class` named `"Check on column names with special characters"`. This test executes the `isContainedIn``Check` on both a value list as well as a (minimum, maximum) boundary. It succeeds only when the associated generated Spark SQL code has the escaped column name.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.