### PR TITLE
Fixed example files

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,12 +28,12 @@ libraryDependencies += "com.amazon.deequ" % "deequ" % "1.0.1"
 
 __Deequ__'s purpose is to "unit-test" data to find errors early, before the data gets fed to consuming systems or machine learning algorithms. In the following, we will walk you through a toy example to showcase the most basic usage of our library. An executable version of the example is available [here](/src/main/scala/com/amazon/deequ/examples/BasicExample.scala).
 
-__Deequ__ works on tabular data, e.g., CSV files, database tables, logs, flattened json files, basically anything that you can fit into a Spark dataframe. For this example, we assume that we work on some kind of `Item` data, where every item has an id, a name, a description, a priority and a count of how often it has been viewed.
+__Deequ__ works on tabular data, e.g., CSV files, database tables, logs, flattened json files, basically anything that you can fit into a Spark dataframe. For this example, we assume that we work on some kind of `Item` data, where every item has an id, a productName, a description, a priority and a count of how often it has been viewed.
 
 ```scala
 case class Item(
   id: Long,
-  name: String,
+  productName: String,
   description: String,
   priority: String,
   numViews: Long
@@ -59,7 +59,7 @@ The main entry point for defining how you expect your data to look is the [Verif
 
   * there are 5 rows in total
   * values of the `id` attribute are never NULL and unique
-  * values of the `name` attribute are never NULL
+  * values of the `productName` attribute are never NULL
   * the `priority` attribute can only contain "high" or "low" as value
   * `numViews` should not contain negative values
   * at least half of the values in `description` should contain a url
@@ -79,7 +79,7 @@ val verificationResult = VerificationSuite()
       .hasSize(_ == 5) // we expect 5 rows
       .isComplete("id") // should never be NULL
       .isUnique("id") // should not contain duplicates
-      .isComplete("name") // should never be NULL
+      .isComplete("productName") // should never be NULL
       // should only contain the values "high" and "low"
       .isContainedIn("priority", Array("high", "low"))
       .isNonNegative("numViews") // should not contain negative values
@@ -114,10 +114,10 @@ If we run the example, we get the following output:
 ```
 We found errors in the data:
 
-CompletenessConstraint(Completeness(name)): Value: 0.8 does not meet the requirement!
+CompletenessConstraint(Completeness(productName)): Value: 0.8 does not meet the requirement!
 PatternConstraint(containsURL(description)): Value: 0.4 does not meet the requirement!
 ```
-The test found that our assumptions are violated! Only 4 out of 5 (80%) of the values of the `name` attribute are non-null and only 2 out of 5 (40%) values of the `description` attribute contained a url. Fortunately, we ran a test and found the errors, somebody should immediately fix the data :)
+The test found that our assumptions are violated! Only 4 out of 5 (80%) of the values of the `productName` attribute are non-null and only 2 out of 5 (40%) values of the `description` attribute contained a url. Fortunately, we ran a test and found the errors, somebody should immediately fix the data :)
 
 ## More examples
 

--- a/src/main/scala/com/amazon/deequ/examples/BasicExample.scala
+++ b/src/main/scala/com/amazon/deequ/examples/BasicExample.scala
@@ -42,8 +42,8 @@ private[examples] object BasicExample extends App {
           .isComplete("id")
           // 'id' should not contain duplicates
           .isUnique("id")
-          // 'name' should never be NULL
-          .isComplete("name")
+          // 'productName' should never be NULL
+          .isComplete("productName")
           // 'priority' should only contain the values "high" and "low"
           .isContainedIn("priority", Array("high", "low"))
           // 'numViews' should not contain negative values

--- a/src/main/scala/com/amazon/deequ/examples/DataProfilingExample.scala
+++ b/src/main/scala/com/amazon/deequ/examples/DataProfilingExample.scala
@@ -19,7 +19,7 @@ package com.amazon.deequ.examples
 import com.amazon.deequ.examples.ExampleUtils.withSpark
 import com.amazon.deequ.profiles.{ColumnProfilerRunner, NumericColumnProfile}
 
-case class RawData(name: String, count: String, status: String, valuable: String)
+case class RawData(productName: String, totalNumber: String, status: String, valuable: String)
 
 private[examples] object DataProfilingExample extends App {
 
@@ -47,22 +47,22 @@ private[examples] object DataProfilingExample extends App {
 
     /* We get a profile for each column which allows to inspect the completeness of the column,
        the approximate number of distinct values and the inferred datatype. */
-    result.profiles.foreach { case (name, profile) =>
+    result.profiles.foreach { case (productName, profile) =>
 
-      println(s"Column '$name':\n " +
+      println(s"Column '$productName':\n " +
         s"\tcompleteness: ${profile.completeness}\n" +
         s"\tapproximate number of distinct values: ${profile.approximateNumDistinctValues}\n" +
         s"\tdatatype: ${profile.dataType}\n")
     }
 
     /* For numeric columns, we get descriptive statistics */
-    val countProfile = result.profiles("count").asInstanceOf[NumericColumnProfile]
+    val totalNumberProfile = result.profiles("totalNumber").asInstanceOf[NumericColumnProfile]
 
-    println(s"Statistics of 'count':\n" +
-      s"\tminimum: ${countProfile.minimum.get}\n" +
-      s"\tmaximum: ${countProfile.maximum.get}\n" +
-      s"\tmean: ${countProfile.mean.get}\n" +
-      s"\tstandard deviation: ${countProfile.stdDev.get}\n")
+    println(s"Statistics of 'totalNumber':\n" +
+      s"\tminimum: ${totalNumberProfile.minimum.get}\n" +
+      s"\tmaximum: ${totalNumberProfile.maximum.get}\n" +
+      s"\tmean: ${totalNumberProfile.mean.get}\n" +
+      s"\tstandard deviation: ${totalNumberProfile.stdDev.get}\n")
 
     val statusProfile = result.profiles("status")
 

--- a/src/main/scala/com/amazon/deequ/examples/IncrementalMetricsExample.scala
+++ b/src/main/scala/com/amazon/deequ/examples/IncrementalMetricsExample.scala
@@ -41,7 +41,7 @@ private[examples] object IncrementalMetricsExample extends App {
     val analysis = Analysis()
       .addAnalyzer(Size())
       .addAnalyzer(ApproxCountDistinct("id"))
-      .addAnalyzer(Completeness("name"))
+      .addAnalyzer(Completeness("productName"))
       .addAnalyzer(Completeness("description"))
 
     val stateStore = InMemoryStateProvider()

--- a/src/main/scala/com/amazon/deequ/examples/MetricsRepositoryExample.scala
+++ b/src/main/scala/com/amazon/deequ/examples/MetricsRepositoryExample.scala
@@ -56,7 +56,7 @@ object MetricsRepositoryExample extends App {
       .addCheck(Check(CheckLevel.Error, "integrity checks")
         .hasSize(_ == 5)
         .isComplete("id")
-        .isComplete("name")
+        .isComplete("productName")
         .isContainedIn("priority", Array("high", "low"))
         .isNonNegative("numViews"))
       // We want to store the computed metrics for the checks in our repository
@@ -68,11 +68,11 @@ object MetricsRepositoryExample extends App {
 
 
     // We can load the metric for a particular analyzer stored under our result key:
-    val completenessOfName = repository
+    val completenessOfProductName = repository
       .loadByKey(resultKey).get
-      .metric(Completeness("name")).get
+      .metric(Completeness("productName")).get
 
-    println(s"The completeness of the name column is: $completenessOfName")
+    println(s"The completeness of the productName column is: $completenessOfProductName")
 
     // We can query the repository for all metrics from the last 10 minutes and get them as json
     val json = repository.load()

--- a/src/main/scala/com/amazon/deequ/examples/UpdateMetricsOnPartitionedDataExample.scala
+++ b/src/main/scala/com/amazon/deequ/examples/UpdateMetricsOnPartitionedDataExample.scala
@@ -46,8 +46,8 @@ object UpdateMetricsOnPartitionedDataExample extends App {
 
     // We are interested in the the following constraints of the table as a whole
     val check = Check(CheckLevel.Warning, "a check")
-        .isComplete("name")
-        .containsURL("name", _ == 0.0)
+        .isComplete("manufacturerName")
+        .containsURL("manufacturerName", _ == 0.0)
         .isContainedIn("countryCode", Array("DE", "US", "CN"))
 
     // Deequ now allows us to compute states for the metrics on which the constraints are defined

--- a/src/main/scala/com/amazon/deequ/examples/algebraic_states_example.md
+++ b/src/main/scala/com/amazon/deequ/examples/algebraic_states_example.md
@@ -19,7 +19,7 @@ val data = ExampleUtils.itemsAsDataframe(spark,
 val analysis = Analysis()
   .addAnalyzer(Size())
   .addAnalyzer(ApproxCountDistinct("id"))
-  .addAnalyzer(Completeness("name"))
+  .addAnalyzer(Completeness("productName"))
   .addAnalyzer(Completeness("description"))
 ```
 We can now trigger the execution of these analyzers via the [AnalysisRunner](https://github.com/awslabs/deequ/blob/master/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala). However, we want to persist the internal state of the computation; therefore we configure a [StateProvider](https://github.com/awslabs/deequ/blob/master/src/main/scala/com/amazon/deequ/analyzers/StateProvider.scala) in order to capture this state.
@@ -42,12 +42,12 @@ metricsForData.metricMap.foreach { case (analyzer, metric) =>
 }
 ```
 
-Executing this code will print the following. We see that there are 3 records in the data, the cardinality of the `ìd` column is 3, there are no missing values in the `name` column and two-thirds of the `description` column have values.
+Executing this code will print the following. We see that there are 3 records in the data, the cardinality of the `ìd` column is 3, there are no missing values in the `productName` column and two-thirds of the `description` column have values.
 
 ```
 Size(None): 3.0
 ApproxCountDistinct(id,None): 3.0
-Completeness(name,None): 1.0
+Completeness(productName,None): 1.0
 Completeness(description,None): 0.6666666666666666
 ```
 
@@ -69,12 +69,12 @@ metricsAfterAddingMoreData.metricMap.foreach { case (analyzer, metric) =>
   println(s"\t$analyzer: ${metric.value.get}")
 }
 ```
-Executing this code prints the updated metrics for the whole dataset. We have 5 records overall, the cardinality of the `ìd` column is also 5, there are still no missing values in the `name` column and the completeness of the `description` column dropped to 0.4.
+Executing this code prints the updated metrics for the whole dataset. We have 5 records overall, the cardinality of the `ìd` column is also 5, there are still no missing values in the `productName` column and the completeness of the `description` column dropped to 0.4.
 
 ```
 Size(None): 5.0
 ApproxCountDistinct(id,None): 5.0
-Completeness(name,None): 1.0
+Completeness(productName,None): 1.0
 Completeness(description,None): 0.4
 ```
 An [executable version of this example](https://github.com/awslabs/deequ/blob/master/src/main/scala/com/amazon/deequ/examples/IncrementalMetricsExample.scala) is part of our codebase.
@@ -102,8 +102,8 @@ And we have the following metrics (defined by a check) that we're interested in 
 
 ```scala
 val check = Check(CheckLevel.Warning, "a check")
-  .isComplete("name")
-  .containsURL("name", _ == 0.0)
+  .isComplete("productName")
+  .containsURL("productName", _ == 0.0)
   .isContainedIn("countryCode", Array("DE", "US", "CN"))
 ```
 
@@ -133,8 +133,8 @@ tableMetrics.metricMap.foreach { case (analyzer, metric) =>
 ```
 
 ```
-Completeness(name,None): 1.0
-PatternMatch(name,(https?|ftp)://[^\s/$.?#].[^\s]*,None): 0.0
+Completeness(productName,None): 1.0
+PatternMatch(productName,(https?|ftp)://[^\s/$.?#].[^\s]*,None): 0.0
 Compliance("countryCode contained in DE,US,CN", 
   countryCode IS NULL OR countryCode IN ('DE','US','CN'),None): 1.0
 ```
@@ -170,8 +170,8 @@ updatedTableMetrics.metricMap.foreach { case (analyzer, metric) =>
 This code will only operate on the updated partition and the states, but will still return the correct metrics for the table as a whole:
 
 ```
-Completeness(name,None): 0.8571428571428571
-PatternMatch(name,(https?|ftp)://[^\s/$.?#].[^\s]*,None): 0.14285714285714285
+Completeness(productName,None): 0.8571428571428571
+PatternMatch(productName,(https?|ftp)://[^\s/$.?#].[^\s]*,None): 0.14285714285714285
 Compliance("countryCode contained in DE,US,CN", 
   countryCode IS NULL OR countryCode IN ('DE','US','CN'),None): 1.0
 ```

--- a/src/main/scala/com/amazon/deequ/examples/anomaly_detection_example.md
+++ b/src/main/scala/com/amazon/deequ/examples/anomaly_detection_example.md
@@ -2,23 +2,23 @@
 
 Very often, it is hard to exactly define what constraints we want to evaluate on our data. However, we often have a better understanding of how much change we expect in certain metrics of our data. Therefore, **deequ** supports anomaly detection for data quality metrics. The idea is that we regularly store the metrics of our data in a [MetricsRepository](https://github.com/awslabs/deequ/blob/master/src/main/scala/com/amazon/deequ/examples/metrics_repository_example.md). Once we do that, we can run anomaly checks that compare the current value of the metric to its values in the past and allow us to detect anomalous changes.
 
-In this simple example, we assume that we compute the size of a dataset every day and we want to ensure that it does not change drastically: the number of rows on a given day should not be more than double of what we have seen on the day before.  
+In this simple example, we assume that we compute the size of a dataset every day and we want to ensure that it does not change drastically: the number of rows on a given day should not be more than double of what we have seen on the day before.
 
 Anomaly detection operates on metrics stored in a metrics repository, so lets create one.
 ```scala
 val metricsRepository = new InMemoryMetricsRepository()
 ```
 
-This is our fictious data from yesterday which only has only two rows. 
+This is our fictious data from yesterday which only has only two rows.
 ```scala
 val yesterdaysDataset = itemsAsDataframe(session,
   Item(1, "Thingy A", "awesome thing.", "high", 0),
-  Item(2, "Thingy B", "available at http://thingb.com", null, 0))   
+  Item(2, "Thingy B", "available at http://thingb.com", null, 0))
 ```
 
 We test for anomalies in the size of the data, and want to enforce that it should not increase by more than 2x. We define a check for this by using the [RateOfChangeStrategy](https://github.com/awslabs/deequ/blob/master/src/main/scala/com/amazon/deequ/anomalydetection/RateOfChangeStrategy.scala) for detecting anomalies. Note that we store the resulting metrics in our repository via `useRepository` and `saveOrAppendResult` under a result key `yesterdaysKey` with yesterdays timestamp.
 ```scala
-val yesterdaysKey = ResultKey(System.currentTimeMillis() - 24 * 60 * 1000) 
+val yesterdaysKey = ResultKey(System.currentTimeMillis() - 24 * 60 * 1000)
 
 VerificationSuite()
   .onData(yesterdaysDataset)
@@ -28,7 +28,7 @@ VerificationSuite()
     RelativeRateOfChangeStrategy(maxRateIncrease = Some(2.0)),
     Size())
   .run()
-```  
+```
 
 The fictious data of today has five rows, so the data size more than doubled and our anomaly check should
 catch this.
@@ -54,11 +54,11 @@ val verificationResult = VerificationSuite()
   .run()
 ```
 
-We can now have a look at the `status` of the result of the verification to see if your check caught an anomaly (it should have). We print the contents of our metrics repository in that case. 
+We can now have a look at the `status` of the result of the verification to see if your check caught an anomaly (it should have). We print the contents of our metrics repository in that case.
 ```scala
 if (verificationResult.status != Success) {
   println("Anomaly detected in the Size() metric!")
-  
+
   metricsRepository
     .load()
     .forAnalyzers(Seq(Size()))
@@ -70,7 +70,7 @@ if (verificationResult.status != Success) {
 We see that the following metrics are stored in the repository, which shows us the reason the anomaly: the data size increased from 2 to 5!
 ```
 +-------+--------+----+-----+-------------+
-| entity|instance|name|value| dataset_date|
+| entity|instance|Name|value| dataset_date|
 +-------+--------+----+-----+-------------+
 |Dataset|       *|Size|  2.0|1538384009558|
 |Dataset|       *|Size|  5.0|1538385453983|

--- a/src/main/scala/com/amazon/deequ/examples/constraint_suggestion_example.md
+++ b/src/main/scala/com/amazon/deequ/examples/constraint_suggestion_example.md
@@ -7,7 +7,7 @@ Our constraint suggestion first [profiles the data](https://github.com/awslabs/d
 Let's first generate some example data:
 ```scala
 case class RawData(
-  name: String, 
+  productName: String, 
   count: String, 
   status: String, 
   valuable: String
@@ -74,13 +74,13 @@ Constraint suggestion for 'count': 'count' has only values that are equal to or 
 The corresponding scala code is .isNonNegative("count")
 ```
 
-Finally, we look at the suggestions for the `name` and `status` columns. Both of them did not have a single missing value in the example data, so an `isComplete` constraint is suggested for them. Furthermore, both of them only have a small set of possible values, therefore an `isContainedIn` constraint is suggested, which would check that future values are also contained in the range of observed values.
+Finally, we look at the suggestions for the `productName` and `status` columns. Both of them did not have a single missing value in the example data, so an `isComplete` constraint is suggested for them. Furthermore, both of them only have a small set of possible values, therefore an `isContainedIn` constraint is suggested, which would check that future values are also contained in the range of observed values.
 ```
-Constraint suggestion for 'name': 'name' is not null
-The corresponding scala code is .isComplete("name")
+Constraint suggestion for 'productName': 'productName' is not null
+The corresponding scala code is .isComplete("productName")
 
-Constraint suggestion for 'name': 'name' has value range 'thingC', 'thingA', 'thingB', 'thingE', 'thingD'
-The corresponding scala code is .isContainedIn("name", Array("thingC", "thingA", "thingB", "thingE", "thingD"))
+Constraint suggestion for 'productName': 'productName' has value range 'thingC', 'thingA', 'thingB', 'thingE', 'thingD'
+The corresponding scala code is .isContainedIn("productName", Array("thingC", "thingA", "thingB", "thingE", "thingD"))
 
 Constraint suggestion for 'status':	'status' is not null
 The corresponding scala code is .isComplete("status")

--- a/src/main/scala/com/amazon/deequ/examples/data_profiling_example.md
+++ b/src/main/scala/com/amazon/deequ/examples/data_profiling_example.md
@@ -6,7 +6,7 @@ Very often we are faced with large, raw datasets and struggle to make sense of t
 Assume we have raw data that is string typed (such as the data you would get from a CSV file). For the sake of simplicity, we use the following toy data in this example:
 
 ```scala
-case class RawData(name: String, count: String, status: String, valuable: String)
+case class RawData(productName: String, count: String, status: String, valuable: String)
 
 val rows = spark.parallelize(Seq(
   RawData("thingA", "13.0", "IN_TRANSIT", "true"),
@@ -33,8 +33,8 @@ As a result, we get a profile for each column in the data, which allows us to in
 the approximate number of distinct values and the inferred datatype:
 
 ```scala
-result.profiles.foreach { case (name, profile) =>
-  println(s"Column '$name':\n " +
+result.profiles.foreach { case (productName, profile) =>
+  println(s"Column '$productName':\n " +
     s"\tcompleteness: ${profile.completeness}\n" +
     s"\tapproximate number of distinct values: ${profile.approximateNumDistinctValues}\n" +
     s"\tdatatype: ${profile.dataType}\n")
@@ -44,7 +44,7 @@ result.profiles.foreach { case (name, profile) =>
 In case of our toy data, we would get the following profiling results. Note that **deequ** detected that `count` is a fractional column (and could be casted to float or double type) and that `valuable` is a boolean column. 
 
 ```
-Column 'name':
+Column 'productName':
  	completeness: 1.0
 	approximate number of distinct values: 5
 	datatype: String

--- a/src/main/scala/com/amazon/deequ/examples/entities.scala
+++ b/src/main/scala/com/amazon/deequ/examples/entities.scala
@@ -18,7 +18,7 @@ package com.amazon.deequ.examples
 
 private[examples] case class Item(
     id: Long,
-    name: String,
+    productName: String,
     description: String,
     priority: String,
     numViews: Long
@@ -26,6 +26,6 @@ private[examples] case class Item(
 
 private[examples] case class Manufacturer(
     id: Long,
-    name: String,
+    manufacturerName: String,
     countryCode: String
 )

--- a/src/main/scala/com/amazon/deequ/examples/metrics_repository_example.md
+++ b/src/main/scala/com/amazon/deequ/examples/metrics_repository_example.md
@@ -24,7 +24,7 @@ tags in the form of key-value pairs. Let's setup one for this example:
 
 ```scala
 val resultKey = ResultKey(
-  System.currentTimeMillis(), 
+  System.currentTimeMillis(),
   Map("tag" -> "repositoryExample"))
 ```
 
@@ -36,7 +36,7 @@ VerificationSuite()
   .addCheck(Check(CheckLevel.Error, "integrity checks")
     .hasSize(_ == 5)
     .isComplete("id")
-    .isComplete("name")
+    .isComplete("productName")
     .isContainedIn("priority", Array("high", "low"))
     .isNonNegative("numViews"))
   .useRepository(repository)
@@ -44,18 +44,18 @@ VerificationSuite()
   .run()
 ```
 
-**Deequ** now executes the verification as usual and additionally stores the metrics under our specified key. Afterwards, we can retrieve the metrics from the repository in different ways. We can for example directly load the metric for a 
+**Deequ** now executes the verification as usual and additionally stores the metrics under our specified key. Afterwards, we can retrieve the metrics from the repository in different ways. We can for example directly load the metric for a
 particular analyzer stored under our result key as follows:
 
 ```scala
-val completenessOfName = repository
+val completenessOfProductName = repository
   .loadByKey(resultKey).get
-  .metric(Completeness("name")).get
+  .metric(Completeness("productName")).get
 
-println(s"The completeness of the name column is: $completenessOfName")
+println(s"The completeness of the productName column is: $completenessOfProductName")
 ```
 
-Executing this code will output `The completeness of the name column is: DoubleMetric(Column,Completeness,name,Success(0.8))`.
+Executing this code will output `The completeness of the productName column is: DoubleMetric(Column,Completeness,Name,Success(0.8))`.
 
 All our repositories support a couple of more general querying methods, e.g., we can also ask the repository for all metrics from the last 10 minutes and have it return the output as json:
 
@@ -96,7 +96,7 @@ This will show us the json representation of the metrics we computed so far:
  {"name":"Completeness",
   "tag":"repositoryExample",
   "dataset_date":1537951323402,
-  "instance":"name",
+  "instance":"productName",
   "entity":"Column",
   "value":0.8}]
 ```
@@ -118,7 +118,7 @@ repository.load()
 | Column|priority containe...|  Compliance|  1.0|1537951323402|repositoryExample|
 |Dataset|                   *|        Size|  5.0|1537951323402|repositoryExample|
 | Column|                  id|Completeness|  1.0|1537951323402|repositoryExample|
-| Column|                name|Completeness|  0.8|1537951323402|repositoryExample|
+| Column|         productName|Completeness|  0.8|1537951323402|repositoryExample|
 +-------+--------------------+------------+-----+-------------+-----------------+
 ```
 


### PR DESCRIPTION
Issue #125 

renaming of attributes in ```examples/``` files ,
```
'name' -> 'productName',
'count' -> 'totalNumber'
```
ambiguous attribute names in the context of the example file

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
