### PR TITLE
WIP - adds state provider support to VerificationRunBuilder (#92)

### DIFF
--- a/src/main/scala/com/amazon/deequ/VerificationRunBuilder.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationRunBuilder.scala
@@ -105,7 +105,7 @@ class VerificationRunBuilder(val data: DataFrame) {
     * Can be used to efficiently compute metrics for a large dataset if e.g. a new partition is added.
     *
     * @param stateLoader A state loader that loads previously calculated states and
-   *                    allows aggregation with the ones calculated in this run.
+    *                    allows aggregation with the ones calculated in this run.
     */
   def aggregateWith(stateLoader: StateLoader): this.type = {
     this.stateLoader = Option(stateLoader)

--- a/src/main/scala/com/amazon/deequ/VerificationRunBuilder.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationRunBuilder.scala
@@ -105,7 +105,7 @@ class VerificationRunBuilder(val data: DataFrame) {
     * Can be used to efficiently compute metrics for a large dataset if e.g. a new partition is added.
     *
     * @param stateLoader A state loader that loads previously calculated states and
-   *                    aggregates them with the ones calculated in this run.
+   *                    allows aggregation with the ones calculated in this run.
     */
   def aggregateWith(stateLoader: StateLoader): this.type = {
     this.stateLoader = Option(stateLoader)

--- a/src/main/scala/com/amazon/deequ/VerificationRunBuilder.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationRunBuilder.scala
@@ -66,7 +66,6 @@ class VerificationRunBuilder(val data: DataFrame) {
 
     stateLoader = verificationRunBuilder.stateLoader
     statePersister = verificationRunBuilder.statePersister
-
   }
 
   /**
@@ -90,8 +89,9 @@ class VerificationRunBuilder(val data: DataFrame) {
   }
 
   /**
-    * Use to automatically save analyzer states.
-    * Enables later aggregation e.g. when a new partition is added to the dataset.
+    * Save analyzer states.
+    * Enables aggregate computation of metrics later, e.g., when a new partition is
+    * added to the dataset.
     *
     * @param statePersister A state persister that saves the computed states for later aggregation
     */
@@ -102,7 +102,8 @@ class VerificationRunBuilder(val data: DataFrame) {
 
   /**
     * Use to load saved analyzer states and aggregate them with those calculated in this new run.
-    * Can be used to efficiently compute metrics for a large dataset if e.g. a new partition is added.
+    * Can be used to efficiently compute metrics for a large dataset
+    * if e.g. a new partition is added.
     *
     * @param stateLoader A state loader that loads previously calculated states and
     *                    allows aggregation with the ones calculated in this run.

--- a/src/main/scala/com/amazon/deequ/VerificationRunBuilder.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationRunBuilder.scala
@@ -96,7 +96,7 @@ class VerificationRunBuilder(val data: DataFrame) {
     * @param statePersister A state persister that saves the computed states for later aggregation
     */
   def saveStatesWith(statePersister: StatePersister): this.type = {
-    this.statePersister = Some(statePersister)
+    this.statePersister = Option(statePersister)
     this
   }
 
@@ -108,7 +108,7 @@ class VerificationRunBuilder(val data: DataFrame) {
    *                    aggregates them with the ones calculated in this run.
     */
   def aggregateWith(stateLoader: StateLoader): this.type = {
-    this.stateLoader = Some(stateLoader)
+    this.stateLoader = Option(stateLoader)
     this
   }
 

--- a/src/main/scala/com/amazon/deequ/VerificationRunBuilder.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationRunBuilder.scala
@@ -42,6 +42,9 @@ class VerificationRunBuilder(val data: DataFrame) {
   protected var saveSuccessMetricsJsonPath: Option[String] = None
   protected var overwriteOutputFiles: Boolean = false
 
+  protected var statePersister: Option[StatePersister] = None
+  protected var stateLoader: Option[StateLoader] = None
+
   protected def this(verificationRunBuilder: VerificationRunBuilder) {
 
     this(verificationRunBuilder.data)
@@ -60,6 +63,10 @@ class VerificationRunBuilder(val data: DataFrame) {
     overwriteOutputFiles = verificationRunBuilder.overwriteOutputFiles
     saveCheckResultsJsonPath = verificationRunBuilder.saveCheckResultsJsonPath
     saveSuccessMetricsJsonPath = verificationRunBuilder.saveSuccessMetricsJsonPath
+
+    stateLoader = verificationRunBuilder.stateLoader
+    statePersister = verificationRunBuilder.statePersister
+
   }
 
   /**
@@ -79,6 +86,29 @@ class VerificationRunBuilder(val data: DataFrame) {
     */
   def addChecks(checks: Seq[Check]): this.type = {
     this.checks ++= checks
+    this
+  }
+
+  /**
+    * Use to automatically save analyzer states.
+    * Enables later aggregation e.g. when a new partition is added to the dataset.
+    *
+    * @param statePersister A state persister that saves the computed states for later aggregation
+    */
+  def saveStatesWith(statePersister: StatePersister): this.type = {
+    this.statePersister = Some(statePersister)
+    this
+  }
+
+  /**
+    * Use to load saved analyzer states and aggregate them with those calculated in this new run.
+    * Can be used to efficiently compute metrics for a large dataset if e.g. a new partition is added.
+    *
+    * @param stateLoader A state loader that loads previously calculated states and
+   *                    aggregates them with the ones calculated in this run.
+    */
+  def aggregateWith(stateLoader: StateLoader): this.type = {
+    this.stateLoader = Some(stateLoader)
     this
   }
 
@@ -143,7 +173,9 @@ class VerificationRunBuilder(val data: DataFrame) {
         sparkSession,
         saveCheckResultsJsonPath,
         saveSuccessMetricsJsonPath,
-        overwriteOutputFiles)
+        overwriteOutputFiles),
+      saveStatesWith = statePersister,
+      aggregateWith = stateLoader
     )
   }
 }

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -28,11 +28,14 @@ import com.amazon.deequ.repository.{MetricsRepository, ResultKey}
 import com.amazon.deequ.utils.CollectionUtils.SeqExtensions
 import com.amazon.deequ.utils.{FixtureSupport, TempFileUtils}
 import org.apache.spark.sql.DataFrame
+import org.scalamock.scalatest.MockFactory
 import org.scalatest.{Matchers, WordSpec}
+
+import scala.util.Success
 
 
 class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
-  with FixtureSupport {
+  with FixtureSupport with MockFactory {
 
   "Verification Suite" should {
 
@@ -309,6 +312,54 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
       DfsUtils.readFromFileOnDfs(sparkSession, successMetricsPath) {
         inputStream => assert(inputStream.read() > 0)
       }
+    }
+
+    "call state persister if specified" in withSparkSession { sparkSession =>
+      val statePersister = mock[StatePersister]
+
+      val df = getDfWithNumericValues(sparkSession)
+      val analyzers = Sum("att2") :: Completeness("att1") :: Nil
+      val states = SumState(18.0) :: NumMatchesAndCount(6, 6) :: Nil
+
+      analyzers.zip(states).foreach {
+        case (analyzer: Analyzer[_, _], state: State[_]) =>
+          (statePersister.persist[state.type] _)
+            .expects(
+              where { (ana, st) => ana == analyzer && st == state }
+            )
+            .returns()
+            .atLeastOnce()
+
+      }
+
+      VerificationSuite().onData(df)
+        .addRequiredAnalyzers(analyzers)
+        .saveStatesWith(statePersister)
+        .run()
+    }
+
+    "load stored states for aggregation if specified" in withSparkSession { sparkSession =>
+      val stateLoaderStub = stub[StateLoader]
+
+      val df = getDfWithNumericValues(sparkSession)
+      val analyzers = Sum("att2") :: Completeness("att1") :: Nil
+
+      (stateLoaderStub.load[SumState] _)
+        .when(Sum("att2"))
+        .returns(Some(SumState(18.0)))
+
+      (stateLoaderStub.load[NumMatchesAndCount] _)
+        .when(Completeness("att1"))
+        .returns(Some(NumMatchesAndCount(0, 6)))
+
+
+      val results = VerificationSuite().onData(df)
+        .addRequiredAnalyzers(analyzers)
+        .aggregateWith(stateLoaderStub)
+        .run()
+
+      assert(results.metrics(Sum("att2")).value == Success(18.0 * 2))
+      assert(results.metrics(Completeness("att1")).value == Success(0.5))
     }
 
     "keep order of check constraints and their results" in withSparkSession { sparkSession =>

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -320,14 +320,13 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
       val analyzers = Sum("att2") :: Completeness("att1") :: Nil
       val states = SumState(18.0) :: NumMatchesAndCount(6, 6) :: Nil
 
-      analyzers.zip(states).foreach {
-        case (analyzer: Analyzer[_, _], state: State[_]) =>
-          (statePersister.persist[state.type] _)
-            .expects(
-              where { (analyzer_, state_) => analyzer_ == analyzer && state_ == state }
-            )
-            .returns()
-            .atLeastOnce()
+      analyzers.zip(states).foreach { case (analyzer: Analyzer[_, _], state: State[_]) =>
+        (statePersister.persist[state.type] _)
+          .expects(
+            where { (analyzer_, state_) => analyzer_ == analyzer && state_ == state }
+          )
+          .returns()
+          .atLeastOnce()
       }
 
       VerificationSuite().onData(df)

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -31,7 +31,6 @@ import org.apache.spark.sql.DataFrame
 import org.scalamock.scalatest.MockFactory
 import org.scalatest.{Matchers, WordSpec}
 
-import scala.util.Success
 
 
 class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
@@ -325,11 +324,10 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
         case (analyzer: Analyzer[_, _], state: State[_]) =>
           (statePersister.persist[state.type] _)
             .expects(
-              where { (ana, st) => ana == analyzer && st == state }
+              where { (analyzer_, state_) => analyzer_ == analyzer && state_ == state }
             )
             .returns()
             .atLeastOnce()
-
       }
 
       VerificationSuite().onData(df)
@@ -358,8 +356,8 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
         .aggregateWith(stateLoaderStub)
         .run()
 
-      assert(results.metrics(Sum("att2")).value == Success(18.0 * 2))
-      assert(results.metrics(Completeness("att1")).value == Success(0.5))
+      assert(results.metrics(Sum("att2")).value.get == 18.0 * 2)
+      assert(results.metrics(Completeness("att1")).value.get == 0.5)
     }
 
     "keep order of check constraints and their results" in withSparkSession { sparkSession =>

--- a/src/test/scala/com/amazon/deequ/analyzers/PartitionedTableIntegrationTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/PartitionedTableIntegrationTest.scala
@@ -67,14 +67,14 @@ class PartitionedTableIntegrationTest extends WordSpec with SparkContextSpec {
           // Key under which the metrics of this partition will be stored
           val partitionMetricsKey = ResultKey(currentTime, Map("target" -> partitionName))
 
-          // We have to use the deprecated run() method because we did not yet integrate the state
-          // handling into the fluid API. We'll do this once we have more clarity on the use case.
-          val verificationResultsForPartition = VerificationSuite().run(
-            data,
-            Seq(check),
-            saveStatesWith = Some(statesForPartition),
-            metricsRepository = Some(metricsRepository),
-            saveOrAppendResultsWithKey = Some(partitionMetricsKey))
+          val verificationResultsForPartition = VerificationSuite()
+            .onData(data)
+            .addCheck(check)
+            .saveStatesWith(statesForPartition)
+            .useRepository(metricsRepository)
+            .saveOrAppendResult(partitionMetricsKey)
+            .run()
+
 
           (verificationResultsForPartition, statesForPartition)
         }


### PR DESCRIPTION
*Issue #, if available:* #92 

*Description of changes:*   
Adds two methods to [`VerificationRunBuilder`](https://github.com/awslabs/deequ/blob/e333f4b507323cdd84ae084cc711eae1bab7a590/src/main/scala/com/amazon/deequ/VerificationRunBuilder.scala#L28) to allow saving and aggregation of states. 
Currently the only way to do this with the [`VerificationSuite`](https://github.com/awslabs/deequ/blob/e333f4b507323cdd84ae084cc711eae1bab7a590/src/main/scala/com/amazon/deequ/VerificationSuite.scala#L42) is by using the deprecated [`run`](https://github.com/awslabs/deequ/blob/e333f4b507323cdd84ae084cc711eae1bab7a590/src/main/scala/com/amazon/deequ/VerificationSuite.scala#L67) method.

This would allow users to use the stateful metrics computation features of deequ without relying on deprecated methods. However, I would like to use this draft PR as a place for discussion as the way this PR implements this might not be optimal for all users. Some problems that I think should be up for discussion are:
1. This PR mainly caters towards users with datasets that grow in size over time. A new partition represents the new entries since the last verification run. However, the proposed change does not make it easier to aggregate multiple states e.g. across various partitions from different regions. For this, the method [`runOnAggregatedStates`](https://github.com/awslabs/deequ/blob/e333f4b507323cdd84ae084cc711eae1bab7a590/src/main/scala/com/amazon/deequ/VerificationSuite.scala#L208) would still be the primary way to do this. My question:
Should the [`VerificationRunBuilder`](https://github.com/awslabs/deequ/blob/e333f4b507323cdd84ae084cc711eae1bab7a590/src/main/scala/com/amazon/deequ/VerificationRunBuilder.scala#L28) offer the user to aggregate *multiple* saved states *in addition* to the data provided via [`onData(data: DataFrame)`](https://github.com/awslabs/deequ/blob/e333f4b507323cdd84ae084cc711eae1bab7a590/src/main/scala/com/amazon/deequ/VerificationSuite.scala#L49)?

2. If a user stores states with the [`StateProvider`](https://github.com/awslabs/deequ/blob/e333f4b507323cdd84ae084cc711eae1bab7a590/src/main/scala/com/amazon/deequ/analyzers/StateProvider.scala#L72) (that implements both the [`StateLoader`](https://github.com/awslabs/deequ/blob/e333f4b507323cdd84ae084cc711eae1bab7a590/src/main/scala/com/amazon/deequ/analyzers/StateProvider.scala#L36) and [`StatePersister`](https://github.com/awslabs/deequ/blob/e333f4b507323cdd84ae084cc711eae1bab7a590/src/main/scala/com/amazon/deequ/analyzers/StateProvider.scala#L41)), they have to find appropriate ways to save/load the states in a manner that allows nice separation of datasets and partitions/ dates (or other criteria) and to correctly attribute and load them later. This can be currently done via location prefixes to the stored path. As I see it, the [`MetricsRepository`](https://github.com/awslabs/deequ/blob/e333f4b507323cdd84ae084cc711eae1bab7a590/src/main/scala/com/amazon/deequ/repository/MetricsRepository.scala#L25) makes it easier for the user by relying on [`ResultKeys`](https://github.com/awslabs/deequ/blob/e333f4b507323cdd84ae084cc711eae1bab7a590/src/main/scala/com/amazon/deequ/repository/MetricsRepository.scala#L51).   
Should we allow a similar abstraction or even provide a shared interface to automatically save both states and metrics by just supplying *one* repository-like object to the [`VerificationRunBuilder`](https://github.com/awslabs/deequ/blob/e333f4b507323cdd84ae084cc711eae1bab7a590/src/main/scala/com/amazon/deequ/VerificationRunBuilder.scala#L28)?


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.