### PR TITLE
Adding parallelism to tests again

### DIFF
--- a/src/test/scala/com/amazon/deequ/SparkContextSpec.scala
+++ b/src/test/scala/com/amazon/deequ/SparkContextSpec.scala
@@ -77,7 +77,7 @@ trait SparkContextSpec {
       .master("local")
       .appName("test")
       .config("spark.ui.enabled", "false")
-      .config("spark.sql.shuffle.partitions", "1")
+      .config("spark.sql.shuffle.partitions", 2.toString)
       .getOrCreate()
     session.sparkContext.setCheckpointDir(System.getProperty("java.io.tmpdir"))
     session


### PR DESCRIPTION
We reduced the number of shuffle partitions to accelerate the tests. He should however set it to at least two, as there might be some concurrency issues that we only observe with more than one partition. A setting of 2 still accelerates the tests very much though.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
