### PR TITLE
Enable column profile histogram analysis for columns of numeric types

### DIFF
--- a/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
+++ b/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
@@ -499,13 +499,8 @@ object ColumnProfiler {
       StringType, BooleanType, DoubleType, FloatType, IntegerType, LongType, ShortType
     )
     val originalStringNumericOrBooleanColumns = schema
-      .flatMap { field =>
-        if (validSparkDataTypesForHistograms.contains(field.dataType)) {
-          Some(field.name)
-        } else {
-          None
-        }
-      }
+      .filter { field => validSparkDataTypesForHistograms.contains(field.dataType) }
+      .map { field => field.name }
       .toSet
 
     genericStatistics.approximateNumDistincts

--- a/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
+++ b/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
@@ -495,7 +495,7 @@ object ColumnProfiler {
       lowCardinalityHistogramThreshold: Long)
     : Seq[String] = {
 
-    val validSparkDataTypesForHistograms = List(
+    val validSparkDataTypesForHistograms: Set[SparkDataType] = Set(
       StringType, BooleanType, DoubleType, FloatType, IntegerType, LongType, ShortType
     )
     val originalStringNumericOrBooleanColumns = schema
@@ -509,9 +509,9 @@ object ColumnProfiler {
       .toSet
 
     genericStatistics.approximateNumDistincts
-      .filter { case (column, _) => originalStringNumericOrBooleanColumns.contains(column) }
       .filter { case (column, _) =>
-        List(String, Boolean, Integral, Fractional).contains(genericStatistics.typeOf(column))
+        originalStringNumericOrBooleanColumns.contains(column) &&
+          Set(String, Boolean, Integral, Fractional).contains(genericStatistics.typeOf(column))
       }
       .filter { case (_, count) => count <= lowCardinalityHistogramThreshold }
       .map { case (column, _) => column }

--- a/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerRunnerTest.scala
+++ b/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerRunnerTest.scala
@@ -60,7 +60,7 @@ class ColumnProfilerRunnerTest extends WordSpec with Matchers with SparkContextS
             (results, stat.jobCount)
           }
 
-        assert(jobNumberAllCalculations == 2)
+        assert(jobNumberAllCalculations == 3)
         assert(jobNumberReusing == 0)
         assertConstraintSuggestionResultsEquals(separateResults, resultsReusingMetrics)
       }

--- a/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerTest.scala
+++ b/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerTest.scala
@@ -18,6 +18,7 @@ package com.amazon.deequ.profiles
 
 import com.amazon.deequ.SparkContextSpec
 import com.amazon.deequ.analyzers.DataTypeInstances
+import com.amazon.deequ.analyzers.Histogram.NullFieldReplacement
 import com.amazon.deequ.metrics.{Distribution, DistributionValue}
 import com.amazon.deequ.utils.FixtureSupport
 import org.apache.spark.sql.Row
@@ -168,7 +169,7 @@ class ColumnProfilerTest extends WordSpec with Matchers with SparkContextSpec
         Some(Distribution(Map(
           "d" -> DistributionValue(1, 0.16666666666666666),
           "f" -> DistributionValue(3, 0.5),
-          "NullValue" -> DistributionValue(2, 0.3333333333333333)), 3)))
+          NullFieldReplacement -> DistributionValue(2, 0.3333333333333333)), 3)))
 
       assert(actualColumnProfile == expectedColumnProfile)
     }
@@ -198,8 +199,8 @@ class ColumnProfilerTest extends WordSpec with Matchers with SparkContextSpec
       assert(histogram("true").ratio == 3.0 / nRows)
       assert(histogram("false").absolute == 2L)
       assert(histogram("false").ratio == 2.0 / nRows)
-      assert(histogram("NullValue").absolute == 1)
-      assert(histogram("NullValue").ratio == 1.0 / nRows)
+      assert(histogram(NullFieldReplacement).absolute == 1)
+      assert(histogram(NullFieldReplacement).ratio == 1.0 / nRows)
     }
 
     "return histograms for IntegerType columns" in withSparkSession { session =>
@@ -227,8 +228,8 @@ class ColumnProfilerTest extends WordSpec with Matchers with SparkContextSpec
       assert(histogram("2147483647").ratio == 3.0 / nRows)
       assert(histogram("2").absolute == 2L)
       assert(histogram("2").ratio == 2.0 / nRows)
-      assert(histogram("NullValue").absolute == 1)
-      assert(histogram("NullValue").ratio == 1.0 / nRows)
+      assert(histogram(NullFieldReplacement).absolute == 1)
+      assert(histogram(NullFieldReplacement).ratio == 1.0 / nRows)
     }
 
     "return histograms for LongType columns" in withSparkSession { session =>
@@ -256,8 +257,8 @@ class ColumnProfilerTest extends WordSpec with Matchers with SparkContextSpec
       assert(histogram("1").ratio == 3.0 / nRows)
       assert(histogram("2").absolute == 2L)
       assert(histogram("2").ratio == 2.0 / nRows)
-      assert(histogram("NullValue").absolute == 1)
-      assert(histogram("NullValue").ratio == 1.0 / nRows)
+      assert(histogram(NullFieldReplacement).absolute == 1)
+      assert(histogram(NullFieldReplacement).ratio == 1.0 / nRows)
     }
 
     "return histograms for DoubleType columns" in withSparkSession { session =>
@@ -285,8 +286,8 @@ class ColumnProfilerTest extends WordSpec with Matchers with SparkContextSpec
       assert(histogram("1.0").ratio == 3.0 / nRows)
       assert(histogram("2.0").absolute == 2L)
       assert(histogram("2.0").ratio == 2.0 / nRows)
-      assert(histogram("NullValue").absolute == 1)
-      assert(histogram("NullValue").ratio == 1.0 / nRows)
+      assert(histogram(NullFieldReplacement).absolute == 1)
+      assert(histogram(NullFieldReplacement).ratio == 1.0 / nRows)
     }
 
     "return histograms for FloatType columns" in withSparkSession { session =>
@@ -314,8 +315,8 @@ class ColumnProfilerTest extends WordSpec with Matchers with SparkContextSpec
       assert(histogram("1.0").ratio == 3.0 / nRows)
       assert(histogram("2.0").absolute == 2L)
       assert(histogram("2.0").ratio == 2.0 / nRows)
-      assert(histogram("NullValue").absolute == 1)
-      assert(histogram("NullValue").ratio == 1.0 / nRows)
+      assert(histogram(NullFieldReplacement).absolute == 1)
+      assert(histogram(NullFieldReplacement).ratio == 1.0 / nRows)
     }
 
     "return histograms for ShortType columns" in withSparkSession { session =>
@@ -343,8 +344,8 @@ class ColumnProfilerTest extends WordSpec with Matchers with SparkContextSpec
       assert(histogram("1").ratio == 3.0 / nRows)
       assert(histogram("2").absolute == 2L)
       assert(histogram("2").ratio == 2.0 / nRows)
-      assert(histogram("NullValue").absolute == 1)
-      assert(histogram("NullValue").ratio == 1.0 / nRows)
+      assert(histogram(NullFieldReplacement).absolute == 1)
+      assert(histogram(NullFieldReplacement).ratio == 1.0 / nRows)
     }
   }
 

--- a/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerTest.scala
+++ b/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerTest.scala
@@ -21,7 +21,7 @@ import com.amazon.deequ.analyzers.DataTypeInstances
 import com.amazon.deequ.metrics.{Distribution, DistributionValue}
 import com.amazon.deequ.utils.FixtureSupport
 import org.apache.spark.sql.Row
-import org.apache.spark.sql.types.BooleanType
+import org.apache.spark.sql.types._
 import org.scalatest.{Matchers, WordSpec}
 
 class ColumnProfilerTest extends WordSpec with Matchers with SparkContextSpec
@@ -145,7 +145,7 @@ class ColumnProfilerTest extends WordSpec with Matchers with SparkContextSpec
           actualColumnProfile.asInstanceOf[NumericColumnProfile])
     }
 
-    "return correct Histograms" in withSparkSession { session =>
+    "return correct Histograms for string columns" in withSparkSession { session =>
 
       val data = getDfCompleteAndInCompleteColumns(session)
 
@@ -198,6 +198,151 @@ class ColumnProfilerTest extends WordSpec with Matchers with SparkContextSpec
       assert(histogram("true").ratio == 3.0 / nRows)
       assert(histogram("false").absolute == 2L)
       assert(histogram("false").ratio == 2.0 / nRows)
+      assert(histogram("NullValue").absolute == 1)
+      assert(histogram("NullValue").ratio == 1.0 / nRows)
+    }
+
+    "return histograms for IntegerType columns" in withSparkSession { session =>
+      val attribute = "attribute"
+      val nRows = 6
+      val data = com.amazon.deequ.dataFrameWithColumn(
+        attribute,
+        IntegerType,
+        session,
+        Row(2147483647),
+        Row(2147483647),
+        Row(2147483647),
+        Row(2),
+        Row(2),
+        Row(null)
+      )
+
+      val actualColumnProfile = ColumnProfiler.profile(data).profiles(attribute)
+
+      assert(actualColumnProfile.histogram.isDefined)
+
+      val histogram = actualColumnProfile.histogram.get
+
+      assert(histogram("2147483647").absolute == 3L)
+      assert(histogram("2147483647").ratio == 3.0 / nRows)
+      assert(histogram("2").absolute == 2L)
+      assert(histogram("2").ratio == 2.0 / nRows)
+      assert(histogram("NullValue").absolute == 1)
+      assert(histogram("NullValue").ratio == 1.0 / nRows)
+    }
+
+    "return histograms for LongType columns" in withSparkSession { session =>
+      val attribute = "attribute"
+      val nRows = 6
+      val data = com.amazon.deequ.dataFrameWithColumn(
+        attribute,
+        LongType,
+        session,
+        Row(1L),
+        Row(1L),
+        Row(1L),
+        Row(2L),
+        Row(2L),
+        Row(null)
+      )
+
+      val actualColumnProfile = ColumnProfiler.profile(data).profiles(attribute)
+
+      assert(actualColumnProfile.histogram.isDefined)
+
+      val histogram = actualColumnProfile.histogram.get
+
+      assert(histogram("1").absolute == 3L)
+      assert(histogram("1").ratio == 3.0 / nRows)
+      assert(histogram("2").absolute == 2L)
+      assert(histogram("2").ratio == 2.0 / nRows)
+      assert(histogram("NullValue").absolute == 1)
+      assert(histogram("NullValue").ratio == 1.0 / nRows)
+    }
+
+    "return histograms for DoubleType columns" in withSparkSession { session =>
+      val attribute = "attribute"
+      val nRows = 6
+      val data = com.amazon.deequ.dataFrameWithColumn(
+        attribute,
+        DoubleType,
+        session,
+        Row(1.0),
+        Row(1.0),
+        Row(1.0),
+        Row(2.0),
+        Row(2.0),
+        Row(null)
+      )
+
+      val actualColumnProfile = ColumnProfiler.profile(data).profiles(attribute)
+
+      assert(actualColumnProfile.histogram.isDefined)
+
+      val histogram = actualColumnProfile.histogram.get
+
+      assert(histogram("1.0").absolute == 3L)
+      assert(histogram("1.0").ratio == 3.0 / nRows)
+      assert(histogram("2.0").absolute == 2L)
+      assert(histogram("2.0").ratio == 2.0 / nRows)
+      assert(histogram("NullValue").absolute == 1)
+      assert(histogram("NullValue").ratio == 1.0 / nRows)
+    }
+
+    "return histograms for FloatType columns" in withSparkSession { session =>
+      val attribute = "attribute"
+      val nRows = 6
+      val data = com.amazon.deequ.dataFrameWithColumn(
+        attribute,
+        FloatType,
+        session,
+        Row(1.0f),
+        Row(1.0f),
+        Row(1.0f),
+        Row(2.0f),
+        Row(2.0f),
+        Row(null)
+      )
+
+      val actualColumnProfile = ColumnProfiler.profile(data).profiles(attribute)
+
+      assert(actualColumnProfile.histogram.isDefined)
+
+      val histogram = actualColumnProfile.histogram.get
+
+      assert(histogram("1.0").absolute == 3L)
+      assert(histogram("1.0").ratio == 3.0 / nRows)
+      assert(histogram("2.0").absolute == 2L)
+      assert(histogram("2.0").ratio == 2.0 / nRows)
+      assert(histogram("NullValue").absolute == 1)
+      assert(histogram("NullValue").ratio == 1.0 / nRows)
+    }
+
+    "return histograms for ShortType columns" in withSparkSession { session =>
+      val attribute = "attribute"
+      val nRows = 6
+      val data = com.amazon.deequ.dataFrameWithColumn(
+        attribute,
+        ShortType,
+        session,
+        Row(1: Short),
+        Row(1: Short),
+        Row(1: Short),
+        Row(2: Short),
+        Row(2: Short),
+        Row(null)
+      )
+
+      val actualColumnProfile = ColumnProfiler.profile(data).profiles(attribute)
+
+      assert(actualColumnProfile.histogram.isDefined)
+
+      val histogram = actualColumnProfile.histogram.get
+
+      assert(histogram("1").absolute == 3L)
+      assert(histogram("1").ratio == 3.0 / nRows)
+      assert(histogram("2").absolute == 2L)
+      assert(histogram("2").ratio == 2.0 / nRows)
       assert(histogram("NullValue").absolute == 1)
       assert(histogram("NullValue").ratio == 1.0 / nRows)
     }

--- a/src/test/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunnerTest.scala
+++ b/src/test/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunnerTest.scala
@@ -78,7 +78,7 @@ class ConstraintSuggestionRunnerTest extends WordSpec with Matchers with SparkCo
             (results, stat.jobCount)
           }
 
-        assert(jobNumberAllCalculations == 2)
+        assert(jobNumberAllCalculations == 3)
         assert(jobNumberReusing == 0)
         assertConstraintSuggestionResultsEquals(separateResults, resultsReusingMetrics)
       }


### PR DESCRIPTION
Fix for issue: https://github.com/awslabs/deequ/issues/95

Description of changes:
Histogram analysis for column profiling was limited to boolean and string columns. However, it is possible to have categorical data with numerical values (ex 1 indicating male and 2 indicating female). Made changes to allow histogram analysis for columns with short, long, double, float, and integer data types

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
