### PR TITLE
Sanitize column names in spark sql calls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/*.iml
 target/.travis/public-signing-key.gpg
 target/
+*.swp

--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,11 @@
             <name>Andrey Taptunov</name>
             <url>https://github.com/andrey-tpt</url>
         </developer>
+        <developer>
+            <id>malcolmgreaves</id>
+            <name>Malcolm Greaves</name>
+            <url>https://github.com/malcolmgreaves</url>
+        </developer>
     </developers>
 
     <scm>

--- a/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
@@ -383,10 +383,12 @@ private[deequ] object Analyzers {
   }
 
   def conditionalSelection(selection: String, where: Option[String]): Column = {
+    // NOTE: `selection` and `where` *MUST* be sanitized and valid Spark SQL.
     conditionalSelection(col(selection), where)
   }
 
   def conditionalSelection(selection: Column, condition: Option[String]): Column = {
+    // NOTE: `condition` *MUST* be sanitized and valid Spark SQL.
     val conditionColumn = condition.map { expression => expr(expression) }
     conditionalSelectionFromColumns(selection, conditionColumn)
   }
@@ -402,6 +404,7 @@ private[deequ] object Analyzers {
   }
 
   def conditionalCount(where: Option[String]): Column = {
+    // NOTE: `where` *MUST* be sanitized and valid Spark SQL.
     where
       .map { filter => sum(expr(filter).cast(LongType)) }
       .getOrElse(count("*"))

--- a/src/main/scala/com/amazon/deequ/analyzers/ApproxCountDistinct.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/ApproxCountDistinct.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.catalyst.expressions.aggregate.DeequHyperLogLogPlusP
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{Column, Row}
 import Analyzers._
+import com.amazon.deequ.schema.ColumnName
 
 case class ApproxCountDistinctState(words: Array[Long])
   extends DoubleValuedState[ApproxCountDistinctState] {
@@ -48,7 +49,7 @@ case class ApproxCountDistinct(column: String, where: Option[String] = None)
   extends StandardScanShareableAnalyzer[ApproxCountDistinctState]("ApproxCountDistinct", column) {
 
   override def aggregationFunctions(): Seq[Column] = {
-    stateful_approx_count_distinct(conditionalSelection(column, where)) :: Nil
+    stateful_approx_count_distinct(conditionalSelection(ColumnName.sanitize(column), where)) :: Nil
   }
 
   override def fromAggregationResult(result: Row, offset: Int): Option[ApproxCountDistinctState] = {

--- a/src/main/scala/com/amazon/deequ/analyzers/ApproxQuantile.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/ApproxQuantile.scala
@@ -19,6 +19,7 @@ package com.amazon.deequ.analyzers
 import com.amazon.deequ.analyzers.Preconditions.{hasColumn, isNumeric}
 import com.amazon.deequ.analyzers.runners.{IllegalAnalyzerParameterException, MetricCalculationException}
 import com.amazon.deequ.metrics.DoubleMetric
+import com.amazon.deequ.schema.ColumnName
 import org.apache.spark.sql.{DeequFunctions, Row}
 import org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile
 import org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile.PercentileDigest
@@ -61,7 +62,7 @@ case class ApproxQuantile(column: String, quantile: Double, relativeError: Doubl
   }
 
   override private[deequ] def aggregationFunctions() = {
-    DeequFunctions.stateful_approx_quantile(col(column), relativeError) :: Nil
+    DeequFunctions.stateful_approx_quantile(col(ColumnName.sanitize(column)), relativeError) :: Nil
   }
 
   override private[deequ] def fromAggregationResult(

--- a/src/main/scala/com/amazon/deequ/analyzers/ApproxQuantiles.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/ApproxQuantiles.scala
@@ -19,6 +19,7 @@ package com.amazon.deequ.analyzers
 import com.amazon.deequ.analyzers.Preconditions.{hasColumn, isNumeric}
 import com.amazon.deequ.analyzers.runners.{IllegalAnalyzerParameterException, MetricCalculationException}
 import com.amazon.deequ.metrics.{Entity, KeyedDoubleMetric}
+import com.amazon.deequ.schema.ColumnName
 import org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.StructType
@@ -53,7 +54,7 @@ case class ApproxQuantiles(column: String, quantiles: Seq[Double], relativeError
   }
 
   override private[deequ] def aggregationFunctions() = {
-    DeequFunctions.stateful_approx_quantile(col(column), relativeError) :: Nil
+    DeequFunctions.stateful_approx_quantile(col(ColumnName.sanitize(column)), relativeError) :: Nil
   }
 
   override private[deequ] def fromAggregationResult(

--- a/src/main/scala/com/amazon/deequ/analyzers/Completeness.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Completeness.scala
@@ -35,7 +35,8 @@ case class Completeness(column: String, where: Option[String] = None) extends
 
   override def aggregationFunctions(): Seq[Column] = {
 
-    val summation = sum(conditionalSelection(column, where).isNotNull.cast(IntegerType))
+    val summation = sum(conditionalSelection(column, where)
+      .isNotNull.cast(IntegerType))
 
     summation :: conditionalCount(where) :: Nil
   }

--- a/src/main/scala/com/amazon/deequ/analyzers/Compliance.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Compliance.scala
@@ -18,7 +18,7 @@ package com.amazon.deequ.analyzers
 
 import org.apache.spark.sql.types.IntegerType
 import org.apache.spark.sql.{Column, Row}
-import org.apache.spark.sql.functions._
+import org.apache.spark.sql.functions.{ sum, expr }
 import Analyzers._
 
 /**
@@ -31,7 +31,7 @@ import Analyzers._
   *                         Also the constraint given here can be referring to multiple columns,
   *                         so metric instance name should be provided,
   *                         describing what the analysis being done for.
-  * @param predicate SQL-predicate to apply per row
+  * @param predicate SQL-predicate to apply per row (MUST be valid Spark SQL syntax)
   * @param where Additional filter to apply before the analyzer is run.
   */
 case class Compliance(instance: String, predicate: String, where: Option[String] = None)

--- a/src/main/scala/com/amazon/deequ/analyzers/Compliance.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Compliance.scala
@@ -18,7 +18,7 @@ package com.amazon.deequ.analyzers
 
 import org.apache.spark.sql.types.IntegerType
 import org.apache.spark.sql.{Column, Row}
-import org.apache.spark.sql.functions.{ sum, expr }
+import org.apache.spark.sql.functions.{sum, expr}
 import Analyzers._
 
 /**

--- a/src/main/scala/com/amazon/deequ/analyzers/Correlation.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Correlation.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.DeequFunctions.stateful_corr
 import org.apache.spark.sql.{Column, Row}
 import org.apache.spark.sql.types.StructType
 import Analyzers._
+import com.amazon.deequ.schema.ColumnName
 
 case class CorrelationState(
     n: Double,
@@ -71,8 +72,8 @@ case class Correlation(
 
   override def aggregationFunctions(): Seq[Column] = {
 
-    val firstSelection = conditionalSelection(firstColumn, where)
-    val secondSelection = conditionalSelection(secondColumn, where)
+    val firstSelection = conditionalSelection(ColumnName.sanitize(firstColumn), where)
+    val secondSelection = conditionalSelection(ColumnName.sanitize(secondColumn), where)
 
     stateful_corr(firstSelection, secondSelection) :: Nil
   }

--- a/src/main/scala/com/amazon/deequ/analyzers/CountDistinct.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/CountDistinct.scala
@@ -19,7 +19,6 @@ package com.amazon.deequ.analyzers
 import com.amazon.deequ.metrics.DoubleMetric
 import org.apache.spark.sql.{Column, Row}
 import org.apache.spark.sql.functions.count
-import Analyzers._
 
 case class CountDistinct(columns: Seq[String])
   extends ScanShareableFrequencyBasedAnalyzer("CountDistinct", columns) {

--- a/src/main/scala/com/amazon/deequ/analyzers/DataType.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/DataType.scala
@@ -22,6 +22,7 @@ import com.amazon.deequ.analyzers.Analyzers._
 import com.amazon.deequ.analyzers.Preconditions.hasColumn
 import com.amazon.deequ.analyzers.runners.MetricCalculationException
 import com.amazon.deequ.metrics.{Distribution, DistributionValue, HistogramMetric}
+import com.amazon.deequ.schema.ColumnName
 import org.apache.spark.sql.DeequFunctions.stateful_datatype
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{Column, Row}
@@ -155,7 +156,7 @@ case class DataType(
   extends ScanShareableAnalyzer[DataTypeHistogram, HistogramMetric] {
 
   override def aggregationFunctions(): Seq[Column] = {
-    stateful_datatype(conditionalSelection(column, where)) :: Nil
+    stateful_datatype(conditionalSelection(ColumnName.sanitize(column), where)) :: Nil
   }
 
   override def fromAggregationResult(result: Row, offset: Int): Option[DataTypeHistogram] = {

--- a/src/main/scala/com/amazon/deequ/analyzers/GroupingAnalyzers.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/GroupingAnalyzers.scala
@@ -56,9 +56,11 @@ object FrequencyBasedAnalyzer {
       numRows: Option[Long] = None)
     : FrequenciesAndNumRows = {
 
-    val columnsToGroupBy = groupingColumns.map { unsafeColumnName =>
-      col(ColumnName.sanitize(unsafeColumnName))
-    }.toArray
+    val columnsToGroupBy = groupingColumns
+      .map { unsafeColumnName =>
+        col(ColumnName.sanitize(unsafeColumnName))
+      }
+      .toArray
     val projectionColumns = columnsToGroupBy :+ col(COUNT_COL)
 
     val noGroupingColumnIsNull = groupingColumns

--- a/src/main/scala/com/amazon/deequ/analyzers/Maximum.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Maximum.scala
@@ -17,6 +17,7 @@
 package com.amazon.deequ.analyzers
 
 import com.amazon.deequ.analyzers.Preconditions.{hasColumn, isNumeric}
+import com.amazon.deequ.schema.ColumnName
 import org.apache.spark.sql.{Column, Row}
 import org.apache.spark.sql.functions.max
 import org.apache.spark.sql.types.{DoubleType, StructType}
@@ -37,7 +38,7 @@ case class Maximum(column: String, where: Option[String] = None)
   extends StandardScanShareableAnalyzer[MaxState]("Maximum", column) {
 
   override def aggregationFunctions(): Seq[Column] = {
-    max(conditionalSelection(column, where)).cast(DoubleType) :: Nil
+    max(conditionalSelection(ColumnName.sanitize(column), where)).cast(DoubleType) :: Nil
   }
 
   override def fromAggregationResult(result: Row, offset: Int): Option[MaxState] = {

--- a/src/main/scala/com/amazon/deequ/analyzers/Mean.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Mean.scala
@@ -17,6 +17,7 @@
 package com.amazon.deequ.analyzers
 
 import com.amazon.deequ.analyzers.Preconditions.{hasColumn, isNumeric}
+import com.amazon.deequ.schema.ColumnName
 import org.apache.spark.sql.{Column, Row}
 import org.apache.spark.sql.functions.{count, sum}
 import org.apache.spark.sql.types.{DoubleType, StructType, LongType}
@@ -37,8 +38,9 @@ case class Mean(column: String, where: Option[String] = None)
   extends StandardScanShareableAnalyzer[MeanState]("Mean", column) {
 
   override def aggregationFunctions(): Seq[Column] = {
-    sum(conditionalSelection(column, where)).cast(DoubleType) ::
-      count(conditionalSelection(column, where)).cast(LongType) :: Nil
+    val columnSafeForSql = ColumnName.sanitize(column)
+    sum(conditionalSelection(columnSafeForSql, where)).cast(DoubleType) ::
+      count(conditionalSelection(columnSafeForSql, where)).cast(LongType) :: Nil
   }
 
   override def fromAggregationResult(result: Row, offset: Int): Option[MeanState] = {

--- a/src/main/scala/com/amazon/deequ/analyzers/Minimum.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Minimum.scala
@@ -17,6 +17,7 @@
 package com.amazon.deequ.analyzers
 
 import com.amazon.deequ.analyzers.Preconditions.{hasColumn, isNumeric}
+import com.amazon.deequ.schema.ColumnName
 import org.apache.spark.sql.{Column, Row}
 import org.apache.spark.sql.functions.min
 import org.apache.spark.sql.types.{DoubleType, StructType}
@@ -37,7 +38,7 @@ case class Minimum(column: String, where: Option[String] = None)
   extends StandardScanShareableAnalyzer[MinState]("Minimum", column) {
 
   override def aggregationFunctions(): Seq[Column] = {
-    min(conditionalSelection(column, where)).cast(DoubleType) :: Nil
+    min(conditionalSelection(ColumnName.sanitize(column), where)).cast(DoubleType) :: Nil
   }
 
   override def fromAggregationResult(result: Row, offset: Int): Option[MinState] = {

--- a/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
@@ -46,9 +46,8 @@ case class PatternMatch(column: String, pattern: Regex, where: Option[String] = 
 
   override def aggregationFunctions(): Seq[Column] = {
     val sanitizedColumn = col(ColumnName.sanitize(column))
-    val expression = when(
-        regexp_extract(sanitizedColumn, pattern.toString(), 0) =!= lit(""), 1
-    ).otherwise(0)
+    val expression = when(regexp_extract(sanitizedColumn, pattern.toString(), 0) =!= lit(""), 1)
+      .otherwise(0)
 
     val summation = sum(conditionalSelection(expression, where).cast(IntegerType))
 

--- a/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
@@ -17,6 +17,7 @@
 package com.amazon.deequ.analyzers
 
 import com.amazon.deequ.analyzers.Analyzers._
+import com.amazon.deequ.schema.ColumnName
 import org.apache.spark.sql.{Column, Row}
 import org.apache.spark.sql.functions.{col, lit, regexp_extract, sum, when}
 import org.apache.spark.sql.types.IntegerType
@@ -44,9 +45,9 @@ case class PatternMatch(column: String, pattern: Regex, where: Option[String] = 
   }
 
   override def aggregationFunctions(): Seq[Column] = {
-
-    val expression = when(regexp_extract(col(column), pattern.toString(), 0) =!= lit(""), 1)
-      .otherwise(0)
+    val expression = when(
+        regexp_extract(col(ColumnName.sanitize(column)), pattern.toString(), 0) =!= lit(""), 1
+    ).otherwise(0)
 
     val summation = sum(conditionalSelection(expression, where).cast(IntegerType))
 

--- a/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
@@ -45,8 +45,9 @@ case class PatternMatch(column: String, pattern: Regex, where: Option[String] = 
   }
 
   override def aggregationFunctions(): Seq[Column] = {
+    val sanitizedColumn = col(ColumnName.sanitize(column))
     val expression = when(
-        regexp_extract(col(ColumnName.sanitize(column)), pattern.toString(), 0) =!= lit(""), 1
+        regexp_extract(sanitizedColumn, pattern.toString(), 0) =!= lit(""), 1
     ).otherwise(0)
 
     val summation = sum(conditionalSelection(expression, where).cast(IntegerType))

--- a/src/main/scala/com/amazon/deequ/analyzers/StandardDeviation.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/StandardDeviation.scala
@@ -21,6 +21,7 @@ import org.apache.spark.sql.DeequFunctions.stateful_stddev_pop
 import org.apache.spark.sql.{Column, Row}
 import org.apache.spark.sql.types.StructType
 import Analyzers._
+import com.amazon.deequ.schema.ColumnName
 
 case class StandardDeviationState(
     n: Double,
@@ -48,7 +49,7 @@ case class StandardDeviation(column: String, where: Option[String] = None)
   extends StandardScanShareableAnalyzer[StandardDeviationState]("StandardDeviation", column) {
 
   override def aggregationFunctions(): Seq[Column] = {
-    stateful_stddev_pop(conditionalSelection(column, where)) :: Nil
+    stateful_stddev_pop(conditionalSelection(ColumnName.sanitize(column), where)) :: Nil
   }
 
   override def fromAggregationResult(result: Row, offset: Int): Option[StandardDeviationState] = {

--- a/src/main/scala/com/amazon/deequ/analyzers/Sum.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Sum.scala
@@ -18,6 +18,7 @@ package com.amazon.deequ.analyzers
 
 import com.amazon.deequ.analyzers.Preconditions.{hasColumn, isNumeric}
 import org.apache.spark.sql.functions.sum
+import com.amazon.deequ.schema.ColumnName
 import org.apache.spark.sql.types.{DoubleType, StructType}
 import org.apache.spark.sql.{Column, Row}
 import Analyzers._
@@ -37,7 +38,7 @@ case class Sum(column: String, where: Option[String] = None)
   extends StandardScanShareableAnalyzer[SumState]("Sum", column) {
 
   override def aggregationFunctions(): Seq[Column] = {
-    sum(conditionalSelection(column, where)).cast(DoubleType) :: Nil
+    sum(conditionalSelection(ColumnName.sanitize(column), where)).cast(DoubleType) :: Nil
   }
 
   override def fromAggregationResult(result: Row, offset: Int): Option[SumState] = {

--- a/src/main/scala/com/amazon/deequ/analyzers/catalyst/DeequFunctions.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/catalyst/DeequFunctions.scala
@@ -17,6 +17,7 @@
 package org.apache.spark.sql
 
 
+import com.amazon.deequ.schema.ColumnName
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateFunction, StatefulApproxQuantile, StatefulHyperloglogPlus}
 import org.apache.spark.sql.catalyst.expressions.Literal
 
@@ -32,7 +33,7 @@ object DeequFunctions {
 
   /** Pearson correlation with state */
   def stateful_corr(columnA: String, columnB: String): Column = {
-    stateful_corr(Column(columnA), Column(columnB))
+    stateful_corr(Column(ColumnName.sanitize(columnA)), Column(ColumnName.sanitize(columnB)))
   }
 
   /** Pearson correlation with state */
@@ -42,7 +43,7 @@ object DeequFunctions {
 
   /** Standard deviation with state */
   def stateful_stddev_pop(column: String): Column = {
-    stateful_stddev_pop(Column(column))
+    stateful_stddev_pop(Column(ColumnName.sanitize(column)))
   }
 
   /** Standard deviation with state */
@@ -52,7 +53,7 @@ object DeequFunctions {
 
   /** Approximate number of distinct values with state via HLL's */
   def stateful_approx_count_distinct(column: String): Column = {
-    stateful_approx_count_distinct(Column(column))
+    stateful_approx_count_distinct(Column(ColumnName.sanitize(column)))
   }
 
   /** Approximate number of distinct values with state via HLL's */

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -879,8 +879,9 @@ case class Check(
     val leftOperand = if (includeLowerBound) ">=" else ">"
     val rightOperand = if (includeUpperBound) "<=" else "<"
 
-    val predicate =
-      s"$sanitizedColumn IS NULL OR ($sanitizedColumn $leftOperand $lowerBound AND $sanitizedColumn $rightOperand $upperBound)"
+    val predicate = s"$sanitizedColumn IS NULL OR " +
+      s"($sanitizedColumn $leftOperand $lowerBound AND " +
+        s"$sanitizedColumn $rightOperand $upperBound)"
 
     satisfies(predicate, s"$column between $lowerBound and $upperBound", hint = hint)
   }

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -674,9 +674,9 @@ case class Check(
       hint: Option[String] = None)
     : CheckWithLastConstraintFilterable = {
 
-    val c = ColumnName.sanitize(column)
+    val sanitizedColumn = ColumnName.sanitize(column)
     // coalescing column to not count NULL values as non-compliant
-    satisfies(s"COALESCE($c, 0.0) >= 0", s"$column is non-negative", hint = hint)
+    satisfies(s"COALESCE($sanitizedColumn, 0.0) >= 0", s"$column is non-negative", hint = hint)
   }
 
   /**
@@ -686,9 +686,9 @@ case class Check(
     * @return
     */
   def isPositive(column: String): CheckWithLastConstraintFilterable = {
-    val c = ColumnName.sanitize(column)
+    val sanitizedColumn = ColumnName.sanitize(column)
     // coalescing column to not count NULL values as non-compliant
-    satisfies(s"COALESCE($c, 1.0) > 0", s"$column is positive")
+    satisfies(s"COALESCE($sanitizedColumn, 1.0) > 0", s"$column is positive")
   }
 
   /**
@@ -844,13 +844,13 @@ case class Check(
       hint: Option[String])
     : CheckWithLastConstraintFilterable = {
 
-    val c = ColumnName.sanitize(column)
+    val sanitizedColumn = ColumnName.sanitize(column)
 
     val valueList = allowedValues
       .map { _.replaceAll("'", "''") }
       .mkString("'", "','", "'")
 
-    val predicate = s"$c IS NULL OR $c IN ($valueList)"
+    val predicate = s"$sanitizedColumn IS NULL OR $sanitizedColumn IN ($valueList)"
     satisfies(predicate, s"$column contained in ${allowedValues.mkString(",")}", assertion, hint)
   }
 
@@ -874,13 +874,13 @@ case class Check(
       hint: Option[String] = None)
     : CheckWithLastConstraintFilterable = {
 
-    val c = ColumnName.sanitize(column)
+    val sanitizedColumn = ColumnName.sanitize(column)
 
     val leftOperand = if (includeLowerBound) ">=" else ">"
     val rightOperand = if (includeUpperBound) "<=" else "<"
 
     val predicate =
-      s"$c IS NULL OR ($c $leftOperand $lowerBound AND $c $rightOperand $upperBound)"
+      s"$sanitizedColumn IS NULL OR ($sanitizedColumn $leftOperand $lowerBound AND $sanitizedColumn $rightOperand $upperBound)"
 
     satisfies(predicate, s"$column between $lowerBound and $upperBound", hint = hint)
   }

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -18,6 +18,7 @@ package com.amazon.deequ.constraints
 
 import com.amazon.deequ.analyzers._
 import com.amazon.deequ.metrics.{Distribution, Metric}
+import com.amazon.deequ.schema.ColumnName
 import org.apache.spark.sql.expressions.UserDefinedFunction
 
 import scala.util.matching.Regex

--- a/src/main/scala/com/amazon/deequ/repository/MetricsRepositoryMultipleResultsLoader.scala
+++ b/src/main/scala/com/amazon/deequ/repository/MetricsRepositoryMultipleResultsLoader.scala
@@ -20,7 +20,8 @@ import com.amazon.deequ.analyzers.Analyzer
 import com.amazon.deequ.metrics.Metric
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
-import org.apache.spark.sql.functions._
+import com.amazon.deequ.schema.ColumnName
+import org.apache.spark.sql.functions.{ col, lit }
 import org.apache.spark.sql.Column
 
 trait MetricsRepositoryMultipleResultsLoader {
@@ -132,8 +133,8 @@ private[repository] object MetricsRepositoryMultipleResultsLoader {
 
   def withAllColumns(myCols: Seq[String], allCols: Seq[String]): List[Column] = {
     allCols.toList.map {
-      case colName if myCols.contains(colName) => col(colName)
-      case colName => lit(null).as(colName)
+      case colName if myCols.contains(colName) => col(ColumnName.sanitize(colName))
+      case colName => lit(null).as(ColumnName.sanitize(colName))
     }
   }
 }

--- a/src/main/scala/com/amazon/deequ/schema/ColumnName.scala
+++ b/src/main/scala/com/amazon/deequ/schema/ColumnName.scala
@@ -53,7 +53,7 @@ object ColumnName {
         Right(s"$prefix$columnName$suffix")
       }
     }
-  
+
   /** Obtains the `String` value if `Right` or throws the `SanitizeError` if `Left`. */
   def getOrThrow(x: Sanitized): String = x match {
     case Left(error) => throw error

--- a/src/main/scala/com/amazon/deequ/schema/ColumnName.scala
+++ b/src/main/scala/com/amazon/deequ/schema/ColumnName.scala
@@ -29,7 +29,6 @@ object ColumnName {
   def sanitizeForSql(columnName: String): Sanitized =
     if (columnName == null) {
       Left(NullColumn)
-
     } else {
       val rawColumnName = extractColumnName(columnName)
       if (rawColumnName.contains("`")) {
@@ -40,22 +39,21 @@ object ColumnName {
     }
 
   /** Extracts the original column name from a possibly sanitized column name. */
-  @inline
-  private[this] def extractColumnName(name: String): String =
-    name.slice(
-      if (hasStartingTick(name)) 1 else 0,
-      name.length - (if (hasEndingTick(name)) 1 else 0)
-    )
+  private[this] def extractColumnName(name: String): String = {
+    val startIndex = if (hasStartingTick(name)) 1 else 0
+    val endIndex = name.length - (if (hasEndingTick(name)) 1 else 0)
+    name.slice(startIndex, endIndex)
+  }
 
   /** True iff the input string starts with a backtick. False otherwise. */
-  @inline
-  private[this] def hasStartingTick(s: String): Boolean =
+  private[this] def hasStartingTick(s: String): Boolean = {
     s.startsWith("`")
+  }
 
   /** True iff the input string ends with a backtick. False otherwise. */
-  @inline
-  private[this] def hasEndingTick(s: String): Boolean =
+  private[this] def hasEndingTick(s: String): Boolean = {
     s.endsWith("`")
+  }
 
   /** Obtains the `String` value if `Right` or throws the `SanitizeError` if `Left`. */
   def getOrThrow(x: Sanitized): String = x match {
@@ -81,8 +79,9 @@ object ColumnName {
   }
 
   /** Alias for `sanitizeForSql andThen getOrThrow`. */
-  def sanitize(columnName: String): String =
+  def sanitize(columnName: String): String = {
     getOrThrow(sanitizeForSql(columnName))
+  }
 
   /** Inverse of `sanitize`: removes surrounding backticks, if present. */
   def desanitize(maybeSanitizedName: String): String =

--- a/src/main/scala/com/amazon/deequ/schema/ColumnName.scala
+++ b/src/main/scala/com/amazon/deequ/schema/ColumnName.scala
@@ -1,0 +1,111 @@
+/**
+  * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+  * use this file except in compliance with the License. A copy of the License
+  * is located at
+  *
+  *     http://aws.amazon.com/apache2.0/
+  *
+  * or in the "license" file accompanying this file. This file is distributed on
+  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  * express or implied. See the License for the specific language governing
+  * permissions and limitations under the License.
+  *
+  */
+
+package com.amazon.deequ.schema
+
+object ColumnName {
+
+  type Sanitized = Either[SanitizeError, String]
+
+  /**
+    * Sanitizes the input column name by ensuring that it is escaped with backticks.
+    *
+    * The resulting String is the escaped input column name, which is safe to use in
+    * any Spark SQL statement.
+    */
+  def sanitizeForSql(columnName: String): Sanitized =
+    if (columnName == null) {
+      Left(NullColumn)
+
+    } else {
+      val (prefix, suffix, insideColumnName) = {
+        val prefix = if (!columnName.startsWith("`")) "`" else ""
+        val suffix = if (!columnName.endsWith("`")) "`" else ""
+        val inside1 = if (prefix.isEmpty) {
+          columnName.slice(1, columnName.length)
+        } else {
+          columnName
+        }
+        val inside2 = if (suffix.isEmpty) {
+          inside1.slice(0, inside1.length - 1)
+        } else {
+          inside1
+        }
+        (prefix, suffix, inside2)
+      }
+
+      if (insideColumnName.contains("`")) {
+        Left(ColumnNameHasBackticks(columnName))
+      } else {
+        Right(s"$prefix$columnName$suffix")
+      }
+    }
+
+  /**
+    * Obtains the `String` value if `Right` or throws the `SanitizeError` if `Left`.
+    **/
+  def getOrThrow(x: Sanitized): String = x match {
+    case Left(e) => throw e
+    case Right(str) => str
+  }
+
+  /**
+    * Obtains the `String` pair if both are `Right`, otherwise throws the error(s).
+    *
+    * If only one of the sanitizations failed, then a `SanitizeError` type is thrown.
+    * If both fail, then an `IllegalArgumentException` is thrown and its message contains
+    * both of the `SanitizeError` messages.
+    * */
+  def getOrThrow(x: (Sanitized, Sanitized)): (String, String) = x match {
+    case (Right(cA), Right(cB)) => (cA, cB)
+    case (Left(eA), Left(eB)) => throw new IllegalArgumentException(
+      s"Cannot sanitize two column names:\n$eA\n$eB"
+    )
+    case (Left(e), _) => throw e
+    case (_, Left(e)) => throw e
+  }
+
+  /** Alias for `sanitizeForSql ` */
+  def sanitize(columnName: String): String =
+    getOrThrow(sanitizeForSql(columnName))
+
+  /** Inverse of `sanitize`: removes surrounding backticks, if present. */
+  def desanitize(maybeSanitizedName: String): String =
+    if (maybeSanitizedName == null) {
+      ""
+    } else {
+      val woPrefix =
+        if (maybeSanitizedName.startsWith("`")) {
+          maybeSanitizedName.slice(1, maybeSanitizedName.length)
+        } else {
+          maybeSanitizedName
+        }
+      val woSuffix =
+        if (woPrefix.endsWith("`")) {
+          woPrefix.slice(0, woPrefix.length - 1)
+        } else {
+          woPrefix
+        }
+      woSuffix
+    }
+
+}
+
+sealed abstract class SanitizeError(message: String) extends Exception(message)
+case class ColumnNameHasBackticks(column: String) extends SanitizeError(
+  s"Column name ($column) has backticks (non-sanitizing), which is not allowed in Spark SQL."
+)
+case object NullColumn extends SanitizeError("null is not a valid column name value")

--- a/src/main/scala/com/amazon/deequ/schema/ColumnName.scala
+++ b/src/main/scala/com/amazon/deequ/schema/ColumnName.scala
@@ -81,9 +81,8 @@ object ColumnName {
   }
 
   /** Alias for `sanitizeForSql andThen getOrThrow`. */
-  def sanitize(columnName: String): String = {
+  def sanitize(columnName: String): String =
     getOrThrow(sanitizeForSql(columnName))
-  }
 
   /** Inverse of `sanitize`: removes surrounding backticks, if present. */
   def desanitize(maybeSanitizedName: String): String =

--- a/src/main/scala/com/amazon/deequ/schema/ColumnName.scala
+++ b/src/main/scala/com/amazon/deequ/schema/ColumnName.scala
@@ -31,8 +31,8 @@ object ColumnName {
       Left(NullColumn)
     } else {
       val rawColumnName = columnName.slice(
-        if(columnName.startsWith("`")) 0 else 1,
-        columnName.length - { if(columnName.endsWith("`")) 0 else 1 }
+        if (columnName.startsWith("`")) 0 else 1,
+        columnName.length - { if (columnName.endsWith("`")) 0 else 1 }
       )
       if(rawColumnName.contains("`")) {
         Left(ColumnNameHasBackticks(columnName))
@@ -76,8 +76,8 @@ object ColumnName {
       ""
     } else {
       maybeSanitizedName.slice(
-        if(maybeSanitizedName.startsWith("`")) 1 else 0,
-        maybeSanitizedName.length - { if(maybeSanitizedName.endsWith("`")) 1 else 0 }
+        if (maybeSanitizedName.startsWith("`")) 1 else 0,
+        maybeSanitizedName.length - { if (maybeSanitizedName.endsWith("`")) 1 else 0 }
       )
     }
 }

--- a/src/main/scala/com/amazon/deequ/schema/ColumnName.scala
+++ b/src/main/scala/com/amazon/deequ/schema/ColumnName.scala
@@ -31,7 +31,7 @@ object ColumnName {
       Left(NullColumn)
     } else {
       val rawColumnName = columnName.slice(
-        if (columnName.startsWith("`")) 0 else 1,
+        if (columnName.startsWith("`")) 1 else 0,
         columnName.length - { if (columnName.endsWith("`")) 0 else 1 }
       )
       if(rawColumnName.contains("`")) {

--- a/src/main/scala/com/amazon/deequ/schema/ColumnName.scala
+++ b/src/main/scala/com/amazon/deequ/schema/ColumnName.scala
@@ -54,9 +54,7 @@ object ColumnName {
       }
     }
 
-  /**
-    * Obtains the `String` value if `Right` or throws the `SanitizeError` if `Left`.
-    **/
+  /** Obtains the `String` value if `Right` or throws the `SanitizeError` if `Left`. */
   def getOrThrow(x: Sanitized): String = x match {
     case Left(e) => throw e
     case Right(str) => str
@@ -68,7 +66,7 @@ object ColumnName {
     * If only one of the sanitizations failed, then a `SanitizeError` type is thrown.
     * If both fail, then an `IllegalArgumentException` is thrown and its message contains
     * both of the `SanitizeError` messages.
-    * */
+    */
   def getOrThrow(x: (Sanitized, Sanitized)): (String, String) = x match {
     case (Right(cA), Right(cB)) => (cA, cB)
     case (Left(eA), Left(eB)) => throw new IllegalArgumentException(
@@ -78,7 +76,7 @@ object ColumnName {
     case (_, Left(e)) => throw e
   }
 
-  /** Alias for `sanitizeForSql ` */
+  /** Alias for `sanitizeForSql | getOrThrow`. */
   def sanitize(columnName: String): String =
     getOrThrow(sanitizeForSql(columnName))
 

--- a/src/main/scala/com/amazon/deequ/schema/ColumnName.scala
+++ b/src/main/scala/com/amazon/deequ/schema/ColumnName.scala
@@ -68,17 +68,19 @@ object ColumnName {
     * both of the `SanitizeError` messages.
     */
   def getOrThrow(x: (Sanitized, Sanitized)): (String, String) = x match {
-    case (Right(cA), Right(cB)) => (cA, cB)
-    case (Left(eA), Left(eB)) => throw new IllegalArgumentException(
-      s"Cannot sanitize two column names:\n$eA\n$eB"
+    case (Right(sanitizedColumn1), Right(sanitizedColumn2)) =>
+      (sanitizedColumn1, sanitizedColumn2)
+    case (Left(error1), Left(error2)) => throw new IllegalArgumentException(
+      s"Cannot sanitize two column names:\n$error1\n$error2"
     )
-    case (Left(e), _) => throw e
-    case (_, Left(e)) => throw e
+    case (Left(error), _) => throw error
+    case (_, Left(error)) => throw error
   }
 
   /** Alias for `sanitizeForSql | getOrThrow`. */
-  def sanitize(columnName: String): String =
+  def sanitize(columnName: String): String = {
     getOrThrow(sanitizeForSql(columnName))
+  }
 
   /** Inverse of `sanitize`: removes surrounding backticks, if present. */
   def desanitize(maybeSanitizedName: String): String =

--- a/src/main/scala/com/amazon/deequ/suggestions/rules/CategoricalRangeRule.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/rules/CategoricalRangeRule.scala
@@ -20,6 +20,7 @@ import com.amazon.deequ.analyzers.{DataTypeInstances, Histogram}
 import com.amazon.deequ.checks.Check
 import com.amazon.deequ.constraints.Constraint.complianceConstraint
 import com.amazon.deequ.profiles.ColumnProfile
+import com.amazon.deequ.schema.ColumnName
 import com.amazon.deequ.suggestions.ConstraintSuggestion
 import org.apache.commons.lang3.StringEscapeUtils
 
@@ -45,6 +46,8 @@ case class CategoricalRangeRule() extends ConstraintRule[ColumnProfile] {
 
   override def candidate(profile: ColumnProfile, numRecords: Long): ConstraintSuggestion = {
 
+    val c = ColumnName.sanitize(profile.column)
+
     val valuesByPopularity = profile.histogram.get.values.toArray
       .filterNot { case (key, _) => key == Histogram.NullFieldReplacement }
       .sortBy { case (_, value) => value.absolute }
@@ -60,7 +63,7 @@ case class CategoricalRangeRule() extends ConstraintRule[ColumnProfile] {
       .mkString(""""""", """", """", """"""")
 
     val description = s"'${profile.column}' has value range $categoriesSql"
-    val columnCondition = s"`${profile.column}` IN ($categoriesSql)"
+    val columnCondition = s"$c IN ($categoriesSql)"
     val constraint = complianceConstraint(description, columnCondition, Check.IsOne)
 
     ConstraintSuggestion(

--- a/src/main/scala/com/amazon/deequ/suggestions/rules/CategoricalRangeRule.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/rules/CategoricalRangeRule.scala
@@ -46,7 +46,7 @@ case class CategoricalRangeRule() extends ConstraintRule[ColumnProfile] {
 
   override def candidate(profile: ColumnProfile, numRecords: Long): ConstraintSuggestion = {
 
-    val c = ColumnName.sanitize(profile.column)
+    val sanitizedColumn = ColumnName.sanitize(profile.column)
 
     val valuesByPopularity = profile.histogram.get.values.toArray
       .filterNot { case (key, _) => key == Histogram.NullFieldReplacement }
@@ -63,7 +63,7 @@ case class CategoricalRangeRule() extends ConstraintRule[ColumnProfile] {
       .mkString(""""""", """", """", """"""")
 
     val description = s"'${profile.column}' has value range $categoriesSql"
-    val columnCondition = s"$c IN ($categoriesSql)"
+    val columnCondition = s"$sanitizedColumn IN ($categoriesSql)"
     val constraint = complianceConstraint(description, columnCondition, Check.IsOne)
 
     ConstraintSuggestion(

--- a/src/main/scala/com/amazon/deequ/suggestions/rules/FractionalCategoricalRangeRule.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/rules/FractionalCategoricalRangeRule.scala
@@ -54,7 +54,7 @@ case class FractionalCategoricalRangeRule(targetDataCoverageFraction: Double = 0
 
   override def candidate(profile: ColumnProfile, numRecords: Long): ConstraintSuggestion = {
 
-    val c = ColumnName.sanitize(profile.column)
+    val sanitizedColumn = ColumnName.sanitize(profile.column)
 
     val topCategories = getTopCategoriesForFractionalDataCoverage(profile,
       targetDataCoverageFraction)
@@ -84,7 +84,7 @@ case class FractionalCategoricalRangeRule(targetDataCoverageFraction: Double = 0
 
     val description = s"'${profile.column}' has value range $categoriesSql for at least " +
       s"${targetCompliance * 100}% of values"
-    val columnCondition = s"$c IN ($categoriesSql)"
+    val columnCondition = s"$sanitizedColumn IN ($categoriesSql)"
     val hint = s"It should be above $targetCompliance!"
     val constraint = complianceConstraint(description, columnCondition, _ >= targetCompliance,
       hint = Some(hint))

--- a/src/test/scala/com/amazon/deequ/VerificationResultTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationResultTest.scala
@@ -19,8 +19,7 @@ package com.amazon.deequ
 import com.amazon.deequ.analyzers._
 import com.amazon.deequ.checks.{Check, CheckLevel}
 import com.amazon.deequ.metrics.Metric
-import com.amazon.deequ.repository.SimpleResultSerde
-import com.amazon.deequ.utils.FixtureSupport
+import com.amazon.deequ.utils.{AssertionUtils, FixtureSupport}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 import org.scalatest.{Matchers, WordSpec}
 
@@ -40,8 +39,8 @@ class VerificationResultTest extends WordSpec with Matchers with SparkContextSpe
         val expected = Seq(
           ("Dataset", "*", "Size", 4.0),
           ("Column", "item", "Distinctness", 1.0),
-          ("Column", "att1", "Completeness", 1.0),
-          ("Mutlicolumn", "att1,att2", "Uniqueness", 0.25)
+          ("Column", "]att1[", "Completeness", 1.0),
+          ("Mutlicolumn", "]att1[,att2", "Uniqueness", 0.25)
         )
           .toDF("entity", "instance", "name", "value")
 
@@ -54,15 +53,15 @@ class VerificationResultTest extends WordSpec with Matchers with SparkContextSpe
 
         evaluate(session) { results =>
 
-          val metricsForAnalyzers = Seq(Completeness("att1"), Uniqueness(Seq("att1", "att2")))
+          val metricsForAnalyzers = Seq(Completeness("]att1["), Uniqueness(Seq("]att1[", "att2")))
 
           val successMetricsAsDataFrame = VerificationResult
             .successMetricsAsDataFrame(session, results, metricsForAnalyzers)
 
           import session.implicits._
           val expected = Seq(
-            ("Column", "att1", "Completeness", 1.0),
-            ("Mutlicolumn", "att1,att2", "Uniqueness", 0.25)
+            ("Column", "]att1[", "Completeness", 1.0),
+            ("Mutlicolumn", "]att1[,att2", "Uniqueness", 0.25)
           )
             .toDF("entity", "instance", "name", "value")
 
@@ -79,13 +78,13 @@ class VerificationResultTest extends WordSpec with Matchers with SparkContextSpe
 
           val expectedJson =
             """[{"entity":"Dataset","instance":"*","name":"Size","value":4.0},
-              |{"entity":"Column","instance":"att1","name":"Completeness","value":1.0},
+              |{"entity":"Column","instance":"]att1[","name":"Completeness","value":1.0},
               |{"entity":"Column","instance":"item","name":"Distinctness","value":1.0},
-              |{"entity":"Mutlicolumn","instance":"att1,att2",
+              |{"entity":"Mutlicolumn","instance":"]att1[,att2",
               |"name":"Uniqueness","value":0.25}]"""
               .stripMargin.replaceAll("\n", "")
 
-          assertSameResultsJson(successMetricsResultsJson, expectedJson)
+          assertSameJson(successMetricsResultsJson, expectedJson)
         }
       }
 
@@ -94,18 +93,18 @@ class VerificationResultTest extends WordSpec with Matchers with SparkContextSpe
 
         evaluate(session) { results =>
 
-          val metricsForAnalyzers = Seq(Completeness("att1"), Uniqueness(Seq("att1", "att2")))
+          val metricsForAnalyzers = Seq(Completeness("]att1["), Uniqueness(Seq("]att1[", "att2")))
 
           val successMetricsResultsJson =
             VerificationResult.successMetricsAsJson(results, metricsForAnalyzers)
 
           val expectedJson =
-            """[{"entity":"Column","instance":"att1","name":"Completeness","value":1.0},
-              |{"entity":"Mutlicolumn","instance":"att1,att2",
+            """[{"entity":"Column","instance":"]att1[","name":"Completeness","value":1.0},
+              |{"entity":"Mutlicolumn","instance":"]att1[,att2",
               |"name":"Uniqueness","value":0.25}]"""
               .stripMargin.replaceAll("\n", "")
 
-           assertSameResultsJson(successMetricsResultsJson, expectedJson)
+          assertSameJson(successMetricsResultsJson, expectedJson)
         }
       }
   }
@@ -121,11 +120,11 @@ class VerificationResultTest extends WordSpec with Matchers with SparkContextSpe
 
         import session.implicits._
         val expected = Seq(
-          ("group-1", "Error", "Success", "CompletenessConstraint(Completeness(att1,None))",
+          ("group-1", "Error", "Success", "CompletenessConstraint(Completeness(]att1[,None))",
             "Success", ""),
           ("group-2-E", "Error", "Error", "SizeConstraint(Size(None))", "Failure",
             "Value: 4 does not meet the constraint requirement! Should be greater than 5!"),
-          ("group-2-E", "Error", "Error", "CompletenessConstraint(Completeness(att1,None))",
+          ("group-2-E", "Error", "Error", "CompletenessConstraint(Completeness(]att1[,None))",
             "Success", ""),
           ("group-2-W", "Warning", "Warning", "DistinctnessConstraint(Distinctness(List(item)))",
             "Failure", "Value: 1.0 does not meet the constraint requirement! " +
@@ -147,7 +146,7 @@ class VerificationResultTest extends WordSpec with Matchers with SparkContextSpe
 
           val expectedJson =
             """[{"check":"group-1","check_level":"Error","check_status":"Success",
-              |"constraint":"CompletenessConstraint(Completeness(att1,None))",
+              |"constraint":"CompletenessConstraint(Completeness(]att1[,None))",
               |"constraint_status":"Success","constraint_message":""},
               |
               |{"check":"group-2-E","check_level":"Error","check_status":"Error",
@@ -156,7 +155,7 @@ class VerificationResultTest extends WordSpec with Matchers with SparkContextSpe
               | Should be greater than 5!"},
               |
               |{"check":"group-2-E","check_level":"Error","check_status":"Error",
-              |"constraint":"CompletenessConstraint(Completeness(att1,None))",
+              |"constraint":"CompletenessConstraint(Completeness(]att1[,None))",
               |"constraint_status":"Success","constraint_message":""},
               |
               |{"check":"group-2-W","check_level":"Warning","check_status":"Warning",
@@ -165,7 +164,7 @@ class VerificationResultTest extends WordSpec with Matchers with SparkContextSpe
               | requirement! Should be smaller than 0.8!"}]"""
               .stripMargin.replaceAll("\n", "")
 
-          assertSameResultsJson(checkResultsAsJson, expectedJson)
+          assertSameJson(checkResultsAsJson, expectedJson)
         }
       }
   }
@@ -189,18 +188,18 @@ class VerificationResultTest extends WordSpec with Matchers with SparkContextSpe
   private[this] def getAnalyzers(): Seq[Analyzer[_, Metric[_]]] = {
     Size() ::
       Distinctness("item") ::
-      Completeness("att1") ::
-      Uniqueness(Seq("att1", "att2")) ::
+      Completeness("]att1[") ::
+      Uniqueness(Seq("]att1[", "att2")) ::
       Nil
   }
 
   private[this] def getChecks(): Seq[Check] = {
     val checkToSucceed = Check(CheckLevel.Error, "group-1")
-      .isComplete("att1")
+      .isComplete("]att1[")
 
     val checkToErrorOut = Check(CheckLevel.Error, "group-2-E")
       .hasSize(_ > 5, Some("Should be greater than 5!"))
-      .hasCompleteness("att1", _ == 1.0, Some("Should equal 1!"))
+      .hasCompleteness("]att1[", _ == 1.0, Some("Should equal 1!"))
 
     val checkToWarn = Check(CheckLevel.Warning, "group-2-W")
       .hasDistinctness(Seq("item"), _ < 0.8, Some("Should be smaller than 0.8!"))
@@ -210,10 +209,5 @@ class VerificationResultTest extends WordSpec with Matchers with SparkContextSpe
 
   private[this] def assertSameRows(dataframeA: DataFrame, dataframeB: DataFrame): Unit = {
     assert(dataframeA.collect().toSet == dataframeB.collect().toSet)
-  }
-
-  private[this] def assertSameResultsJson(jsonA: String, jsonB: String): Unit = {
-    assert(SimpleResultSerde.deserialize(jsonA) ==
-      SimpleResultSerde.deserialize(jsonB))
   }
 }

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -50,8 +50,8 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
         val df = getDfCompleteAndInCompleteColumns(sparkSession)
 
         val checkToSucceed = Check(CheckLevel.Error, "group-1")
-          .isComplete("att1")
-          .hasCompleteness("att1", _ == 1.0)
+          .isComplete("]att1[")
+          .hasCompleteness("]att1[", _ == 1.0)
 
         val checkToErrorOut = Check(CheckLevel.Error, "group-2-E")
           .hasCompleteness("att2", _ > 0.8)
@@ -89,13 +89,13 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
 
       val result = {
         val checkToSucceed = Check(CheckLevel.Error, "group-1")
-          .isComplete("att1") // 1.0
-          .hasCompleteness("att1", _ == 1.0) // 1.0
+          .isComplete("]att1[") // 1.0
+          .hasCompleteness("]att1[", _ == 1.0) // 1.0
 
         val analyzers = Size() :: // Analyzer that works on overall document
           Completeness("att2") ::
           Uniqueness("att2") :: // Analyzer that works on single column
-          MutualInformation("att1", "att2") :: Nil // Analyzer that works on multi column
+          MutualInformation("]att1[", "att2") :: Nil // Analyzer that works on multi column
 
         VerificationSuite().onData(df).addCheck(checkToSucceed)
           .addRequiredAnalyzers(analyzers).run()
@@ -108,10 +108,10 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
 
       val expected = Seq(
         ("Dataset", "*", "Size", 4.0),
-        ("Column", "att1", "Completeness", 1.0),
+        ("Column", "]att1[", "Completeness", 1.0),
         ("Column", "att2", "Completeness", 1.0),
         ("Column", "att2", "Uniqueness", 0.25),
-        ("Mutlicolumn", "att1,att2", "MutualInformation",
+        ("Mutlicolumn", "]att1[,att2", "MutualInformation",
           -(0.75 * math.log(0.75) + 0.25 * math.log(0.25))))
         .toDF("entity", "instance", "name", "value")
 
@@ -145,7 +145,7 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
 
         val df = getDfWithNumericValues(sparkSession)
 
-        val analyzerToTestReusingResults = Distinctness(Seq("att1", "att2"))
+        val analyzerToTestReusingResults = Distinctness(Seq("]att1[", "att2"))
 
         val verificationResult = VerificationSuite().onData(df)
           .addRequiredAnalyzer(analyzerToTestReusingResults).run()
@@ -289,8 +289,8 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
       val df = getDfWithNumericValues(sparkSession)
 
       val checkToSucceed = Check(CheckLevel.Error, "group-1")
-        .isComplete("att1") // 1.0
-        .hasCompleteness("att1", _ == 1.0) // 1.0
+        .isComplete("]att1[") // 1.0
+        .hasCompleteness("]att1[", _ == 1.0) // 1.0
 
       val tempDir = TempFileUtils.tempDir("verificationOuput")
       val checkResultsPath = tempDir + "/check-result.json"
@@ -316,8 +316,8 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
       val df = getDfWithNumericValues(sparkSession)
 
       val expectedConstraints = Seq(
-        Constraint.completenessConstraint("att1", _ == 1.0),
-        Constraint.complianceConstraint("att1 is positive", "att1", _ == 1.0)
+        Constraint.completenessConstraint("]att1[", _ == 1.0),
+        Constraint.complianceConstraint("]att1[ is positive", "]att1[", _ == 1.0)
       )
 
       val check = expectedConstraints.foldLeft(Check(CheckLevel.Error, "check")) {

--- a/src/test/scala/com/amazon/deequ/analyzers/IncrementalAnalyzerTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/IncrementalAnalyzerTest.scala
@@ -55,7 +55,7 @@ class IncrementalAnalyzerTest extends WordSpec with Matchers with SparkContextSp
   "ComplianceAnalyzer" should {
     "compute correct metrics" in withSparkSession { session =>
 
-      val analyzer = Compliance("att1", "att1 = 'b'")
+      val analyzer = Compliance("]att1[", "`]att1[` = 'b'")
 
       val initial = initialData(session)
       val delta = deltaData(session)
@@ -79,7 +79,7 @@ class IncrementalAnalyzerTest extends WordSpec with Matchers with SparkContextSp
   "CompletenessAnalyzer" should {
     "compute correct metrics" in withSparkSession { session =>
 
-      val analyzer = Completeness("att1")
+      val analyzer = Completeness("]att1[")
 
       val initial = initialData(session)
       val delta = deltaData(session)
@@ -103,7 +103,7 @@ class IncrementalAnalyzerTest extends WordSpec with Matchers with SparkContextSp
   "UniquenessAnalyzer" should {
     "compute correct metrics for a single column" in withSparkSession { session =>
 
-      val analyzer = Uniqueness("att1")
+      val analyzer = Uniqueness("]att1[")
 
       val initial = initialData(session)
       val delta = deltaData(session)
@@ -125,7 +125,7 @@ class IncrementalAnalyzerTest extends WordSpec with Matchers with SparkContextSp
 
     "compute correct metrics for column combinations" in withSparkSession { session =>
 
-      val analyzer = Uniqueness(Seq("att1", "count"))
+      val analyzer = Uniqueness(Seq("]att1[", "count"))
 
       val initial = initialData(session)
       val delta = deltaData(session)
@@ -149,7 +149,7 @@ class IncrementalAnalyzerTest extends WordSpec with Matchers with SparkContextSp
   "EntropyAnalyzer" should {
     "compute correct metrics" in withSparkSession { session =>
 
-      val analyzer = Entropy("att1")
+      val analyzer = Entropy("]att1[")
 
       val initial = initialData(session)
       val delta = deltaData(session)
@@ -177,7 +177,7 @@ class IncrementalAnalyzerTest extends WordSpec with Matchers with SparkContextSp
     "compute correct metrics for the whole and partial data-sets" in withSparkSession { session =>
       import session.implicits._
 
-      val attribute = "att1"
+      val attribute = "]att1["
       val first = Seq(("1", 0.0), ("2", 1.0), ("3", 2.0)).toDF("item", attribute)
       val second = Seq(("1", -2.0), ("2", -1.0)).toDF("item", attribute)
       val firstAndSecond = first.union(second)
@@ -202,7 +202,7 @@ class IncrementalAnalyzerTest extends WordSpec with Matchers with SparkContextSp
   "EntropyAnalyzer" should {
     "compute correct metrics for three snapshots" in withSparkSession { session =>
 
-      val analyzer = Entropy("att1")
+      val analyzer = Entropy("]att1[")
 
       val delta1 = initialData(session)
       val delta2 = deltaData(session)
@@ -247,7 +247,7 @@ class IncrementalAnalyzerTest extends WordSpec with Matchers with SparkContextSp
       ("1", "a", 12),
       ("2", null, 12),
       ("3", "b", 12))
-      .toDF("item", "att1", "count")
+      .toDF("item", "]att1[", "count")
   }
 
   def deltaData(session: SparkSession): DataFrame = {
@@ -256,7 +256,7 @@ class IncrementalAnalyzerTest extends WordSpec with Matchers with SparkContextSp
     Seq(
       ("4", "b", 12),
       ("5", null, 12))
-      .toDF("item", "att1", "count")
+      .toDF("item", "]att1[", "count")
   }
 
   def moreDeltaData(session: SparkSession): DataFrame = {
@@ -265,6 +265,6 @@ class IncrementalAnalyzerTest extends WordSpec with Matchers with SparkContextSp
     Seq(
       ("6", "a", 12),
       ("7", null, 12))
-      .toDF("item", "att1", "count")
+      .toDF("item", "]att1[", "count")
   }
 }

--- a/src/test/scala/com/amazon/deequ/analyzers/StateProviderTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/StateProviderTest.scala
@@ -34,11 +34,11 @@ class StateProviderTest extends WordSpec with Matchers with SparkContextSpec wit
 
       assertCorrectlyRestoresState[NumMatches](provider, provider, Size(), data)
       assertCorrectlyRestoresState[NumMatchesAndCount](provider, provider,
-        Completeness("att1"), data)
+        Completeness("]att1["), data)
       assertCorrectlyRestoresState[NumMatchesAndCount](provider, provider,
-        Compliance("att1", "att1 = 'b'"), data)
+        Compliance("]att1[", "`]att1[` = 'b'"), data)
       assertCorrectlyRestoresState[NumMatchesAndCount](provider, provider,
-        PatternMatch("att1", Patterns.EMAIL), data)
+        PatternMatch("]att1[", Patterns.EMAIL), data)
 
       assertCorrectlyRestoresState[SumState](provider, provider, Sum("price"), data)
       assertCorrectlyRestoresState[MeanState](provider, provider, Mean("price"), data)
@@ -48,14 +48,14 @@ class StateProviderTest extends WordSpec with Matchers with SparkContextSpec wit
         StandardDeviation("price"), data)
 
       assertCorrectlyRestoresState[DataTypeHistogram](provider, provider, DataType("item"), data)
-      assertCorrectlyRestoresStateForHLL(provider, provider, ApproxCountDistinct("att1"), data)
+      assertCorrectlyRestoresStateForHLL(provider, provider, ApproxCountDistinct("]att1["), data)
       assertCorrectlyRestoresState[CorrelationState](provider, provider,
         Correlation("count", "price"), data)
 
-      assertCorrectlyRestoresFrequencyBasedState(provider, provider, Uniqueness("att1"), data)
+      assertCorrectlyRestoresFrequencyBasedState(provider, provider, Uniqueness("]att1["), data)
       assertCorrectlyRestoresFrequencyBasedState(provider, provider,
-        Uniqueness(Seq("att1", "count")), data)
-      assertCorrectlyRestoresFrequencyBasedState(provider, provider, Entropy("att1"), data)
+        Uniqueness(Seq("]att1[", "count")), data)
+      assertCorrectlyRestoresFrequencyBasedState(provider, provider, Entropy("]att1["), data)
 
       assertCorrectlyApproxQuantileState(provider, provider, ApproxQuantile("price", 0.5), data)
     }
@@ -70,12 +70,12 @@ class StateProviderTest extends WordSpec with Matchers with SparkContextSpec wit
 
       assertCorrectlyRestoresState[NumMatches](provider, provider, Size(), data)
       assertCorrectlyRestoresState[NumMatchesAndCount](provider, provider,
-        Completeness("att1"), data)
+        Completeness("]att1["), data)
       assertCorrectlyRestoresState[NumMatchesAndCount](provider, provider,
-        Compliance("att1", "att1 = 'b'"), data)
+        Compliance("]att1[", "`]att1[` = 'b'"), data)
 
       assertCorrectlyRestoresState[NumMatchesAndCount](provider, provider,
-        PatternMatch("att1", Patterns.EMAIL), data)
+        PatternMatch("]att1[", Patterns.EMAIL), data)
 
       assertCorrectlyRestoresState[SumState](provider, provider, Sum("price"), data)
       assertCorrectlyRestoresState[MeanState](provider, provider, Mean("price"), data)
@@ -85,14 +85,14 @@ class StateProviderTest extends WordSpec with Matchers with SparkContextSpec wit
         StandardDeviation("price"), data)
 
       assertCorrectlyRestoresState[DataTypeHistogram](provider, provider, DataType("item"), data)
-      assertCorrectlyRestoresStateForHLL(provider, provider, ApproxCountDistinct("att1"), data)
+      assertCorrectlyRestoresStateForHLL(provider, provider, ApproxCountDistinct("]att1["), data)
       assertCorrectlyRestoresState[CorrelationState](provider, provider,
         Correlation("count", "price"), data)
 
-      assertCorrectlyRestoresFrequencyBasedState(provider, provider, Uniqueness("att1"), data)
+      assertCorrectlyRestoresFrequencyBasedState(provider, provider, Uniqueness("]att1["), data)
       assertCorrectlyRestoresFrequencyBasedState(provider, provider,
-        Uniqueness(Seq("att1", "count")), data)
-      assertCorrectlyRestoresFrequencyBasedState(provider, provider, Entropy("att1"), data)
+        Uniqueness(Seq("]att1[", "count")), data)
+      assertCorrectlyRestoresFrequencyBasedState(provider, provider, Entropy("]att1["), data)
 
       assertCorrectlyApproxQuantileState(provider, provider, ApproxQuantile("price", 0.5), data)
     }
@@ -185,7 +185,7 @@ class StateProviderTest extends WordSpec with Matchers with SparkContextSpec wit
       ("5", null, 1, 1.0),
       ("6", "a", 21, 78.0),
       ("7", null, 12, 0.0))
-    .toDF("item", "att1", "count", "price")
+    .toDF("item", "]att1[", "count", "price")
   }
 
 }

--- a/src/test/scala/com/amazon/deequ/analyzers/StatesTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/StatesTest.scala
@@ -27,11 +27,11 @@ class StatesTest extends WordSpec with Matchers with SparkContextSpec with Fixtu
 
       import session.implicits._
 
-      val dataA = Seq("A", "A", "B").toDF("att1")
-      val dataB = Seq("A", "C", "C").toDF("att1")
+      val dataA = Seq("A", "A", "B").toDF("]att1[")
+      val dataB = Seq("A", "C", "C").toDF("]att1[")
 
-      val stateA = FrequencyBasedAnalyzer.computeFrequencies(dataA, "att1" :: Nil)
-      val stateB = FrequencyBasedAnalyzer.computeFrequencies(dataB, "att1" :: Nil)
+      val stateA = FrequencyBasedAnalyzer.computeFrequencies(dataA, "]att1[" :: Nil)
+      val stateB = FrequencyBasedAnalyzer.computeFrequencies(dataB, "]att1[" :: Nil)
 
       val stateAB = stateA.sum(stateB)
 

--- a/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
@@ -38,7 +38,7 @@ class AnalysisRunnerTests extends WordSpec with Matchers with SparkContextSpec w
 
       val binning = udf { value: Int => value > 2 }
 
-      val analyzer = Histogram("att1", Some(binning))
+      val analyzer = Histogram("]att1[", Some(binning))
 
       val directlyCalculated = analyzer.calculate(data)
 
@@ -53,8 +53,8 @@ class AnalysisRunnerTests extends WordSpec with Matchers with SparkContextSpec w
         val df = getDfWithNumericValues(sparkSession)
 
         val analyzers =
-          Completeness("att1") :: Compliance("rule1", "att1 > 3") ::
-          Completeness("att2") :: Compliance("rule1", "att1 > 2") ::
+          Completeness("]att1[") :: Compliance("rule1", "`]att1[` > 3") ::
+          Completeness("att2") :: Compliance("rule1", "`]att1[` > 2") ::
           Compliance("rule1", "att2 > 2") ::
           ApproxQuantile("att2", 0.5) :: Nil
 
@@ -78,7 +78,7 @@ class AnalysisRunnerTests extends WordSpec with Matchers with SparkContextSpec w
 
           val df = getDfWithNumericValues(sparkSession)
 
-          val analyzers = Entropy("att1") :: Uniqueness("att1") :: Nil
+          val analyzers = Entropy("]att1[") :: Uniqueness("]att1[") :: Nil
 
           val (separateResults, numSeparateJobs) = sparkMonitor.withMonitoringSession { stat =>
             val results = analyzers.map { _.calculate(df) }.toSet
@@ -100,7 +100,8 @@ class AnalysisRunnerTests extends WordSpec with Matchers with SparkContextSpec w
 
         val df = getDfWithNumericValues(sparkSession)
 
-        val analyzers = Distinctness(Seq("att1", "att2")) :: Uniqueness(Seq("att1", "att2")) :: Nil
+        val analyzers = Distinctness(Seq("]att1[", "att2")) :: Uniqueness(Seq("]att1[", "att2")) ::
+          Nil
 
         val (separateResults, numSeparateJobs) = sparkMonitor.withMonitoringSession { stat =>
           val results = analyzers.map { _.calculate(df) }.toSet
@@ -122,7 +123,7 @@ class AnalysisRunnerTests extends WordSpec with Matchers with SparkContextSpec w
 
         val df = getDfWithNumericValues(sparkSession)
 
-        val analyzerToTestReusingResults = Distinctness(Seq("att1", "att2"))
+        val analyzerToTestReusingResults = Distinctness(Seq("]att1[", "att2"))
 
         val analysisResult = Analysis().addAnalyzer(analyzerToTestReusingResults).run(df)
         val repository = new InMemoryMetricsRepository
@@ -154,7 +155,7 @@ class AnalysisRunnerTests extends WordSpec with Matchers with SparkContextSpec w
 
         val df = getDfWithNumericValues(sparkSession)
 
-        val analyzerToTestReusingResults = Distinctness(Seq("att1", "att2"))
+        val analyzerToTestReusingResults = Distinctness(Seq("]att1[", "att2"))
 
         val analysisResult = Analysis().addAnalyzer(analyzerToTestReusingResults).run(df)
         val repository = new InMemoryMetricsRepository

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -878,11 +878,11 @@ object CheckTest extends WordSpec with Matchers {
   }
 
   def testCheckOnData(df: DataFrame, c: Check): Unit = {
-    val r = VerificationSuite()
+    val checkResult = VerificationSuite()
       .onData(df)
       .addCheck(c)
       .run()
-    assert(r.status == CheckStatus.Success)
+    assert(checkResult.status == CheckStatus.Success)
   }
 
   val badColumnName: String = "[this column]:has a handful of problematic chars"

--- a/src/test/scala/com/amazon/deequ/constraints/AnalysisBasedConstraintTest.scala
+++ b/src/test/scala/com/amazon/deequ/constraints/AnalysisBasedConstraintTest.scala
@@ -80,7 +80,7 @@ class AnalysisBasedConstraintTest extends WordSpec with Matchers with SparkConte
 
         // Analysis result should equal to 1.0 for an existing column
         val resultA = calculate(AnalysisBasedConstraint[NumMatches, Double, Double](
-          SampleAnalyzer("att1"), _ == 1.0), df)
+          SampleAnalyzer("]att1["), _ == 1.0), df)
 
         assert(resultA.status == ConstraintStatus.Success)
         assert(resultA.message.isEmpty)
@@ -88,7 +88,7 @@ class AnalysisBasedConstraintTest extends WordSpec with Matchers with SparkConte
 
         // Analysis result should equal to 1.0 for an existing column
         val resultB = calculate(AnalysisBasedConstraint[NumMatches, Double, Double](
-          SampleAnalyzer("att1"), _ != 1.0), df)
+          SampleAnalyzer("]att1["), _ != 1.0), df)
 
         assert(resultB.status == ConstraintStatus.Failure)
         assert(resultB.message.contains("Value: 1.0 does not meet the constraint requirement!"))
@@ -111,11 +111,11 @@ class AnalysisBasedConstraintTest extends WordSpec with Matchers with SparkConte
 
       // Analysis result should equal to 100.0 for an existing column
       assert(calculate(AnalysisBasedConstraint[NumMatches, Double, Double](
-        SampleAnalyzer("att1"), _ == 2.0, Some(valueDoubler)), df).status ==
+        SampleAnalyzer("]att1["), _ == 2.0, Some(valueDoubler)), df).status ==
         ConstraintStatus.Success)
 
       assert(calculate(AnalysisBasedConstraint[NumMatches, Double, Double](
-        SampleAnalyzer("att1"), _ != 2.0, Some(valueDoubler)), df).status ==
+        SampleAnalyzer("]att1["), _ != 2.0, Some(valueDoubler)), df).status ==
         ConstraintStatus.Failure)
 
       // Analysis should fail for a non existing column
@@ -129,14 +129,14 @@ class AnalysisBasedConstraintTest extends WordSpec with Matchers with SparkConte
 
       val emptyResults = Map.empty[Analyzer[_, Metric[_]], Metric[_]]
       val validResults = Map[Analyzer[_, Metric[_]], Metric[_]](
-        SampleAnalyzer("att1") -> SampleAnalyzer("att1").calculate(df),
+        SampleAnalyzer("]att1[") -> SampleAnalyzer("]att1[").calculate(df),
         SampleAnalyzer("someMissingColumn") -> SampleAnalyzer("someMissingColumn").calculate(df)
       )
 
       // Analysis result should equal to 1.0 for an existing column
-      assert(AnalysisBasedConstraint[NumMatches, Double, Double](SampleAnalyzer("att1"), _ == 1.0)
+      assert(AnalysisBasedConstraint[NumMatches, Double, Double](SampleAnalyzer("]att1["), _ == 1.0)
         .evaluate(validResults).status == ConstraintStatus.Success)
-      assert(AnalysisBasedConstraint[NumMatches, Double, Double](SampleAnalyzer("att1"), _ != 1.0)
+      assert(AnalysisBasedConstraint[NumMatches, Double, Double](SampleAnalyzer("]att1["), _ != 1.0)
         .evaluate(validResults).status == ConstraintStatus.Failure)
       assert(AnalysisBasedConstraint[NumMatches, Double, Double](
           SampleAnalyzer("someMissingColumn"), _ != 1.0)
@@ -144,7 +144,7 @@ class AnalysisBasedConstraintTest extends WordSpec with Matchers with SparkConte
 
       // Although assertion would pass, since analysis result is missing,
       // constraint fails with missing analysis message
-      AnalysisBasedConstraint[NumMatches, Double, Double](SampleAnalyzer("att1"), _ == 1.0)
+      AnalysisBasedConstraint[NumMatches, Double, Double](SampleAnalyzer("]att1["), _ == 1.0)
         .evaluate(emptyResults) match {
         case result =>
           assert(result.status == ConstraintStatus.Failure)
@@ -157,10 +157,10 @@ class AnalysisBasedConstraintTest extends WordSpec with Matchers with SparkConte
       withSparkSession { sparkSession =>
         val df = getDfMissing(sparkSession)
         val validResults = Map[Analyzer[_, Metric[_]], Metric[_]](
-          SampleAnalyzer("att1") -> SampleAnalyzer("att1").calculate(df))
+          SampleAnalyzer("]att1[") -> SampleAnalyzer("]att1[").calculate(df))
 
         assert(AnalysisBasedConstraint[NumMatches, Double, Double](
-            SampleAnalyzer("att1"), _ == 2.0, Some(valueDoubler))
+            SampleAnalyzer("]att1["), _ == 2.0, Some(valueDoubler))
           .evaluate(validResults).status == ConstraintStatus.Success)
       }
 
@@ -174,10 +174,10 @@ class AnalysisBasedConstraintTest extends WordSpec with Matchers with SparkConte
 
       val emptyResults = Map.empty[Analyzer[_, Metric[_]], Metric[_]]
       val validResults = Map[Analyzer[_, Metric[_]], Metric[_]](
-        SampleAnalyzer("att1") -> SampleAnalyzer("att1").calculate(df))
+        SampleAnalyzer("]att1[") -> SampleAnalyzer("]att1[").calculate(df))
 
       val constraint = AnalysisBasedConstraint[NumMatches, Double, Double](
-          SampleAnalyzer("att1"), _ == 1.0, Some(problematicValuePicker))
+          SampleAnalyzer("]att1["), _ == 1.0, Some(problematicValuePicker))
 
       calculate(constraint, df) match {
         case result =>
@@ -209,7 +209,7 @@ class AnalysisBasedConstraintTest extends WordSpec with Matchers with SparkConte
       val df = getDfMissing(sparkSession)
 
       val failingConstraint = AnalysisBasedConstraint[NumMatches, Double, Double](
-          SampleAnalyzer("att1"), _ == 0.9, hint = Some("Value should be like ...!"))
+          SampleAnalyzer("]att1["), _ == 0.9, hint = Some("Value should be like ...!"))
 
       calculate(failingConstraint, df) match {
         case result =>
@@ -230,7 +230,7 @@ class AnalysisBasedConstraintTest extends WordSpec with Matchers with SparkConte
 
       val constraintResult = calculate(
         AnalysisBasedConstraint[NumMatches, Double, Double](
-          SampleAnalyzer("att1"), failingAssertion), df
+          SampleAnalyzer("]att1["), failingAssertion), df
       )
 
       assert(constraintResult.status == ConstraintStatus.Failure)

--- a/src/test/scala/com/amazon/deequ/constraints/ConstraintsTest.scala
+++ b/src/test/scala/com/amazon/deequ/constraints/ConstraintsTest.scala
@@ -31,9 +31,9 @@ class ConstraintsTest extends WordSpec with Matchers with SparkContextSpec with 
   "Completeness constraint" should {
     "assert on wrong completeness" in withSparkSession { sparkSession =>
       val df = getDfMissing(sparkSession)
-      assert(calculate(Constraint.completenessConstraint("att1", _ == 0.5), df).status ==
+      assert(calculate(Constraint.completenessConstraint("]att1[", _ == 0.5), df).status ==
         ConstraintStatus.Success)
-      assert(calculate(Constraint.completenessConstraint("att1", _ != 0.5), df).status ==
+      assert(calculate(Constraint.completenessConstraint("]att1[", _ != 0.5), df).status ==
         ConstraintStatus.Failure)
       assert(calculate(Constraint.completenessConstraint("att2", _ == 0.75), df).status ==
         ConstraintStatus.Success)
@@ -45,15 +45,15 @@ class ConstraintsTest extends WordSpec with Matchers with SparkContextSpec with 
   "Histogram constraints" should {
     "assert on bin number" in withSparkSession { sparkSession =>
       val df = getDfMissing(sparkSession)
-      assert(calculate(Constraint.histogramBinConstraint("att1", _ == 3), df).status ==
+      assert(calculate(Constraint.histogramBinConstraint("]att1[", _ == 3), df).status ==
         ConstraintStatus.Success)
-      assert(calculate(Constraint.histogramBinConstraint("att1", _ != 3), df).status ==
+      assert(calculate(Constraint.histogramBinConstraint("]att1[", _ != 3), df).status ==
         ConstraintStatus.Failure)
     }
     "assert on ratios for a column value which does not exist" in withSparkSession { sparkSession =>
       val df = getDfMissing(sparkSession)
 
-      val metric = calculate(Constraint.histogramConstraint("att1",
+      val metric = calculate(Constraint.histogramConstraint("]att1[",
         _("non-existent-column-value").ratio == 3), df)
 
       metric match {
@@ -69,45 +69,45 @@ class ConstraintsTest extends WordSpec with Matchers with SparkContextSpec with 
     "yield a mutual information of 0 for conditionally uninformative columns" in
       withSparkSession { sparkSession =>
         val df = getDfWithConditionallyUninformativeColumns(sparkSession)
-        calculate(Constraint.mutualInformationConstraint("att1", "att2", _ == 0), df)
-          .status shouldBe ConstraintStatus.Success
+        calculate(Constraint.mutualInformationConstraint("]att1[", "att2", _ == 0), df)
+         .status shouldBe ConstraintStatus.Success
       }
   }
 
   "Basic stats constraints" should {
     "assert on approximate quantile" in withSparkSession { sparkSession =>
       val df = getDfWithNumericValues(sparkSession)
-      calculate(Constraint.approxQuantileConstraint("att1", quantile = 0.5, _ == 3.0), df)
+      calculate(Constraint.approxQuantileConstraint("]att1[", quantile = 0.5, _ == 3.0), df)
         .status shouldBe ConstraintStatus.Success
     }
     "assert on minimum" in withSparkSession { sparkSession =>
       val df = getDfWithNumericValues(sparkSession)
-      calculate(Constraint.minConstraint("att1", _ == 1.0), df)
+      calculate(Constraint.minConstraint("]att1[", _ == 1.0), df)
         .status shouldBe ConstraintStatus.Success
     }
     "assert on maximum" in withSparkSession { sparkSession =>
       val df = getDfWithNumericValues(sparkSession)
-      calculate(Constraint.maxConstraint("att1", _ == 6.0), df)
+      calculate(Constraint.maxConstraint("]att1[", _ == 6.0), df)
         .status shouldBe ConstraintStatus.Success
     }
     "assert on mean" in withSparkSession { sparkSession =>
       val df = getDfWithNumericValues(sparkSession)
-      calculate(Constraint.meanConstraint("att1", _ == 3.5), df)
+      calculate(Constraint.meanConstraint("]att1[", _ == 3.5), df)
         .status shouldBe ConstraintStatus.Success
     }
     "assert on sum" in withSparkSession { sparkSession =>
       val df = getDfWithNumericValues(sparkSession)
-      calculate(Constraint.sumConstraint("att1", _ == 21), df)
+      calculate(Constraint.sumConstraint("]att1[", _ == 21), df)
         .status shouldBe ConstraintStatus.Success
     }
     "assert on standard deviation" in withSparkSession { sparkSession =>
       val df = getDfWithNumericValues(sparkSession)
-      calculate(Constraint.standardDeviationConstraint("att1", _ == 1.707825127659933), df)
+      calculate(Constraint.standardDeviationConstraint("]att1[", _ == 1.707825127659933), df)
         .status shouldBe ConstraintStatus.Success
     }
     "assert on approximate count distinct" in withSparkSession { sparkSession =>
       val df = getDfWithNumericValues(sparkSession)
-      calculate(Constraint.approxCountDistinctConstraint("att1", _ == 6.0), df)
+      calculate(Constraint.approxCountDistinctConstraint("]att1[", _ == 6.0), df)
         .status shouldBe ConstraintStatus.Success
     }
   }
@@ -115,12 +115,12 @@ class ConstraintsTest extends WordSpec with Matchers with SparkContextSpec with 
   "Correlation constraint" should {
     "assert maximal correlation" in withSparkSession { sparkSession =>
       val df = getDfWithConditionallyInformativeColumns(sparkSession)
-      calculate(Constraint.correlationConstraint("att1", "att2", _ == 1.0), df)
+      calculate(Constraint.correlationConstraint("]att1[", "att2", _ == 1.0), df)
         .status shouldBe ConstraintStatus.Success
     }
     "assert no correlation" in withSparkSession { sparkSession =>
       val df = getDfWithConditionallyUninformativeColumns(sparkSession)
-      calculate(Constraint.correlationConstraint("att1", "att2", java.lang.Double.isNaN), df)
+      calculate(Constraint.correlationConstraint("]att1[", "att2", java.lang.Double.isNaN), df)
         .status shouldBe ConstraintStatus.Success
     }
   }
@@ -151,9 +151,9 @@ class ConstraintsTest extends WordSpec with Matchers with SparkContextSpec with 
     "assert on anomaly analyzer values" in withSparkSession { sparkSession =>
       val df = getDfMissing(sparkSession)
       assert(calculate(Constraint.anomalyConstraint[NumMatchesAndCount](
-        Completeness("att1"), _ > 0.4), df).status == ConstraintStatus.Success)
+        Completeness("]att1["), _ > 0.4), df).status == ConstraintStatus.Success)
       assert(calculate(Constraint.anomalyConstraint[NumMatchesAndCount](
-        Completeness("att1"), _ < 0.4), df).status == ConstraintStatus.Failure)
+        Completeness("]att1["), _ < 0.4), df).status == ConstraintStatus.Failure)
 
       assert(calculate(Constraint.anomalyConstraint[NumMatchesAndCount](
         Completeness("att2"), _ > 0.7), df).status == ConstraintStatus.Success)

--- a/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerTest.scala
+++ b/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerTest.scala
@@ -117,11 +117,11 @@ class ColumnProfilerTest extends WordSpec with Matchers with SparkContextSpec
 
       val data = getDfWithNumericFractionalValues(session)
 
-      val actualColumnProfile = ColumnProfiler.profile(data, Option(Seq("att1")), false, 1)
-        .profiles("att1")
+      val actualColumnProfile = ColumnProfiler.profile(data, Option(Seq("]att1[")), false, 1)
+        .profiles("]att1[")
 
       val expectedColumnProfile = NumericColumnProfile(
-        "att1",
+        "]att1[",
         1.0,
         6,
         DataTypeInstances.Fractional,

--- a/src/test/scala/com/amazon/deequ/repository/AnalysisResultTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/AnalysisResultTest.scala
@@ -19,7 +19,7 @@ package com.amazon.deequ.repository
 import java.time.{LocalDate, ZoneOffset}
 
 import com.amazon.deequ.SparkContextSpec
-import com.amazon.deequ.utils.FixtureSupport
+import com.amazon.deequ.utils.{AssertionUtils, FixtureSupport}
 import org.scalatest.{Matchers, WordSpec}
 import com.amazon.deequ.analyzers._
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
@@ -50,8 +50,8 @@ class AnalysisResultTest extends WordSpec with Matchers with SparkContextSpec wi
         val expected = Seq(
           ("Dataset", "*", "Size", 4.0, DATE_ONE, "EU"),
           ("Column", "item", "Distinctness", 1.0, DATE_ONE, "EU"),
-          ("Column", "att1", "Completeness", 1.0, DATE_ONE, "EU"),
-          ("Mutlicolumn", "att1,att2", "Uniqueness", 0.25, DATE_ONE, "EU"))
+          ("Column", "]att1[", "Completeness", 1.0, DATE_ONE, "EU"),
+          ("Mutlicolumn", "]att1[,att2", "Uniqueness", 0.25, DATE_ONE, "EU"))
           .toDF("entity", "instance", "name", "value", "dataset_date", "region")
 
         assertSameRows(analysisResultsAsDataFrame, expected)
@@ -70,11 +70,11 @@ class AnalysisResultTest extends WordSpec with Matchers with SparkContextSpec wi
           val expected =
             s"""[{"entity":"Dataset","instance":"*","name":"Size","value":4.0,
               |"region":"EU", "dataset_date":$DATE_ONE},
-              |{"entity":"Column","instance":"att1","name":"Completeness","value":1.0,
+              |{"entity":"Column","instance":"]att1[","name":"Completeness","value":1.0,
               |"region":"EU", "dataset_date":$DATE_ONE},
               |{"entity":"Column","instance":"item","name":"Distinctness","value":1.0,
               |"region":"EU", "dataset_date":$DATE_ONE},
-              |{"entity":"Mutlicolumn","instance":"att1,att2",
+              |{"entity":"Mutlicolumn","instance":"]att1[,att2",
               |"name":"Uniqueness","value":0.25,
               |"region":"EU", "dataset_date":$DATE_ONE}]"""
               .stripMargin.replaceAll("\n", "")
@@ -89,7 +89,7 @@ class AnalysisResultTest extends WordSpec with Matchers with SparkContextSpec wi
 
         val resultKey = ResultKey(DATE_ONE, REGION_EU)
 
-        val metricsForAnalyzers = Seq(Completeness("att1"), Uniqueness(Seq("att1", "att2")))
+        val metricsForAnalyzers = Seq(Completeness("]att1["), Uniqueness(Seq("]att1[", "att2")))
 
         val analysisResultsAsDataFrame = AnalysisResult
           .getSuccessMetricsAsDataFrame(session, AnalysisResult(resultKey, results),
@@ -98,8 +98,8 @@ class AnalysisResultTest extends WordSpec with Matchers with SparkContextSpec wi
         import session.implicits._
 
         val expected = Seq(
-          ("Column", "att1", "Completeness", 1.0, DATE_ONE, "EU"),
-          ("Mutlicolumn", "att1,att2", "Uniqueness", 0.25, DATE_ONE, "EU"))
+          ("Column", "]att1[", "Completeness", 1.0, DATE_ONE, "EU"),
+          ("Mutlicolumn", "]att1[,att2", "Uniqueness", 0.25, DATE_ONE, "EU"))
           .toDF("entity", "instance", "name", "value", "dataset_date", "region")
 
         assertSameRows(analysisResultsAsDataFrame, expected)
@@ -112,7 +112,7 @@ class AnalysisResultTest extends WordSpec with Matchers with SparkContextSpec wi
 
           val resultKey = ResultKey(DATE_ONE, REGION_EU)
 
-          val metricsForAnalyzers = Seq(Completeness("att1"), Uniqueness(Seq("att1", "att2")))
+          val metricsForAnalyzers = Seq(Completeness("]att1["), Uniqueness(Seq("]att1[", "att2")))
 
           val analysisResultsAsJson = AnalysisResult
             .getSuccessMetricsAsJson(AnalysisResult(resultKey, results),
@@ -120,9 +120,9 @@ class AnalysisResultTest extends WordSpec with Matchers with SparkContextSpec wi
 
 
           val expected =
-            s"""[{"entity":"Column","instance":"att1","name":"Completeness","value":1.0,
+            s"""[{"entity":"Column","instance":"]att1[","name":"Completeness","value":1.0,
               |"region":"EU", "dataset_date":$DATE_ONE},
-              |{"entity":"Mutlicolumn","instance":"att1,att2",
+              |{"entity":"Mutlicolumn","instance":"]att1[,att2",
               |"name":"Uniqueness","value":0.25,
               |"region":"EU", "dataset_date":$DATE_ONE}]"""
               .stripMargin.replaceAll("\n", "")
@@ -145,8 +145,8 @@ class AnalysisResultTest extends WordSpec with Matchers with SparkContextSpec wi
         val expected = Seq(
           ("Dataset", "*", "Size", 4.0, DATE_ONE, "EU"),
           ("Column", "item", "Distinctness", 1.0, DATE_ONE, "EU"),
-          ("Column", "att1", "Completeness", 1.0, DATE_ONE, "EU"),
-          ("Mutlicolumn", "att1,att2", "Uniqueness", 0.25, DATE_ONE, "EU"))
+          ("Column", "]att1[", "Completeness", 1.0, DATE_ONE, "EU"),
+          ("Mutlicolumn", "]att1[,att2", "Uniqueness", 0.25, DATE_ONE, "EU"))
           .toDF("entity", "instance", "name", "value", "dataset_date", "region")
 
         assertSameRows(analysisResultsAsDataFrame, expected)
@@ -165,11 +165,11 @@ class AnalysisResultTest extends WordSpec with Matchers with SparkContextSpec wi
         val expected =
           s"""[{"entity":"Dataset","instance":"*","name":"Size","value":4.0,
             |"region":"EU", "dataset_date":$DATE_ONE},
-            |{"entity":"Column","instance":"att1","name":"Completeness","value":1.0,
+            |{"entity":"Column","instance":"]att1[","name":"Completeness","value":1.0,
             |"region":"EU", "dataset_date":$DATE_ONE},
             |{"entity":"Column","instance":"item","name":"Distinctness","value":1.0,
             |"region":"EU", "dataset_date":$DATE_ONE},
-            |{"entity":"Mutlicolumn","instance":"att1,att2",
+            |{"entity":"Mutlicolumn","instance":"]att1[,att2",
             |"name":"Uniqueness","value":0.25,
             |"region":"EU", "dataset_date":$DATE_ONE}]"""
             .stripMargin.replaceAll("\n", "")
@@ -192,8 +192,8 @@ class AnalysisResultTest extends WordSpec with Matchers with SparkContextSpec wi
         val expected = Seq(
           ("Dataset", "*", "Size", 4.0, DATE_ONE, "EU"),
           ("Column", "item", "Distinctness", 1.0, DATE_ONE, "EU"),
-          ("Column", "att1", "Completeness", 1.0, DATE_ONE, "EU"),
-          ("Mutlicolumn", "att1,att2", "Uniqueness", 0.25, DATE_ONE, "EU"))
+          ("Column", "]att1[", "Completeness", 1.0, DATE_ONE, "EU"),
+          ("Mutlicolumn", "]att1[,att2", "Uniqueness", 0.25, DATE_ONE, "EU"))
           .toDF("entity", "instance", "name", "value", "dataset_date", "name_2")
 
         assertSameRows(analysisResultsAsDataFrame, expected)
@@ -212,11 +212,11 @@ class AnalysisResultTest extends WordSpec with Matchers with SparkContextSpec wi
         val expected =
           s"""[{"entity":"Dataset","instance":"*","name":"Size","value":4.0,
             |"name_2":"EU", "dataset_date":$DATE_ONE},
-            |{"entity":"Column","instance":"att1","name":"Completeness","value":1.0,
+            |{"entity":"Column","instance":"]att1[","name":"Completeness","value":1.0,
             |"name_2":"EU", "dataset_date":$DATE_ONE},
             |{"entity":"Column","instance":"item","name":"Distinctness","value":1.0,
             |"name_2":"EU", "dataset_date":$DATE_ONE},
-            |{"entity":"Mutlicolumn","instance":"att1,att2",
+            |{"entity":"Mutlicolumn","instance":"]att1[,att2",
             |"name":"Uniqueness","value":0.25,
             |"name_2":"EU", "dataset_date":$DATE_ONE}]"""
             .stripMargin.replaceAll("\n", "")
@@ -241,8 +241,8 @@ class AnalysisResultTest extends WordSpec with Matchers with SparkContextSpec wi
           val expected = Seq(
             ("Dataset", "*", "Size", 4.0, DATE_ONE, "EU"),
             ("Column", "item", "Distinctness", 1.0, DATE_ONE, "EU"),
-            ("Column", "att1", "Completeness", 1.0, DATE_ONE, "EU"),
-            ("Mutlicolumn", "att1,att2", "Uniqueness", 0.25, DATE_ONE, "EU"))
+            ("Column", "]att1[", "Completeness", 1.0, DATE_ONE, "EU"),
+            ("Mutlicolumn", "]att1[,att2", "Uniqueness", 0.25, DATE_ONE, "EU"))
             .toDF("entity", "instance", "name", "value", "dataset_date", "region")
 
           assertSameRows(analysisResultsAsDataFrame, expected)
@@ -263,12 +263,12 @@ class AnalysisResultTest extends WordSpec with Matchers with SparkContextSpec wi
           val expected =
             s"""[{"entity":"Dataset","instance":"*","name":"Size","value":4.0,
               |"region":"EU", "dataset_date":$DATE_ONE},
-              |{"entity":"Column","instance":"att1","name":"Completeness","value":1.0,
+              |{"entity":"Column","instance":"]att1[","name":"Completeness","value":1.0,
+              |"region":"EU", "dataset_date":$DATE_ONE},
+              |{"entity":"Mutlicolumn","instance":"]att1[,att2",
+              |"name":"Uniqueness","value":0.25,
               |"region":"EU", "dataset_date":$DATE_ONE},
               |{"entity":"Column","instance":"item","name":"Distinctness","value":1.0,
-              |"region":"EU", "dataset_date":$DATE_ONE},
-              |{"entity":"Mutlicolumn","instance":"att1,att2",
-              |"name":"Uniqueness","value":0.25,
               |"region":"EU", "dataset_date":$DATE_ONE}]"""
               .stripMargin.replaceAll("\n", "")
 
@@ -327,8 +327,8 @@ class AnalysisResultTest extends WordSpec with Matchers with SparkContextSpec wi
     Analysis()
       .addAnalyzer(Size())
       .addAnalyzer(Distinctness("item"))
-      .addAnalyzer(Completeness("att1"))
-      .addAnalyzer(Uniqueness(Seq("att1", "att2")))
+      .addAnalyzer(Completeness("]att1["))
+      .addAnalyzer(Uniqueness(Seq("]att1[", "att2")))
   }
 
   private[this] def createDate(year: Int, month: Int, day: Int): Long = {
@@ -337,10 +337,5 @@ class AnalysisResultTest extends WordSpec with Matchers with SparkContextSpec wi
 
   private[this] def assertSameRows(dataframeA: DataFrame, dataframeB: DataFrame): Unit = {
     assert(dataframeA.collect().toSet == dataframeB.collect().toSet)
-  }
-
-  private[this] def assertSameJson(jsonA: String, jsonB: String): Unit = {
-    assert(SimpleResultSerde.deserialize(jsonA) ==
-      SimpleResultSerde.deserialize(jsonB))
   }
 }

--- a/src/test/scala/com/amazon/deequ/repository/MetricsRepositoryMultipleResultsLoaderTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/MetricsRepositoryMultipleResultsLoaderTest.scala
@@ -19,7 +19,7 @@ package com.amazon.deequ.repository
 import java.time.{LocalDate, ZoneOffset}
 
 import com.amazon.deequ.SparkContextSpec
-import com.amazon.deequ.utils.FixtureSupport
+import com.amazon.deequ.utils.{AssertionUtils, FixtureSupport}
 import org.scalatest.{Matchers, WordSpec}
 import com.amazon.deequ.analyzers._
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
@@ -56,13 +56,13 @@ class MetricsRepositoryMultipleResultsLoaderTest extends WordSpec with Matchers
             // First analysisResult
             ("Dataset", "*", "Size", 4.0, DATE_ONE, "EU"),
             ("Column", "item", "Distinctness", 1.0, DATE_ONE, "EU"),
-            ("Column", "att1", "Completeness", 1.0, DATE_ONE, "EU"),
-            ("Mutlicolumn", "att1,att2", "Uniqueness", 0.25, DATE_ONE, "EU"),
+            ("Column", "]att1[", "Completeness", 1.0, DATE_ONE, "EU"),
+            ("Mutlicolumn", "]att1[,att2", "Uniqueness", 0.25, DATE_ONE, "EU"),
             // Second analysisResult
             ("Dataset", "*", "Size", 4.0, DATE_TWO, "NA"),
             ("Column", "item", "Distinctness", 1.0, DATE_TWO, "NA"),
-            ("Column", "att1", "Completeness", 1.0, DATE_TWO, "NA"),
-            ("Mutlicolumn", "att1,att2", "Uniqueness", 0.25, DATE_TWO, "NA"))
+            ("Column", "]att1[", "Completeness", 1.0, DATE_TWO, "NA"),
+            ("Mutlicolumn", "]att1[,att2", "Uniqueness", 0.25, DATE_TWO, "NA"))
             .toDF("entity", "instance", "name", "value", "dataset_date", "region")
 
           assertSameRows(analysisResultsAsDataFrame, expected)
@@ -83,21 +83,21 @@ class MetricsRepositoryMultipleResultsLoaderTest extends WordSpec with Matchers
           val expected =
             s"""[{"entity":"Dataset","instance":"*","name":"Size","value":4.0,
               |"region":"EU", "dataset_date":$DATE_ONE},
-              |{"entity":"Column","instance":"att1","name":"Completeness","value":1.0,
+              |{"entity":"Column","instance":"]att1[","name":"Completeness","value":1.0,
               |"region":"EU", "dataset_date":$DATE_ONE},
               |{"entity":"Column","instance":"item","name":"Distinctness","value":1.0,
               |"region":"EU", "dataset_date":$DATE_ONE},
-              |{"entity":"Mutlicolumn","instance":"att1,att2",
+              |{"entity":"Mutlicolumn","instance":"]att1[,att2",
               |"name":"Uniqueness","value":0.25,
               |"region":"EU", "dataset_date":$DATE_ONE},
               |
               |{"entity":"Dataset","instance":"*","name":"Size","value":4.0,
               |"region":"NA", "dataset_date":$DATE_TWO},
-              |{"entity":"Column","instance":"att1","name":"Completeness","value":1.0,
+              |{"entity":"Column","instance":"]att1[","name":"Completeness","value":1.0,
               |"region":"NA", "dataset_date":$DATE_TWO},
               |{"entity":"Column","instance":"item","name":"Distinctness","value":1.0,
               |"region":"NA", "dataset_date":$DATE_TWO},
-              |{"entity":"Mutlicolumn","instance":"att1,att2","name":"Uniqueness","value":0.25,
+              |{"entity":"Mutlicolumn","instance":"]att1[,att2","name":"Uniqueness","value":0.25,
               |"region":"NA", "dataset_date":$DATE_TWO}]"""
               .stripMargin.replaceAll("\n", "")
 
@@ -163,18 +163,18 @@ class MetricsRepositoryMultipleResultsLoaderTest extends WordSpec with Matchers
               null.asInstanceOf[String], "Some"),
             ("Column", "item", "Distinctness", 1.0, DATE_ONE, "EU",
               null.asInstanceOf[String], "Some"),
-            ("Column", "att1", "Completeness", 1.0, DATE_ONE, "EU",
+            ("Column", "]att1[", "Completeness", 1.0, DATE_ONE, "EU",
               null.asInstanceOf[String], "Some"),
-            ("Mutlicolumn", "att1,att2", "Uniqueness", 0.25, DATE_ONE, "EU",
+            ("Mutlicolumn", "]att1[,att2", "Uniqueness", 0.25, DATE_ONE, "EU",
               null.asInstanceOf[String], "Some"),
             // Second analysisResult
             ("Dataset", "*", "Size", 4.0, DATE_TWO, "NA",
               "2.0", null.asInstanceOf[String]),
             ("Column", "item", "Distinctness", 1.0, DATE_TWO, "NA",
               "2.0", null.asInstanceOf[String]),
-            ("Column", "att1", "Completeness", 1.0, DATE_TWO, "NA",
+            ("Column", "]att1[", "Completeness", 1.0, DATE_TWO, "NA",
               "2.0", null.asInstanceOf[String]),
-            ("Mutlicolumn", "att1,att2", "Uniqueness", 0.25, DATE_TWO, "NA",
+            ("Mutlicolumn", "]att1[,att2", "Uniqueness", 0.25, DATE_TWO, "NA",
               "2.0", null.asInstanceOf[String]))
             .toDF("entity", "instance", "name",
               "value", "dataset_date", "region", "dataset_version", "dataset_name")
@@ -198,13 +198,13 @@ class MetricsRepositoryMultipleResultsLoaderTest extends WordSpec with Matchers
             s"""[{"entity":"Dataset","instance":"*","name":"Size","value":4.0,
               |"region":"EU", "dataset_date":$DATE_ONE,
               |"dataset_name":"Some", "dataset_version":null},
-              |{"entity":"Column","instance":"att1","name":"Completeness","value":1.0,
+              |{"entity":"Column","instance":"]att1[","name":"Completeness","value":1.0,
               |"region":"EU", "dataset_date":$DATE_ONE,
               |"dataset_name":"Some", "dataset_version":null},
               |{"entity":"Column","instance":"item","name":"Distinctness","value":1.0,
               |"region":"EU", "dataset_date":$DATE_ONE,
               |"dataset_name":"Some", "dataset_version":null},
-              |{"entity":"Mutlicolumn","instance":"att1,att2",
+              |{"entity":"Mutlicolumn","instance":"]att1[,att2",
               |"name":"Uniqueness","value":0.25,
               |"region":"EU", "dataset_date":$DATE_ONE,
               |"dataset_name":"Some", "dataset_version":null},
@@ -212,19 +212,17 @@ class MetricsRepositoryMultipleResultsLoaderTest extends WordSpec with Matchers
               |{"entity":"Dataset","instance":"*","name":"Size","value":4.0,
               |"region":"NA", "dataset_date":$DATE_TWO,
               |"dataset_name":null, "dataset_version":"2.0"},
-              |{"entity":"Column","instance":"att1","name":"Completeness","value":1.0,
+              |{"entity":"Column","instance":"]att1[","name":"Completeness","value":1.0,
               |"region":"NA", "dataset_date":$DATE_TWO,
               |"dataset_name":null, "dataset_version":"2.0"},
               |{"entity":"Column","instance":"item","name":"Distinctness","value":1.0,
               |"region":"NA", "dataset_date":$DATE_TWO,
               |"dataset_name":null, "dataset_version":"2.0"},
-              |{"entity":"Mutlicolumn","instance":"att1,att2",
+              |{"entity":"Mutlicolumn","instance":"]att1[,att2",
               |"name":"Uniqueness","value":0.25,
               |"region":"NA", "dataset_date":$DATE_TWO,
               |"dataset_name":null, "dataset_version":"2.0"}]"""
               .stripMargin.replaceAll("\n", "")
-
-          assertSameJson(analysisResultsAsJson, expected)
 
           assertSameJson(analysisResultsAsJson, expected)
         }
@@ -246,8 +244,8 @@ class MetricsRepositoryMultipleResultsLoaderTest extends WordSpec with Matchers
     Analysis()
       .addAnalyzer(Size())
       .addAnalyzer(Distinctness("item"))
-      .addAnalyzer(Completeness("att1"))
-      .addAnalyzer(Uniqueness(Seq("att1", "att2")))
+      .addAnalyzer(Completeness("]att1["))
+      .addAnalyzer(Uniqueness(Seq("]att1[", "att2")))
   }
 
   private[this] def createRepository(): MetricsRepository = {
@@ -262,8 +260,4 @@ class MetricsRepositoryMultipleResultsLoaderTest extends WordSpec with Matchers
     assert(dataframeA.collect().toSet == dataframeB.collect().toSet)
   }
 
-  private[this] def assertSameJson(jsonA: String, jsonB: String): Unit = {
-    assert(SimpleResultSerde.deserialize(jsonA) ==
-      SimpleResultSerde.deserialize(jsonB))
-  }
 }

--- a/src/test/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepositoryTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepositoryTest.scala
@@ -110,13 +110,13 @@ class FileSystemMetricsRepositoryTest extends WordSpec with SparkContextSpec wit
           // First analysisResult
           ("Dataset", "*", "Size", 4.0, DATE_ONE, "EU"),
           ("Column", "item", "Distinctness", 1.0, DATE_ONE, "EU"),
-          ("Column", "att1", "Completeness", 1.0, DATE_ONE, "EU"),
-          ("Mutlicolumn", "att1,att2", "Uniqueness", 0.25, DATE_ONE, "EU"),
+          ("Column", "]att1[", "Completeness", 1.0, DATE_ONE, "EU"),
+          ("Mutlicolumn", "]att1[,att2", "Uniqueness", 0.25, DATE_ONE, "EU"),
           // Second analysisResult
           ("Dataset", "*", "Size", 4.0, DATE_TWO, "NA"),
           ("Column", "item", "Distinctness", 1.0, DATE_TWO, "NA"),
-          ("Column", "att1", "Completeness", 1.0, DATE_TWO, "NA"),
-          ("Mutlicolumn", "att1,att2", "Uniqueness", 0.25, DATE_TWO, "NA"))
+          ("Column", "]att1[", "Completeness", 1.0, DATE_TWO, "NA"),
+          ("Mutlicolumn", "]att1[,att2", "Uniqueness", 0.25, DATE_TWO, "NA"))
           .toDF("entity", "instance", "name", "value", "dataset_date", "region")
 
         assertSameRows(analysisResultsAsDataFrame, expected)
@@ -142,8 +142,8 @@ class FileSystemMetricsRepositoryTest extends WordSpec with SparkContextSpec wit
             // Second analysisResult
             ("Dataset", "*", "Size", 4.0, DATE_TWO, "NA"),
             ("Column", "item", "Distinctness", 1.0, DATE_TWO, "NA"),
-            ("Column", "att1", "Completeness", 1.0, DATE_TWO, "NA"),
-            ("Mutlicolumn", "att1,att2", "Uniqueness", 0.25, DATE_TWO, "NA"))
+            ("Column", "]att1[", "Completeness", 1.0, DATE_TWO, "NA"),
+            ("Mutlicolumn", "]att1[,att2", "Uniqueness", 0.25, DATE_TWO, "NA"))
             .toDF("entity", "instance", "name", "value", "dataset_date", "region")
 
           assertSameRows(analysisResultsAsDataFrame, expected)
@@ -167,8 +167,8 @@ class FileSystemMetricsRepositoryTest extends WordSpec with SparkContextSpec wit
           // First analysisResult
           ("Dataset", "*", "Size", 4.0, DATE_ONE, "EU"),
           ("Column", "item", "Distinctness", 1.0, DATE_ONE, "EU"),
-          ("Column", "att1", "Completeness", 1.0, DATE_ONE, "EU"),
-          ("Mutlicolumn", "att1,att2", "Uniqueness", 0.25, DATE_ONE, "EU"))
+          ("Column", "]att1[", "Completeness", 1.0, DATE_ONE, "EU"),
+          ("Mutlicolumn", "]att1[,att2", "Uniqueness", 0.25, DATE_ONE, "EU"))
           .toDF("entity", "instance", "name", "value", "dataset_date", "region")
 
         assertSameRows(analysisResultsAsDataFrame, expected)
@@ -185,17 +185,17 @@ class FileSystemMetricsRepositoryTest extends WordSpec with SparkContextSpec wit
 
           val analysisResultsAsDataFrame = repository.load()
             .after(DATE_ONE)
-            .forAnalyzers(Seq(Completeness("att1"), Uniqueness(Seq("att1", "att2"))))
+            .forAnalyzers(Seq(Completeness("]att1["), Uniqueness(Seq("]att1[", "att2"))))
             .getSuccessMetricsAsDataFrame(sparkSession)
 
           import sparkSession.implicits._
           val expected = Seq(
             // First analysisResult
-            ("Column", "att1", "Completeness", 1.0, DATE_ONE, "EU"),
-            ("Mutlicolumn", "att1,att2", "Uniqueness", 0.25, DATE_ONE, "EU"),
+            ("Column", "]att1[", "Completeness", 1.0, DATE_ONE, "EU"),
+            ("Mutlicolumn", "]att1[,att2", "Uniqueness", 0.25, DATE_ONE, "EU"),
             // Second analysisResult
-            ("Column", "att1", "Completeness", 1.0, DATE_TWO, "NA"),
-            ("Mutlicolumn", "att1,att2", "Uniqueness", 0.25, DATE_TWO, "NA"))
+            ("Column", "]att1[", "Completeness", 1.0, DATE_TWO, "NA"),
+            ("Mutlicolumn", "]att1[,att2", "Uniqueness", 0.25, DATE_TWO, "NA"))
             .toDF("entity", "instance", "name", "value", "dataset_date", "region")
 
           assertSameRows(analysisResultsAsDataFrame, expected)
@@ -253,8 +253,8 @@ class FileSystemMetricsRepositoryTest extends WordSpec with SparkContextSpec wit
     Analysis()
       .addAnalyzer(Size())
       .addAnalyzer(Distinctness("item"))
-      .addAnalyzer(Completeness("att1"))
-      .addAnalyzer(Uniqueness(Seq("att1", "att2")))
+      .addAnalyzer(Completeness("]att1["))
+      .addAnalyzer(Uniqueness(Seq("]att1[", "att2")))
   }
 
   private[this] def createDate(year: Int, month: Int, day: Int): Long = {

--- a/src/test/scala/com/amazon/deequ/repository/memory/InMemoryMetricsRepositoryTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/memory/InMemoryMetricsRepositoryTest.scala
@@ -99,13 +99,13 @@ class InMemoryMetricsRepositoryTest extends WordSpec with SparkContextSpec with 
           // First analysisResult
           ("Dataset", "*", "Size", 4.0, DATE_ONE, "EU"),
           ("Column", "item", "Distinctness", 1.0, DATE_ONE, "EU"),
-          ("Column", "att1", "Completeness", 1.0, DATE_ONE, "EU"),
-          ("Mutlicolumn", "att1,att2", "Uniqueness", 0.25, DATE_ONE, "EU"),
+          ("Column", "]att1[", "Completeness", 1.0, DATE_ONE, "EU"),
+          ("Mutlicolumn", "]att1[,att2", "Uniqueness", 0.25, DATE_ONE, "EU"),
           // Second analysisResult
           ("Dataset", "*", "Size", 4.0, DATE_TWO, "NA"),
           ("Column", "item", "Distinctness", 1.0, DATE_TWO, "NA"),
-          ("Column", "att1", "Completeness", 1.0, DATE_TWO, "NA"),
-          ("Mutlicolumn", "att1,att2", "Uniqueness", 0.25, DATE_TWO, "NA"))
+          ("Column", "]att1[", "Completeness", 1.0, DATE_TWO, "NA"),
+          ("Mutlicolumn", "]att1[,att2", "Uniqueness", 0.25, DATE_TWO, "NA"))
           .toDF("entity", "instance", "name", "value", "dataset_date", "region")
 
         assertSameRows(analysisResultsAsDataFrame, expected)
@@ -131,8 +131,8 @@ class InMemoryMetricsRepositoryTest extends WordSpec with SparkContextSpec with 
             // Second analysisResult
             ("Dataset", "*", "Size", 4.0, DATE_TWO, "NA"),
             ("Column", "item", "Distinctness", 1.0, DATE_TWO, "NA"),
-            ("Column", "att1", "Completeness", 1.0, DATE_TWO, "NA"),
-            ("Mutlicolumn", "att1,att2", "Uniqueness", 0.25, DATE_TWO, "NA"))
+            ("Column", "]att1[", "Completeness", 1.0, DATE_TWO, "NA"),
+            ("Mutlicolumn", "]att1[,att2", "Uniqueness", 0.25, DATE_TWO, "NA"))
             .toDF("entity", "instance", "name", "value", "dataset_date", "region")
 
           assertSameRows(analysisResultsAsDataFrame, expected)
@@ -156,8 +156,8 @@ class InMemoryMetricsRepositoryTest extends WordSpec with SparkContextSpec with 
           // First analysisResult
           ("Dataset", "*", "Size", 4.0, DATE_ONE, "EU"),
           ("Column", "item", "Distinctness", 1.0, DATE_ONE, "EU"),
-          ("Column", "att1", "Completeness", 1.0, DATE_ONE, "EU"),
-          ("Mutlicolumn", "att1,att2", "Uniqueness", 0.25, DATE_ONE, "EU"))
+          ("Column", "]att1[", "Completeness", 1.0, DATE_ONE, "EU"),
+          ("Mutlicolumn", "]att1[,att2", "Uniqueness", 0.25, DATE_ONE, "EU"))
           .toDF("entity", "instance", "name", "value", "dataset_date", "region")
 
         assertSameRows(analysisResultsAsDataframe, expected)
@@ -174,17 +174,17 @@ class InMemoryMetricsRepositoryTest extends WordSpec with SparkContextSpec with 
 
           val analysisResultsAsDataFrame = repository.load()
             .after(DATE_ONE)
-            .forAnalyzers(Seq(Completeness("att1"), Uniqueness(Seq("att1", "att2"))))
+            .forAnalyzers(Seq(Completeness("]att1["), Uniqueness(Seq("]att1[", "att2"))))
             .getSuccessMetricsAsDataFrame(sparkSession)
 
           import sparkSession.implicits._
           val expected = Seq(
             // First analysisResult
-            ("Column", "att1", "Completeness", 1.0, DATE_ONE, "EU"),
-            ("Mutlicolumn", "att1,att2", "Uniqueness", 0.25, DATE_ONE, "EU"),
+            ("Column", "]att1[", "Completeness", 1.0, DATE_ONE, "EU"),
+            ("Mutlicolumn", "]att1[,att2", "Uniqueness", 0.25, DATE_ONE, "EU"),
             // Second analysisResult
-            ("Column", "att1", "Completeness", 1.0, DATE_TWO, "NA"),
-            ("Mutlicolumn", "att1,att2", "Uniqueness", 0.25, DATE_TWO, "NA"))
+            ("Column", "]att1[", "Completeness", 1.0, DATE_TWO, "NA"),
+            ("Mutlicolumn", "]att1[,att2", "Uniqueness", 0.25, DATE_TWO, "NA"))
             .toDF("entity", "instance", "name", "value", "dataset_date", "region")
 
           assertSameRows(analysisResultsAsDataFrame, expected)
@@ -244,8 +244,8 @@ class InMemoryMetricsRepositoryTest extends WordSpec with SparkContextSpec with 
     Analysis()
       .addAnalyzer(Size())
       .addAnalyzer(Distinctness("item"))
-      .addAnalyzer(Completeness("att1"))
-      .addAnalyzer(Uniqueness(Seq("att1", "att2")))
+      .addAnalyzer(Completeness("]att1["))
+      .addAnalyzer(Uniqueness(Seq("]att1[", "att2")))
   }
 
   private[this] def createDate(year: Int, month: Int, day: Int): Long = {

--- a/src/test/scala/com/amazon/deequ/schema/ColumnNameTest.scala
+++ b/src/test/scala/com/amazon/deequ/schema/ColumnNameTest.scala
@@ -1,0 +1,119 @@
+/**
+  * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+  * use this file except in compliance with the License. A copy of the License
+  * is located at
+  *
+  *     http://aws.amazon.com/apache2.0/
+  *
+  * or in the "license" file accompanying this file. This file is distributed on
+  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  * express or implied. See the License for the specific language governing
+  * permissions and limitations under the License.
+  *
+  */
+
+package com.amazon.deequ.schema
+
+import org.scalatest.{Matchers, WordSpec}
+
+class ColumnNameTest extends WordSpec with Matchers {
+
+  "ColumnName's sanitizeForSql function" should {
+
+    "leave escaped column name unchanged" in {
+      val c = "`escaped_column_name`"
+      ColumnName.sanitizeForSql(c) match {
+        case Right(x) => assert(c == x)
+        case Left(x) => fail(x.getMessage)
+      }
+    }
+
+    "add leading ` if necessary" in {
+      val c = "almost_escaped_column_name`"
+      ColumnName.sanitizeForSql(c) match {
+        case Right(x) => assert(x == s"`$c")
+        case Left(x) => fail(x.getMessage)
+      }
+    }
+
+    "add trailing ` if necessary" in {
+      val c = "`almost_escaped_column_name"
+      ColumnName.sanitizeForSql(c) match {
+        case Right(x) => assert(x == s"$c`")
+        case Left(x) => fail(x.getMessage)
+      }
+    }
+
+    "surround column with `` when not escaped" in {
+      val c = "]not escaped na[m]e[ "
+      ColumnName.sanitizeForSql(c) match {
+        case Right(x) => assert(x == s"`$c`")
+        case Left(x) => fail(x.getMessage)
+      }
+    }
+
+    "fail to sanitize a column with a ` in the name" in {
+      val c = "cannot_`_sanitize"
+      ColumnName.sanitizeForSql(c) match {
+        case Left(ColumnNameHasBackticks(column)) => assert(column == c)
+        case x => fail(s"Expecting ColumnNameHasBackticks, not: $x")
+      }
+    }
+
+    "fail to sanitize a null column name" in {
+      ColumnName.sanitizeForSql(null) match {
+        case Left(NullColumn) => ()
+        case x => fail(s"Expecting EmptyColumn, not: $x")
+      }
+    }
+
+    "be idempotent" in {
+      val originalSanitized = ColumnName.sanitize(" this ][ is s0meth!ng to sanitize (   ")
+      (0 until 10).foldLeft(originalSanitized) {
+        case (sanitized, _) =>
+          val s = ColumnName.sanitize(sanitized)
+          assert(s == originalSanitized)
+          s
+      }
+    }
+
+  }
+
+  "desanitize" should {
+
+    "invert sanitized result" in  {
+      val x = " he!1[] w<>rlD   ("
+      assert(ColumnName.desanitize(ColumnName.sanitize(x)) == x)
+    }
+
+    "cleanly unsanitize sanitized column" in {
+      assert(ColumnName.desanitize("`hello world`") == "hello world")
+    }
+
+    "desanitize leading `" in {
+      assert(ColumnName.desanitize("`hello world") == "hello world")
+    }
+
+    "desanitize trailing `" in {
+      assert(ColumnName.desanitize("hello world`") == "hello world")
+    }
+
+    "evaluate to empty string on null input" in {
+      assert(ColumnName.desanitize(null).length == 0)
+    }
+
+    "be idempotent" in {
+      val originalDesanitized = ColumnName.desanitize("`a_column`")
+      (0 until 10).foldLeft(originalDesanitized) {
+        case (desanitized, _) =>
+        val d = ColumnName.desanitize(desanitized)
+        assert(d == originalDesanitized)
+        d
+      }
+    }
+
+  }
+
+}

--- a/src/test/scala/com/amazon/deequ/schema/ColumnNameTest.scala
+++ b/src/test/scala/com/amazon/deequ/schema/ColumnNameTest.scala
@@ -23,7 +23,7 @@ class ColumnNameTest extends WordSpec with Matchers {
   "ColumnName's sanitizeForSql function" should {
 
     "leave escaped column name unchanged" in {
-      val c = "`escaped_column_name`"
+      val columnName"`escaped_column_name`"
       ColumnName.sanitizeForSql(c) match {
         case Right(x) => assert(c == x)
         case Left(x) => fail(x.getMessage)
@@ -31,7 +31,7 @@ class ColumnNameTest extends WordSpec with Matchers {
     }
 
     "add leading ` if necessary" in {
-      val c = "almost_escaped_column_name`"
+      val columnName"almost_escaped_column_name`"
       ColumnName.sanitizeForSql(c) match {
         case Right(x) => assert(x == s"`$sanitizedColumn")
         case Left(x) => fail(x.getMessage)
@@ -39,7 +39,7 @@ class ColumnNameTest extends WordSpec with Matchers {
     }
 
     "add trailing ` if necessary" in {
-      val c = "`almost_escaped_column_name"
+      val columnName"`almost_escaped_column_name"
       ColumnName.sanitizeForSql(c) match {
         case Right(x) => assert(x == s"$sanitizedColumn`")
         case Left(x) => fail(x.getMessage)
@@ -47,7 +47,7 @@ class ColumnNameTest extends WordSpec with Matchers {
     }
 
     "surround column with `` when not escaped" in {
-      val c = "]not escaped na[m]e[ "
+      val columnName"]not escaped na[m]e[ "
       ColumnName.sanitizeForSql(c) match {
         case Right(x) => assert(x == s"`$sanitizedColumn`")
         case Left(x) => fail(x.getMessage)
@@ -55,7 +55,7 @@ class ColumnNameTest extends WordSpec with Matchers {
     }
 
     "fail to sanitize a column with a ` in the name" in {
-      val c = "cannot_`_sanitize"
+      val columnName"cannot_`_sanitize"
       ColumnName.sanitizeForSql(c) match {
         case Left(ColumnNameHasBackticks(column)) => assert(column == c)
         case x => fail(s"Expecting ColumnNameHasBackticks, not: $x")

--- a/src/test/scala/com/amazon/deequ/schema/ColumnNameTest.scala
+++ b/src/test/scala/com/amazon/deequ/schema/ColumnNameTest.scala
@@ -23,41 +23,41 @@ class ColumnNameTest extends WordSpec with Matchers {
   "ColumnName's sanitizeForSql function" should {
 
     "leave escaped column name unchanged" in {
-      val columnName"`escaped_column_name`"
-      ColumnName.sanitizeForSql(c) match {
-        case Right(x) => assert(c == x)
+      val column = "`escaped_column_name`"
+      ColumnName.sanitizeForSql(column) match {
+        case Right(x) => assert(x == column)
         case Left(x) => fail(x.getMessage)
       }
     }
 
     "add leading ` if necessary" in {
-      val columnName"almost_escaped_column_name`"
-      ColumnName.sanitizeForSql(c) match {
-        case Right(x) => assert(x == s"`$sanitizedColumn")
+      val column = "almost_escaped_column_name`"
+      ColumnName.sanitizeForSql(column) match {
+        case Right(x) => assert(x == s"`$column")
         case Left(x) => fail(x.getMessage)
       }
     }
 
     "add trailing ` if necessary" in {
-      val columnName"`almost_escaped_column_name"
-      ColumnName.sanitizeForSql(c) match {
-        case Right(x) => assert(x == s"$sanitizedColumn`")
+      val column = "`almost_escaped_column_name"
+      ColumnName.sanitizeForSql(column) match {
+        case Right(x) => assert(x == s"$column`")
         case Left(x) => fail(x.getMessage)
       }
     }
 
     "surround column with `` when not escaped" in {
-      val columnName"]not escaped na[m]e[ "
-      ColumnName.sanitizeForSql(c) match {
-        case Right(x) => assert(x == s"`$sanitizedColumn`")
+      val column = "]not escaped na[m]e[ "
+      ColumnName.sanitizeForSql(column) match {
+        case Right(x) => assert(x == s"`$column`")
         case Left(x) => fail(x.getMessage)
       }
     }
 
     "fail to sanitize a column with a ` in the name" in {
-      val columnName"cannot_`_sanitize"
-      ColumnName.sanitizeForSql(c) match {
-        case Left(ColumnNameHasBackticks(column)) => assert(column == c)
+      val column = "cannot_`_sanitize"
+      ColumnName.sanitizeForSql(column) match {
+        case Left(ColumnNameHasBackticks(c)) => assert(column == c)
         case x => fail(s"Expecting ColumnNameHasBackticks, not: $x")
       }
     }

--- a/src/test/scala/com/amazon/deequ/schema/ColumnNameTest.scala
+++ b/src/test/scala/com/amazon/deequ/schema/ColumnNameTest.scala
@@ -33,7 +33,7 @@ class ColumnNameTest extends WordSpec with Matchers {
     "add leading ` if necessary" in {
       val c = "almost_escaped_column_name`"
       ColumnName.sanitizeForSql(c) match {
-        case Right(x) => assert(x == s"`$c")
+        case Right(x) => assert(x == s"`$sanitizedColumn")
         case Left(x) => fail(x.getMessage)
       }
     }
@@ -41,7 +41,7 @@ class ColumnNameTest extends WordSpec with Matchers {
     "add trailing ` if necessary" in {
       val c = "`almost_escaped_column_name"
       ColumnName.sanitizeForSql(c) match {
-        case Right(x) => assert(x == s"$c`")
+        case Right(x) => assert(x == s"$sanitizedColumn`")
         case Left(x) => fail(x.getMessage)
       }
     }
@@ -49,7 +49,7 @@ class ColumnNameTest extends WordSpec with Matchers {
     "surround column with `` when not escaped" in {
       val c = "]not escaped na[m]e[ "
       ColumnName.sanitizeForSql(c) match {
-        case Right(x) => assert(x == s"`$c`")
+        case Right(x) => assert(x == s"`$sanitizedColumn`")
         case Left(x) => fail(x.getMessage)
       }
     }

--- a/src/test/scala/com/amazon/deequ/suggestions/rules/ConstraintRulesTest.scala
+++ b/src/test/scala/com/amazon/deequ/suggestions/rules/ConstraintRulesTest.scala
@@ -46,7 +46,7 @@ class ConstraintRulesTest extends WordSpec with FixtureSupport with SparkContext
 
       val dfWithColumnCandidate = getDfFull(session)
 
-      val fakeColumnProfile = getFakeColumnProfileWithNameAndCompleteness("att1", 1)
+      val fakeColumnProfile = getFakeColumnProfileWithNameAndCompleteness("]att1[", 1)
 
       val check = Check(CheckLevel.Warning, "some")
         .addConstraint(CompleteIfCompleteRule().candidate(fakeColumnProfile, 100).constraint)
@@ -66,16 +66,16 @@ class ConstraintRulesTest extends WordSpec with FixtureSupport with SparkContext
 
       val dfWithColumnCandidate = getDfFull(session)
 
-      val fakeColumnProfile = getFakeColumnProfileWithNameAndCompleteness("att1", 1)
+      val fakeColumnProfile = getFakeColumnProfileWithNameAndCompleteness("]att1[", 1)
 
       val codeForConstraint = CompleteIfCompleteRule().candidate(fakeColumnProfile, 100)
         .codeForConstraint
-      val expectedCodeForConstraint = """.isComplete("att1")"""
+      val expectedCodeForConstraint = """.isComplete("]att1[")"""
 
       assert(expectedCodeForConstraint == codeForConstraint)
 
       val check = Check(CheckLevel.Warning, "some")
-        .isComplete("att1")
+        .isComplete("]att1[")
 
       val verificationResult = VerificationSuite()
         .onData(dfWithColumnCandidate)
@@ -103,7 +103,7 @@ class ConstraintRulesTest extends WordSpec with FixtureSupport with SparkContext
 
       val dfWithColumnCandidate = getDfFull(session)
 
-      val fakeColumnProfile = getFakeColumnProfileWithNameAndCompleteness("att1", 0.5)
+      val fakeColumnProfile = getFakeColumnProfileWithNameAndCompleteness("]att1[", 0.5)
 
       val check = Check(CheckLevel.Warning, "some")
         .addConstraint(RetainCompletenessRule().candidate(fakeColumnProfile, 100).constraint)
@@ -123,18 +123,18 @@ class ConstraintRulesTest extends WordSpec with FixtureSupport with SparkContext
 
       val dfWithColumnCandidate = getDfFull(session)
 
-      val fakeColumnProfile = getFakeColumnProfileWithNameAndCompleteness("att1", 0.5)
+      val fakeColumnProfile = getFakeColumnProfileWithNameAndCompleteness("]att1[", 0.5)
 
       val codeForConstraint = RetainCompletenessRule().candidate(fakeColumnProfile, 100)
         .codeForConstraint
 
-      val expectedCodeForConstraint = """.hasCompleteness("att1", _ >= 0.4,
+      val expectedCodeForConstraint = """.hasCompleteness("]att1[", _ >= 0.4,
           | Some("It should be above 0.4!"))""".stripMargin.replaceAll("\n", "")
 
       assert(expectedCodeForConstraint == codeForConstraint)
 
       val check = Check(CheckLevel.Warning, "some")
-        .hasCompleteness("att1", _ >= 0.4, Some("It should be above 0.4!"))
+        .hasCompleteness("]att1[", _ >= 0.4, Some("It should be above 0.4!"))
 
       val verificationResult = VerificationSuite()
         .onData(dfWithColumnCandidate)

--- a/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
+++ b/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
@@ -244,7 +244,6 @@ trait FixtureSupport extends Assertions {
 
     type T = Map[String, Any]
 
-    @inline
     private[this] def get(key: String)(x: T): String =
       x.get(key).fold("")(_.asInstanceOf[String])
 

--- a/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
+++ b/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
@@ -16,12 +16,15 @@
 
 package com.amazon.deequ.utils
 
+import com.amazon.deequ.repository.SimpleResultSerde
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.scalatest.Assertions
+
 import scala.util.Random
 
 
-trait FixtureSupport {
+trait FixtureSupport extends Assertions {
 
   def getDfEmpty(sparkSession: SparkSession): DataFrame = {
     import sparkSession.implicits._
@@ -58,7 +61,7 @@ trait FixtureSupport {
       ("10", null, null),
       ("11", null, "f"),
       ("12", null, "d")
-    ).toDF("item", "att1", "att2")
+    ).toDF("item", "]att1[", "att2")
   }
 
   def getDfFull(sparkSession: SparkSession): DataFrame = {
@@ -69,7 +72,7 @@ trait FixtureSupport {
       ("2", "a", "c"),
       ("3", "a", "c"),
       ("4", "b", "d")
-    ).toDF("item", "att1", "att2")
+    ).toDF("item", "]att1[", "att2")
   }
 
   def getDfWithNegativeNumbers(sparkSession: SparkSession): DataFrame = {
@@ -80,7 +83,7 @@ trait FixtureSupport {
       ("2", "-2", "-2.0"),
       ("3", "-3", "-3.0"),
       ("4", "-4", "-4.0")
-    ).toDF("item", "att1", "att2")
+    ).toDF("item", "]att1[", "att2")
   }
 
   def getDfCompleteAndInCompleteColumns(sparkSession: SparkSession): DataFrame = {
@@ -93,7 +96,7 @@ trait FixtureSupport {
       ("4", "a", "f"),
       ("5", "b", null),
       ("6", "a", "f")
-    ).toDF("item", "att1", "att2")
+    ).toDF("item", "]att1[", "att2")
   }
 
   def getDfCompleteAndInCompleteColumnsDelta(sparkSession: SparkSession): DataFrame = {
@@ -103,7 +106,7 @@ trait FixtureSupport {
       ("7", "a", null),
       ("8", "b", "d"),
       ("9", "a", null)
-    ).toDF("item", "att1", "att2")
+    ).toDF("item", "]att1[", "att2")
   }
 
 
@@ -113,7 +116,7 @@ trait FixtureSupport {
     Seq(
       ("1", "1.0"),
       ("2", "1")
-    ).toDF("item", "att1")
+    ).toDF("item", "]att1[")
   }
 
   def getDfFractionalStringTypes(sparkSession: SparkSession): DataFrame = {
@@ -122,7 +125,7 @@ trait FixtureSupport {
     Seq(
       ("1", "1.0"),
       ("2", "a")
-    ).toDF("item", "att1")
+    ).toDF("item", "]att1[")
   }
 
   def getDfIntegralStringTypes(sparkSession: SparkSession): DataFrame = {
@@ -131,12 +134,12 @@ trait FixtureSupport {
     Seq(
       ("1", "1"),
       ("2", "a")
-    ).toDF("item", "att1")
+    ).toDF("item", "]att1[")
   }
 
   def getDfWithNumericValues(sparkSession: SparkSession): DataFrame = {
     import sparkSession.implicits._
-    // att2 is always bigger than att1
+    // att2 is always bigger than ]att1[
     Seq(
       ("1", 1, 0),
       ("2", 2, 0),
@@ -144,7 +147,7 @@ trait FixtureSupport {
       ("4", 4, 5),
       ("5", 5, 6),
       ("6", 6, 7)
-    ).toDF("item", "att1", "att2")
+    ).toDF("item", "]att1[", "att2")
   }
 
   def getDfWithNumericFractionalValues(sparkSession: SparkSession): DataFrame = {
@@ -156,7 +159,7 @@ trait FixtureSupport {
       ("4", 4.0, 5.0),
       ("5", 5.0, 6.0),
       ("6", 6.0, 7.0)
-    ).toDF("item", "att1", "att2")
+    ).toDF("item", "]att1[", "att2")
   }
 
   def getDfWithUniqueColumns(sparkSession: SparkSession): DataFrame = {
@@ -170,8 +173,8 @@ trait FixtureSupport {
       ("5", "6", null, "4", "0", "5"),
       ("6", "7", null, "5", "0", "6")
     )
-    .toDF("unique", "nonUnique", "nonUniqueWithNulls", "uniqueWithNulls",
-      "onlyUniqueWithOtherNonUnique", "halfUniqueCombinedWithNonUnique")
+      .toDF("unique", "nonUnique", "nonUniqueWithNulls", "uniqueWithNulls",
+        "onlyUniqueWithOtherNonUnique", "halfUniqueCombinedWithNonUnique")
   }
 
   def getDfWithDistinctValues(sparkSession: SparkSession): DataFrame = {
@@ -184,7 +187,7 @@ trait FixtureSupport {
       ("b", "x"),
       ("b", "x"),
       ("c", "y"))
-      .toDF("att1", "att2")
+      .toDF("]att1[", "att2")
   }
 
   def getDfWithConditionallyUninformativeColumns(sparkSession: SparkSession): DataFrame = {
@@ -193,7 +196,7 @@ trait FixtureSupport {
       (1, 0),
       (2, 0),
       (3, 0)
-    ).toDF("att1", "att2")
+    ).toDF("]att1[", "att2")
   }
 
   def getDfWithConditionallyInformativeColumns(sparkSession: SparkSession): DataFrame = {
@@ -202,14 +205,14 @@ trait FixtureSupport {
       (1, 4),
       (2, 5),
       (3, 6)
-    ).toDF("att1", "att2")
+    ).toDF("]att1[", "att2")
   }
 
   def getDfWithCategoricalColumn(
       sparkSession: SparkSession,
       numberOfRows: Int,
       categories: Seq[String])
-    : DataFrame = {
+  : DataFrame = {
 
     val random = new Random(0)
 
@@ -217,6 +220,38 @@ trait FixtureSupport {
     (1 to numberOfRows)
       .toList
       .map { index => (s"$index", random.shuffle(categories).head)}
-      .toDF("att1", "categoricalColumn")
+      .toDF("]att1[", "categoricalColumn")
+  }
+
+  implicit object OrderingTestMap extends Ordering[Map[String, Any]] {
+
+    type T = Map[String, Any]
+
+    def get(key: String)(x: T): String =
+      x.get(key).fold("")(_.asInstanceOf[String])
+
+    override def compare(x: T, y: T): Int = {
+      val instance = get("instance") _
+      val name = get("name") _
+      val columnName = get("column_name") _
+
+      val cmp1 = instance(x).compareTo(instance(y))
+      if (cmp1 == 0) {
+        val cmp2 = name(x).compareTo(name(y))
+        if (cmp2 == 0) {
+          columnName(x).compareTo(columnName(y))
+        } else {
+          cmp2
+        }
+      } else {
+        cmp1
+      }
+    }
+  }
+
+  def assertSameJson(jsonA: String, jsonB: String): Unit = {
+    val a = SimpleResultSerde.deserialize(jsonA)
+    val b = SimpleResultSerde.deserialize(jsonB)
+    assert(a.sorted == b.sorted)
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/deequ/issues/89

*Description of changes:*
#### Problem
Deequ does not sanitize column names when creating Spark SQL statements.
Thus, deequ fails on `DataFrame`s that contain any special characters 
that are reserved in the Spark SQL syntax.


#### Tests Showing Failure
Tests have been changed to use at least one column name with special
characters. Specifically, all of the `att1` columns have been changed to
the value `]att1[`. When used in Spark SQL statements, these special
characters will, if not properly escaped, cause syntax errors during
interpretation.

This column name change has caused `com.amazon.deequ.checks.CheckTest`
to fail. Specifically, the failing tests are:
```
Check
...
- should correctly evaluate convenience constraints *** FAILED ***
  Error did not equal Success (CheckTest.scala:835)

Check on column names with special characters
...
- should work for isPositive *** FAILED ***
  Error did not equal Success (CheckTest.scala:885)
- should work for isNonNegative *** FAILED ***
  Error did not equal Success (CheckTest.scala:885)

Checks for two-columned DataFrames
- should check greater than *** FAILED ***
  Error did not equal Success (CheckTest.scala:885)
- should check less than *** FAILED ***
  Error did not equal Success (CheckTest.scala:885)
- should check greater than or equal to *** FAILED ***
  Error did not equal Success (CheckTest.scala:885)
- should check less than or equal to *** FAILED ***
  Error did not equal Success (CheckTest.scala:885)
```

Also note that a new test case for the >, <, >=, and <= checks has been
added under `Checks for two-columned DataFrames`.

The `assertSameJson` functionality has been refactored into a single
callsite. Additionally, this test utility function now properly sorts
the previosuly not guarenteed to be sorted lists that it has to assert
equality between. This functionality is in the `FixtureSupport` trait
of the `com.amazon.deequ.utils` package. Moreover, the
`assertJsonStringsAreEqual` helper function in the
`ConstraintSuggestionResultTest` has been updated to use this sorted
comparision fix.


#### Fix
Support for sanitizing column names for Spark SQL has been added in
the new `com.amazon.deequ.schema.ColumnName` object. The `sanitizeForSql`
function will either sanitize the column name or result in a descriptive
error. Since the rest of the deequ codebase doesn't handle errors in
a first-class way, the `sanitize` method has been added, which will
throw the error if it fails to sanitize.

The fix for ensuring that all column names that are used in Spark SQL
statements involves ensuring that all calls that would put the bare
column name into a Spark SQL statement do so only after calling
`ColumnName.sanitize`, which will wrap the name in backticks ("``").
Additionally, this fix includes understanding when it is crucial to
include the escaped column name vs. the real (unescaped) name.


#### License
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
