### PR TITLE
Lift the private package restriction on analysis result and corresposing serde object

### DIFF
--- a/src/main/scala/com/amazon/deequ/repository/AnalysisResult.scala
+++ b/src/main/scala/com/amazon/deequ/repository/AnalysisResult.scala
@@ -22,7 +22,7 @@ import org.apache.spark.sql._
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
 import org.apache.spark.sql.functions.lit
 
-private[deequ] case class AnalysisResult(
+case class AnalysisResult(
     resultKey: ResultKey,
     analyzerContext: AnalyzerContext
 )

--- a/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
+++ b/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
@@ -72,7 +72,7 @@ private[deequ] object SimpleResultSerde {
   }
 }
 
-private[deequ] object AnalysisResultSerde {
+object AnalysisResultSerde {
 
   def serialize(analysisResults: Seq[AnalysisResult]): String = {
     val gson = new GsonBuilder()


### PR DESCRIPTION
*Description of changes:*

Currently there is no way to implement a custom metrics repository as the `AnalysisResult` class is private to deequ. This is the return type of `get()` in the `MetricsRepositoryMultipleResultsLoader` trait, therefore there is no way to actually implement this trait.

There is also no way to serialise this result object so it can be stored in a custom way.

This PR lifts the private restriction on both the `AnalysisResult` class and it's corresponding serialisation object.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
