### PR TITLE
Report number of records used for profiling during constraint suggestion

### DIFF
--- a/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionResult.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionResult.scala
@@ -24,11 +24,14 @@ import com.amazon.deequ.profiles.{ColumnProfile, ColumnProfiles}
   * The result returned from the ConstraintSuggestionSuite
   *
   * @param columnProfiles The column profiles
+  * @param numRecordsUsedForProfiling The number of records that were used for computing
+  *                                   the column profiles
   * @param constraintSuggestions The suggested constraints
   * @param verificationResult The verificationResult in case a train/test split was used
   */
 case class ConstraintSuggestionResult(
   columnProfiles: Map[String, ColumnProfile],
+  numRecordsUsedForProfiling: Long,
   constraintSuggestions: Map[String, Seq[ConstraintSuggestion]],
   verificationResult: Option[VerificationResult] = None)
 

--- a/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunner.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunner.scala
@@ -127,7 +127,8 @@ class ConstraintSuggestionRunner {
       .mapValues { groupedSuggestionsWithColumnNames =>
         groupedSuggestionsWithColumnNames.map { case (_, suggestion) => suggestion } }
 
-    ConstraintSuggestionResult(columnProfiles.profiles, columnsWithSuggestions, verificationResult)
+    ConstraintSuggestionResult(columnProfiles.profiles, columnProfiles.numRecords,
+      columnsWithSuggestions, verificationResult)
   }
 
   private[this] def splitTrainTestSets(

--- a/src/test/scala/com/amazon/deequ/suggestions/ConstraintSuggestionsIntegrationTest.scala
+++ b/src/test/scala/com/amazon/deequ/suggestions/ConstraintSuggestionsIntegrationTest.scala
@@ -86,6 +86,8 @@ class ConstraintSuggestionsIntegrationTest extends WordSpec with SparkContextSpe
         println(profile)
       }
 
+      assert(constraintSuggestionResult.numRecordsUsedForProfiling == numRecords)
+
       // IS NOT NULL for "id"
       assertConstraintExistsIn(constraintSuggestionResult) { (analyzer, assertionFunc) =>
         analyzer == Completeness("id") && assertionFunc(1.0)


### PR DESCRIPTION
We should report the number of records used for profiling during constraint suggestion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
