### PR TITLE
Adapts AttributeReference call to changes made in Spark 2.4

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/catalyst/AttributeReferenceCreation.java
+++ b/src/main/scala/com/amazon/deequ/analyzers/catalyst/AttributeReferenceCreation.java
@@ -100,14 +100,17 @@ public class AttributeReferenceCreation {
                         emptyMetadata, exprId, none, false);
             } else {
                 // Spark 2.4
-                if (Seq.class.isAssignableFrom(apply.getParameterTypes()[5])) {
+                Class<?> qualifierParameterType = apply.getParameterTypes()[5];
+                boolean qualifierParameterTypeIsSeq =
+                    Seq.class.isAssignableFrom(qualifierParameterType);
+                if (qualifierParameterTypeIsSeq) {
                     return (AttributeReference) apply.invoke(companion, name, dataType, true,
                             emptyMetadata, exprId, Seq$.MODULE$.<String>empty());
+                } else {
+                    // Spark 2.3
+                    return (AttributeReference) apply.invoke(companion, name, dataType, true,
+                            emptyMetadata, exprId, none);
                 }
-
-                // Spark 2.3
-                return (AttributeReference) apply.invoke(companion, name, dataType, true,
-                        emptyMetadata, exprId, none);
             }
         } catch (Exception e) {
             throw new IllegalStateException(e);

--- a/src/main/scala/com/amazon/deequ/analyzers/catalyst/AttributeReferenceCreation.java
+++ b/src/main/scala/com/amazon/deequ/analyzers/catalyst/AttributeReferenceCreation.java
@@ -26,6 +26,8 @@ import org.apache.spark.sql.types.Metadata;
 import org.apache.spark.sql.types.Metadata$;
 
 import java.lang.reflect.Method;
+import scala.collection.Seq;
+import scala.collection.Seq$;
 
 public class AttributeReferenceCreation {
 
@@ -36,6 +38,16 @@ public class AttributeReferenceCreation {
         org.apache.spark.sql.catalyst.expressions.AttributeReference which has a non-compatible
         signature in different versions of Spark 2.x. Therefore we need to invoke it via reflection
         depending on which version of Spark we run.
+
+        SPARK 2.4:
+
+            case class AttributeReference(
+                name: String,
+                dataType: DataType,
+                nullable: Boolean = true,
+                override val metadata: Metadata = Metadata.empty)(
+                val exprId: ExprId = NamedExpression.newExprId,
+                val qualifier: Seq[String] = Seq.empty[String])
 
         SPARK 2.3:
 
@@ -87,6 +99,12 @@ public class AttributeReferenceCreation {
                 return (AttributeReference) apply.invoke(companion, name, dataType, true,
                         emptyMetadata, exprId, none, false);
             } else {
+                // Spark 2.4
+                if (Seq.class.isAssignableFrom(apply.getParameterTypes()[5])) {
+                    return (AttributeReference) apply.invoke(companion, name, dataType, true,
+                            emptyMetadata, exprId, Seq$.MODULE$.<String>empty());
+                }
+
                 // Spark 2.3
                 return (AttributeReference) apply.invoke(companion, name, dataType, true,
                         emptyMetadata, exprId, none);


### PR DESCRIPTION
*Description of changes:*

In Spark 2.4 [[Spark-19602]](https://github.com/apache/spark/commit/b4bf8be549afa51e931e48dd79ddd9480f567b13) the signature for `AttributeReference` has changed (`qualifier` argument changed from `Option[String]` to `Seq[String]`), causing an `IllegalArgumentException` for some of our analyzers (`ApproxCountDistinct`) when used in conjunction with Spark 2.4. This PR adds a condition on the argument type (via reflection) for `AttributeReference`, in order to distinguish behavior for Spark 2.4 from previous versions.

Successfully tested against Spark 2.2, Spark 2.3, and Spark 2.4.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
