### PR TITLE
Set the Spark shuffle partitions to one make the test suite run 68 percent faster

### DIFF
--- a/src/test/scala/com/amazon/deequ/SparkContextSpec.scala
+++ b/src/test/scala/com/amazon/deequ/SparkContextSpec.scala
@@ -77,6 +77,7 @@ trait SparkContextSpec {
       .master("local")
       .appName("test")
       .config("spark.ui.enabled", "false")
+      .config("spark.sql.shuffle.partitions", "1")
       .getOrCreate()
     session.sparkContext.setCheckpointDir(System.getProperty("java.io.tmpdir"))
     session


### PR DESCRIPTION
The test suite took 7 minutes and 7 seconds to run on my machine with `mvn test`.  I set the spark shuffle partitions to one and this sped up the test suite 68% (only takes 2 minutes & 18 seconds on my machine now).

I've seen similar performance improvements in test suite runtimes on other projects.

Thanks for creating this project :)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
