### PR TITLE
make the overwritePreviousFiles working

### DIFF
--- a/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunBuilder.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunBuilder.scala
@@ -287,7 +287,7 @@ class ConstraintSuggestionRunBuilderWithSparkSession(
     *                       should be overwritten
     */
   def overwritePreviousFiles(overwriteFiles: Boolean): this.type = {
-    overwriteOutputFiles = overwriteOutputFiles
+    overwriteOutputFiles = overwriteFiles
     this
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
The `overwritePreviousFiles` function is not working properly. So whatever the parameter is, the `overwritePreviousFiles` will return back `false`.

*Description of changes:*
Simple change : `overwriteOutputFiles = overwriteFiles` instead of `overwriteOutputFiles = overwriteOutputFiles `.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.