### PR TITLE
Add assertion param to convenience constraints

### DIFF
--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -664,27 +664,35 @@ case class Check(
     * Creates a constraint that asserts that a column contains no negative values
     *
     * @param column Column to run the assertion on
+    * @param assertion Function that receives a double input parameter and returns a boolean
     * @param hint A hint to provide additional context why a constraint could have failed
     * @return
     */
   def isNonNegative(
       column: String,
+      assertion: Double => Boolean = Check.IsOne,
       hint: Option[String] = None)
     : CheckWithLastConstraintFilterable = {
 
     // coalescing column to not count NULL values as non-compliant
-    satisfies(s"COALESCE($column, 0.0) >= 0", s"$column is non-negative", hint = hint)
+    satisfies(s"COALESCE($column, 0.0) >= 0", s"$column is non-negative", assertion, hint = hint)
   }
 
   /**
     * Creates a constraint that asserts that a column contains no negative values
     *
     * @param column Column to run the assertion on
+    * @param assertion Function that receives a double input parameter and returns a boolean
+    * @param hint A hint to provide additional context why a constraint could have failed
     * @return
     */
-  def isPositive(column: String): CheckWithLastConstraintFilterable = {
+  def isPositive(
+      column: String,
+      assertion: Double => Boolean = Check.IsOne,
+      hint: Option[String] = None)
+    : CheckWithLastConstraintFilterable = {
     // coalescing column to not count NULL values as non-compliant
-    satisfies(s"COALESCE($column, 1.0) > 0", s"$column is positive")
+    satisfies(s"COALESCE($column, 1.0) > 0", s"$column is positive", assertion, hint)
   }
 
   /**
@@ -693,16 +701,18 @@ case class Check(
     *
     * @param columnA Column to run the assertion on
     * @param columnB Column to run the assertion on
+    * @param assertion Function that receives a double input parameter and returns a boolean
     * @param hint A hint to provide additional context why a constraint could have failed
     * @return
     */
   def isLessThan(
       columnA: String,
       columnB: String,
+      assertion: Double => Boolean = Check.IsOne,
       hint: Option[String] = None)
     : CheckWithLastConstraintFilterable = {
 
-    satisfies(s"$columnA < $columnB", s"$columnA is less than $columnB",
+    satisfies(s"$columnA < $columnB", s"$columnA is less than $columnB", assertion,
       hint = hint)
   }
 
@@ -711,17 +721,19 @@ case class Check(
     *
     * @param columnA Column to run the assertion on
     * @param columnB Column to run the assertion on
+    * @param assertion Function that receives a double input parameter and returns a boolean
     * @param hint A hint to provide additional context why a constraint could have failed
     * @return
     */
   def isLessThanOrEqualTo(
       columnA: String,
       columnB: String,
+      assertion: Double => Boolean = Check.IsOne,
       hint: Option[String] = None)
     : CheckWithLastConstraintFilterable = {
 
     satisfies(s"$columnA <= $columnB", s"$columnA is less than or equal to $columnB",
-      hint = hint)
+      assertion, hint = hint)
   }
 
   /**
@@ -729,16 +741,18 @@ case class Check(
     *
     * @param columnA Column to run the assertion on
     * @param columnB Column to run the assertion on
+    * @param assertion Function that receives a double input parameter and returns a boolean
     * @param hint A hint to provide additional context why a constraint could have failed
     * @return
     */
   def isGreaterThan(
       columnA: String,
       columnB: String,
+      assertion: Double => Boolean = Check.IsOne,
       hint: Option[String] = None)
     : CheckWithLastConstraintFilterable = {
 
-    satisfies(s"$columnA > $columnB", s"$columnA is greater than $columnB",
+    satisfies(s"$columnA > $columnB", s"$columnA is greater than $columnB", assertion,
       hint = hint)
   }
 
@@ -748,17 +762,19 @@ case class Check(
     *
     * @param columnA Column to run the assertion on
     * @param columnB Column to run the assertion on
+    * @param assertion Function that receives a double input parameter and returns a boolean
     * @param hint A hint to provide additional context why a constraint could have failed
     * @return
     */
   def isGreaterThanOrEqualTo(
       columnA: String,
       columnB: String,
+      assertion: Double => Boolean = Check.IsOne,
       hint: Option[String] = None)
     : CheckWithLastConstraintFilterable = {
 
     satisfies(s"$columnA >= $columnB", s"$columnA is greater than or equal to $columnB",
-      hint = hint)
+      assertion, hint = hint)
   }
 
   // We can't use default values here as you can't combine default values and overloading in Scala

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -204,13 +204,15 @@ class CheckTest extends WordSpec with Matchers with SparkContextSpec with Fixtur
       val incorrectLessThanCheckWithCustomAssertionFunction = Check(CheckLevel.Error, "a")
         .isLessThan("att1", "att2", _ == 0.4)
 
-      val results = runChecks(getDfWithNumericValues(sparkSession), lessThanCheck, incorrectLessThanCheck,
-        lessThanCheckWithCustomAssertionFunction, incorrectLessThanCheckWithCustomAssertionFunction)
+      val results = runChecks(getDfWithNumericValues(sparkSession), lessThanCheck,
+        incorrectLessThanCheck, lessThanCheckWithCustomAssertionFunction,
+        incorrectLessThanCheckWithCustomAssertionFunction)
 
       assertEvaluatesTo(lessThanCheck, results, CheckStatus.Success)
       assertEvaluatesTo(incorrectLessThanCheck, results, CheckStatus.Error)
       assertEvaluatesTo(lessThanCheckWithCustomAssertionFunction, results, CheckStatus.Success)
-      assertEvaluatesTo(incorrectLessThanCheckWithCustomAssertionFunction, results, CheckStatus.Error)
+      assertEvaluatesTo(incorrectLessThanCheckWithCustomAssertionFunction, results,
+        CheckStatus.Error)
     }
 
     "correctly evaluate less than or equal to constraints" in withSparkSession { sparkSession =>
@@ -232,8 +234,10 @@ class CheckTest extends WordSpec with Matchers with SparkContextSpec with Fixtur
 
       assertEvaluatesTo(lessThanOrEqualCheck, results, CheckStatus.Success)
       assertEvaluatesTo(incorrectLessThanOrEqualCheck, results, CheckStatus.Error)
-      assertEvaluatesTo(lessThanOrEqualCheckWithCustomAssertionFunction, results, CheckStatus.Success)
-      assertEvaluatesTo(incorrectLessThanOrEqualCheckWithCustomAssertionFunction, results, CheckStatus.Error)
+      assertEvaluatesTo(lessThanOrEqualCheckWithCustomAssertionFunction, results,
+        CheckStatus.Success)
+      assertEvaluatesTo(incorrectLessThanOrEqualCheckWithCustomAssertionFunction, results,
+        CheckStatus.Error)
     }
 
     "correctly evaluate greater than constraints" in withSparkSession { sparkSession =>
@@ -256,7 +260,8 @@ class CheckTest extends WordSpec with Matchers with SparkContextSpec with Fixtur
       assertEvaluatesTo(greaterThanCheck, results, CheckStatus.Success)
       assertEvaluatesTo(incorrectGreaterThanCheck, results, CheckStatus.Error)
       assertEvaluatesTo(greaterThanCheckWithCustomAssertionFunction, results, CheckStatus.Success)
-      assertEvaluatesTo(incorrectGreaterThanCheckWithCustomAssertionFunction, results, CheckStatus.Error)
+      assertEvaluatesTo(incorrectGreaterThanCheckWithCustomAssertionFunction, results,
+        CheckStatus.Error)
     }
 
     "correctly evaluate greater than or equal to constraints" in withSparkSession { sparkSession =>
@@ -278,8 +283,10 @@ class CheckTest extends WordSpec with Matchers with SparkContextSpec with Fixtur
 
       assertEvaluatesTo(greaterThanOrEqualCheck, results, CheckStatus.Success)
       assertEvaluatesTo(incorrectGreaterOrEqualThanCheck, results, CheckStatus.Error)
-      assertEvaluatesTo(greaterThanOrEqualCheckWithCustomAssertionFunction, results, CheckStatus.Success)
-      assertEvaluatesTo(incorrectGreaterThanOrEqualCheckWithCustomAssertionFunction, results, CheckStatus.Error)
+      assertEvaluatesTo(greaterThanOrEqualCheckWithCustomAssertionFunction, results,
+        CheckStatus.Success)
+      assertEvaluatesTo(incorrectGreaterThanOrEqualCheckWithCustomAssertionFunction, results,
+        CheckStatus.Error)
     }
 
     "correctly evaluate non negative and positive constraints" in withSparkSession { sparkSession =>

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -191,28 +191,112 @@ class CheckTest extends WordSpec with Matchers with SparkContextSpec with Fixtur
         assertEvaluatesTo(checkPartiallyGetsSatisfied, context, CheckStatus.Success)
       }
 
-    "correctly evaluate convenience constraints" in withSparkSession { sparkSession =>
-
+    "correctly evaluate less than constraints" in withSparkSession { sparkSession =>
       val lessThanCheck = Check(CheckLevel.Error, "a")
         .isLessThan("att1", "att2").where("item > 3")
 
       val incorrectLessThanCheck = Check(CheckLevel.Error, "a")
         .isLessThan("att1", "att2")
 
+      val lessThanCheckWithCustomAssertionFunction = Check(CheckLevel.Error, "a")
+        .isLessThan("att1", "att2", _ == 0.5)
+
+      val incorrectLessThanCheckWithCustomAssertionFunction = Check(CheckLevel.Error, "a")
+        .isLessThan("att1", "att2", _ == 0.4)
+
+      val results = runChecks(getDfWithNumericValues(sparkSession), lessThanCheck, incorrectLessThanCheck,
+        lessThanCheckWithCustomAssertionFunction, incorrectLessThanCheckWithCustomAssertionFunction)
+
+      assertEvaluatesTo(lessThanCheck, results, CheckStatus.Success)
+      assertEvaluatesTo(incorrectLessThanCheck, results, CheckStatus.Error)
+      assertEvaluatesTo(lessThanCheckWithCustomAssertionFunction, results, CheckStatus.Success)
+      assertEvaluatesTo(incorrectLessThanCheckWithCustomAssertionFunction, results, CheckStatus.Error)
+    }
+
+    "correctly evaluate less than or equal to constraints" in withSparkSession { sparkSession =>
+      val lessThanOrEqualCheck = Check(CheckLevel.Error, "a")
+        .isLessThanOrEqualTo("att1", "att3").where("item > 3")
+
+      val incorrectLessThanOrEqualCheck = Check(CheckLevel.Error, "a")
+        .isLessThanOrEqualTo("att1", "att3")
+
+      val lessThanOrEqualCheckWithCustomAssertionFunction = Check(CheckLevel.Error, "a")
+        .isLessThanOrEqualTo("att1", "att3", _ == 0.5)
+
+      val incorrectLessThanOrEqualCheckWithCustomAssertionFunction = Check(CheckLevel.Error, "a")
+        .isLessThanOrEqualTo("att1", "att3", _ == 0.4)
+
+      val results = runChecks(getDfWithNumericValues(sparkSession), lessThanOrEqualCheck,
+        incorrectLessThanOrEqualCheck, lessThanOrEqualCheckWithCustomAssertionFunction,
+        incorrectLessThanOrEqualCheckWithCustomAssertionFunction)
+
+      assertEvaluatesTo(lessThanOrEqualCheck, results, CheckStatus.Success)
+      assertEvaluatesTo(incorrectLessThanOrEqualCheck, results, CheckStatus.Error)
+      assertEvaluatesTo(lessThanOrEqualCheckWithCustomAssertionFunction, results, CheckStatus.Success)
+      assertEvaluatesTo(incorrectLessThanOrEqualCheckWithCustomAssertionFunction, results, CheckStatus.Error)
+    }
+
+    "correctly evaluate greater than constraints" in withSparkSession { sparkSession =>
+      val greaterThanCheck = Check(CheckLevel.Error, "a")
+        .isGreaterThan("att2", "att1").where("item > 3")
+
+      val incorrectGreaterThanCheck = Check(CheckLevel.Error, "a")
+        .isGreaterThan("att2", "att1")
+
+      val greaterThanCheckWithCustomAssertionFunction = Check(CheckLevel.Error, "a")
+        .isGreaterThan("att2", "att1", _ == 0.5)
+
+      val incorrectGreaterThanCheckWithCustomAssertionFunction = Check(CheckLevel.Error, "a")
+        .isGreaterThan("att2", "att1", _ == 0.4)
+
+      val results = runChecks(getDfWithNumericValues(sparkSession), greaterThanCheck,
+        incorrectGreaterThanCheck, greaterThanCheckWithCustomAssertionFunction,
+        incorrectGreaterThanCheckWithCustomAssertionFunction)
+
+      assertEvaluatesTo(greaterThanCheck, results, CheckStatus.Success)
+      assertEvaluatesTo(incorrectGreaterThanCheck, results, CheckStatus.Error)
+      assertEvaluatesTo(greaterThanCheckWithCustomAssertionFunction, results, CheckStatus.Success)
+      assertEvaluatesTo(incorrectGreaterThanCheckWithCustomAssertionFunction, results, CheckStatus.Error)
+    }
+
+    "correctly evaluate greater than or equal to constraints" in withSparkSession { sparkSession =>
+      val greaterThanOrEqualCheck = Check(CheckLevel.Error, "a")
+        .isGreaterThanOrEqualTo("att3", "att1").where("item > 3")
+
+      val incorrectGreaterOrEqualThanCheck = Check(CheckLevel.Error, "a")
+        .isGreaterThanOrEqualTo("att3", "att1")
+
+      val greaterThanOrEqualCheckWithCustomAssertionFunction = Check(CheckLevel.Error, "a")
+        .isGreaterThanOrEqualTo("att3", "att1", _ == 0.5)
+
+      val incorrectGreaterThanOrEqualCheckWithCustomAssertionFunction = Check(CheckLevel.Error, "a")
+        .isGreaterThanOrEqualTo("att3", "att1", _ == 0.4)
+
+      val results = runChecks(getDfWithNumericValues(sparkSession), greaterThanOrEqualCheck,
+        incorrectGreaterOrEqualThanCheck, greaterThanOrEqualCheckWithCustomAssertionFunction,
+        incorrectGreaterThanOrEqualCheckWithCustomAssertionFunction)
+
+      assertEvaluatesTo(greaterThanOrEqualCheck, results, CheckStatus.Success)
+      assertEvaluatesTo(incorrectGreaterOrEqualThanCheck, results, CheckStatus.Error)
+      assertEvaluatesTo(greaterThanOrEqualCheckWithCustomAssertionFunction, results, CheckStatus.Success)
+      assertEvaluatesTo(incorrectGreaterThanOrEqualCheckWithCustomAssertionFunction, results, CheckStatus.Error)
+    }
+
+    "correctly evaluate non negative and positive constraints" in withSparkSession { sparkSession =>
       val nonNegativeCheck = Check(CheckLevel.Error, "a")
         .isNonNegative("item")
 
       val isPositiveCheck = Check(CheckLevel.Error, "a")
         .isPositive("item")
 
-      val results = runChecks(getDfWithNumericValues(sparkSession), lessThanCheck,
-        incorrectLessThanCheck, nonNegativeCheck, isPositiveCheck)
+      val nonNegativeAndPositiveResults = runChecks(getDfWithNumericValues(sparkSession), nonNegativeCheck,
+        isPositiveCheck)
 
-      assertEvaluatesTo(lessThanCheck, results, CheckStatus.Success)
-      assertEvaluatesTo(incorrectLessThanCheck, results, CheckStatus.Error)
-      assertEvaluatesTo(nonNegativeCheck, results, CheckStatus.Success)
-      assertEvaluatesTo(isPositiveCheck, results, CheckStatus.Success)
+      assertEvaluatesTo(nonNegativeCheck, nonNegativeAndPositiveResults, CheckStatus.Success)
+      assertEvaluatesTo(isPositiveCheck, nonNegativeAndPositiveResults, CheckStatus.Success)
+    }
 
+    "correctly evaluate range constraints" in withSparkSession { sparkSession =>
       val rangeCheck = Check(CheckLevel.Error, "a")
         .isContainedIn("att1", Array("a", "b", "c"))
 

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -289,11 +289,11 @@ class CheckTest extends WordSpec with Matchers with SparkContextSpec with Fixtur
       val isPositiveCheck = Check(CheckLevel.Error, "a")
         .isPositive("item")
 
-      val nonNegativeAndPositiveResults = runChecks(getDfWithNumericValues(sparkSession), nonNegativeCheck,
+      val results = runChecks(getDfWithNumericValues(sparkSession), nonNegativeCheck,
         isPositiveCheck)
 
-      assertEvaluatesTo(nonNegativeCheck, nonNegativeAndPositiveResults, CheckStatus.Success)
-      assertEvaluatesTo(isPositiveCheck, nonNegativeAndPositiveResults, CheckStatus.Success)
+      assertEvaluatesTo(nonNegativeCheck, results, CheckStatus.Success)
+      assertEvaluatesTo(isPositiveCheck, results, CheckStatus.Success)
     }
 
     "correctly evaluate range constraints" in withSparkSession { sparkSession =>

--- a/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
+++ b/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
@@ -138,13 +138,13 @@ trait FixtureSupport {
     import sparkSession.implicits._
     // att2 is always bigger than att1
     Seq(
-      ("1", 1, 0),
-      ("2", 2, 0),
-      ("3", 3, 0),
-      ("4", 4, 5),
-      ("5", 5, 6),
-      ("6", 6, 7)
-    ).toDF("item", "att1", "att2")
+      ("1", 1, 0, 0),
+      ("2", 2, 0, 0),
+      ("3", 3, 0, 0),
+      ("4", 4, 5, 4),
+      ("5", 5, 6, 6),
+      ("6", 6, 7, 7)
+    ).toDF("item", "att1", "att2", "att3")
   }
 
   def getDfWithNumericFractionalValues(sparkSession: SparkSession): DataFrame = {


### PR DESCRIPTION
Description of changes:
I want to use some of the convenience constraints, but with an assertion threshold.
I added a assertion param to the following check constraints:
- isPositive
- isNotNegative
- isLessThanOrEqualTo
- isLessThan
- isGreaterThanOrEqualTo
- isGreaterThan

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
