### PR TITLE
Add numerical & categorical distance comparison

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/Distance.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Distance.scala
@@ -23,10 +23,10 @@ case class CategoricalHistogram(buckets: List[CategoricalHistogramBucket])
 object Distance {
 
     /** Calculate distance of numerical profiles based on KLL Sketches and L-Infinity Distance */
-    def calculateNumericalDistance(
+    def numericalDistance(
       sample1: QuantileNonSample[Double],
       sample2: QuantileNonSample[Double],
-      enoughSample: Boolean = false)
+      correctForLowNumberOfSamples: Boolean = false)
     : Double = {
       val rankMap1 = sample1.getRankMap()
       val rankMap2 = sample2.getRankMap()
@@ -41,14 +41,14 @@ object Distance {
         val cdfDiff = Math.abs(cdf1 - cdf2)
         linfSimple = Math.max(linfSimple, cdfDiff)
       }
-      selectMetrics(linfSimple, n, m, enoughSample)
+      selectMetrics(linfSimple, n, m, correctForLowNumberOfSamples)
     }
 
     /** Calculate distance of categorical profiles based on L-Infinity Distance */
-    def calculateCategoricalDistance(
+    def categoricalDistance(
       sample1: CategoricalHistogram,
       sample2: CategoricalHistogram,
-      enoughSample: Boolean = false)
+      correctForLowNumberOfSamples: Boolean = false)
     : Double = {
 
       var countMap1 = scala.collection.mutable.Map[String, Long]()
@@ -72,18 +72,18 @@ object Distance {
         val cdfDiff = Math.abs(cdf1 - cdf2)
         linfSimple = Math.max(linfSimple, cdfDiff)
       }
-      selectMetrics(linfSimple, n, m, enoughSample)
+      selectMetrics(linfSimple, n, m, correctForLowNumberOfSamples)
     }
 
   /** Select which metrics to compute (linf_simple or linf_robust)
    *  based on whether samples are enough */
-   private def selectMetrics(
+   private[this] def selectMetrics(
      linfSimple: Double,
      n: Double,
      m: Double,
-     enoughSamples: Boolean = false)
+     correctForLowNumberOfSamples: Boolean = false)
    : Double = {
-     if (enoughSamples) {
+     if (correctForLowNumberOfSamples) {
        linfSimple
      } else {
        // This formula is based on  “Two-sample Kolmogorov–Smirnov test"

--- a/src/main/scala/com/amazon/deequ/analyzers/Distance.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Distance.scala
@@ -1,0 +1,90 @@
+/**
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.analyzers
+
+case class CategoricalBucket(value: String, count: Long)
+
+case class Categorical(buckets: List[CategoricalBucket])
+
+class Distance {
+
+    /** Calculate distance of numerical profiles based on KLL Sketch
+     *  This formula is based on  “Two-sample Kolmogorov–Smirnov test"
+     *  Reference: https://en.m.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test */
+    def calculateNumericalDistance(
+      sample1: QuantileNonSample[Double],
+      sample2: QuantileNonSample[Double],
+      isSimple: Boolean = false)
+    : Double = {
+      val rankMap1 = sample1.getRankMap()
+      val rankMap2 = sample2.getRankMap()
+      val combinedKeys = rankMap1.keySet.union(rankMap2.keySet)
+      val n = rankMap1.valuesIterator.max.toDouble
+      val m = rankMap2.valuesIterator.max.toDouble
+      var linfSimple = 0.0
+
+      combinedKeys.foreach { key =>
+        linfSimple = Math.max(linfSimple,
+          Math.abs(sample1.getRank(key, rankMap1) / n - sample2.getRank(key, rankMap2) / m))
+      }
+      val linfRobust = Math.max(0.0, linfSimple - 1.8 * Math.sqrt((n + m) / (n * m) ))
+      if (isSimple) {
+        linfSimple
+      } else {
+        linfRobust
+      }
+    }
+
+    /** Calculate distance of categorical profiles based on L-Infinity Distance */
+    def calculateCategoricalDistance(
+      sample1: Categorical,
+      sample2: Categorical,
+      isSimple: Boolean = false)
+    : Double = {
+
+      val buckets1 = sample1.buckets
+      val buckets2 = sample2.buckets
+      var countMap1 = scala.collection.mutable.Map[String, Long]()
+      var countMap2 = scala.collection.mutable.Map[String, Long]()
+      var n = 0.0
+      var m = 0.0
+      buckets1.foreach { bucket =>
+        n += bucket.count
+        countMap1 += (bucket.value -> bucket.count)
+      }
+      buckets2.foreach { bucket =>
+        m += bucket.count
+        countMap2 += (bucket.value -> bucket.count)
+      }
+      val combinedKeys = countMap1.keySet.union(countMap2.keySet)
+      var linfSimple = 0.0
+      combinedKeys.foreach { key =>
+        linfSimple = Math.max(linfSimple,
+          Math.abs(countMap1.getOrElse(key, 0L) / n - countMap2.getOrElse(key, 0L) / m))
+      }
+      val linfRobust = Math.max(0.0, linfSimple - 1.8 * Math.sqrt((n + m) / (n * m) ))
+      if (isSimple) {
+        linfSimple
+      } else {
+        linfRobust
+      }
+    }
+}
+
+object Distance{
+  val distance: Distance = new Distance
+}

--- a/src/main/scala/com/amazon/deequ/analyzers/QuantileNonSample.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/QuantileNonSample.scala
@@ -24,7 +24,7 @@ import scala.util.control.Breaks._
 
 class QuantileNonSample[T](
     var sketchSize: Int,
-    var shrinkingFactor: Double)
+    var shrinkingFactor: Double = 0.64)
     (implicit ordering: Ordering[T], ct: ClassTag[T])
   extends Serializable{
 
@@ -43,17 +43,18 @@ class QuantileNonSample[T](
   expand()
 
   /** Given sketchSize, shrinkingFactor, and data, reconstruct the KLL Object */
-  def reconstruct(k: Int, c: Double, data: Array[Array[T]]): Unit = {
-    sketchSize = k
-    shrinkingFactor = c
-    compactors = ArrayBuffer[NonSampleCompactor[T]]()
-    for (i <- data.indices) {
-      expand()
-      for (j <- data(i).indices) {
-        compactors(i).buffer = compactors(i).buffer :+ data(i)(j)
-      }
+  def reconstruct(
+    sketchSizeInput: Int,
+    shrinkingFactorInput: Double,
+    dataInput: Array[Array[T]])
+  : Unit = {
+    sketchSize = sketchSizeInput
+    shrinkingFactor = shrinkingFactorInput
+    compactors = ArrayBuffer.fill(dataInput.length)(new NonSampleCompactor[T])
+    for (i <- dataInput.indices) {
+      compactors(i).buffer = dataInput(i).to[ArrayBuffer]
     }
-    curNumOfCompactors = compactors.length
+    curNumOfCompactors = dataInput.length
     compactorActualSize = getCompactorItemsCount
     compactorTotalSize = getCompactorCapacityCount
   }

--- a/src/main/scala/com/amazon/deequ/analyzers/QuantileNonSample.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/QuantileNonSample.scala
@@ -44,17 +44,17 @@ class QuantileNonSample[T](
 
   /** Given sketchSize, shrinkingFactor, and data, reconstruct the KLL Object */
   def reconstruct(
-    sketchSizeInput: Int,
-    shrinkingFactorInput: Double,
-    dataInput: Array[Array[T]])
+    sketchSize: Int,
+    shrinkingFactor: Double,
+    data: Array[Array[T]])
   : Unit = {
-    sketchSize = sketchSizeInput
-    shrinkingFactor = shrinkingFactorInput
-    compactors = ArrayBuffer.fill(dataInput.length)(new NonSampleCompactor[T])
-    for (i <- dataInput.indices) {
-      compactors(i).buffer = dataInput(i).to[ArrayBuffer]
+    this.sketchSize = sketchSize
+    this.shrinkingFactor = shrinkingFactor
+    compactors = ArrayBuffer.fill(data.length)(new NonSampleCompactor[T])
+    for (i <- data.indices) {
+      compactors(i).buffer = data(i).to[ArrayBuffer]
     }
-    curNumOfCompactors = dataInput.length
+    curNumOfCompactors = data.length
     compactorActualSize = getCompactorItemsCount
     compactorTotalSize = getCompactorCapacityCount
   }

--- a/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
+++ b/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
@@ -17,7 +17,8 @@
 package com.amazon.deequ.KLL
 
 import com.amazon.deequ.SparkContextSpec
-import com.amazon.deequ.analyzers.{Categorical, CategoricalBucket, Distance, QuantileNonSample}
+import com.amazon.deequ.analyzers.{CategoricalHistogram, CategoricalHistogramBucket}
+import com.amazon.deequ.analyzers.{Distance, QuantileNonSample}
 import com.amazon.deequ.utils.FixtureSupport
 import org.scalatest.{Matchers, WordSpec}
 
@@ -29,7 +30,7 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
     var sample2 = new QuantileNonSample[Double](4, 0.64)
     sample1.reconstruct(4, 0.64, Array(Array(1, 2, 3, 4)))
     sample2.reconstruct(4, 0.64, Array(Array(2, 3, 4, 5)))
-    assert(Distance.distance.calculateNumericalDistance(sample1, sample2, true) == 0.25)
+    assert(Distance.calculateNumericalDistance(sample1, sample2, true) == 0.25)
   }
 
   "KLL distance calculator should compute correct linf_robust" in {
@@ -37,64 +38,64 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
     var sample2 = new QuantileNonSample[Double](4, 0.64)
     sample1.reconstruct(4, 0.64, Array(Array(1, 2, 3, 4)))
     sample2.reconstruct(4, 0.64, Array(Array(2, 3, 4, 5)))
-    assert(Distance.distance.calculateNumericalDistance(sample1, sample2) == 0.0)
+    assert(Distance.calculateNumericalDistance(sample1, sample2) == 0.0)
   }
 
   "Categorial distance should compute correct linf_simple" in {
-    var sample1 = Categorical(List(CategoricalBucket("a", 10),
-      CategoricalBucket("b", 20),
-      CategoricalBucket("c", 25),
-      CategoricalBucket("d", 10),
-      CategoricalBucket("e", 5)))
-    var sample2 = Categorical(List(CategoricalBucket("a", 11),
-      CategoricalBucket("b", 20),
-      CategoricalBucket("c", 25),
-      CategoricalBucket("d", 10),
-      CategoricalBucket("e", 10)))
-    assert(Distance.distance.calculateCategoricalDistance(sample1,
+    var sample1 = CategoricalHistogram(List(CategoricalHistogramBucket("a", 10),
+      CategoricalHistogramBucket("b", 20),
+      CategoricalHistogramBucket("c", 25),
+      CategoricalHistogramBucket("d", 10),
+      CategoricalHistogramBucket("e", 5)))
+    var sample2 = CategoricalHistogram(List(CategoricalHistogramBucket("a", 11),
+      CategoricalHistogramBucket("b", 20),
+      CategoricalHistogramBucket("c", 25),
+      CategoricalHistogramBucket("d", 10),
+      CategoricalHistogramBucket("e", 10)))
+    assert(Distance.calculateLInfinityCategoricalDistance(sample1,
       sample2, true) == 0.06015037593984962)
   }
 
   "Categorial distance should compute correct linf_robust" in {
-    var sample1 = Categorical(List(CategoricalBucket("a", 10),
-      CategoricalBucket("b", 20),
-      CategoricalBucket("c", 25),
-      CategoricalBucket("d", 10),
-      CategoricalBucket("e", 5)))
-    var sample2 = Categorical(List(CategoricalBucket("a", 11),
-      CategoricalBucket("b", 20),
-      CategoricalBucket("c", 25),
-      CategoricalBucket("d", 10),
-      CategoricalBucket("e", 10)))
-    assert(Distance.distance.calculateCategoricalDistance(sample1, sample2) == 0.0)
+    var sample1 = CategoricalHistogram(List(CategoricalHistogramBucket("a", 10),
+      CategoricalHistogramBucket("b", 20),
+      CategoricalHistogramBucket("c", 25),
+      CategoricalHistogramBucket("d", 10),
+      CategoricalHistogramBucket("e", 5)))
+    var sample2 = CategoricalHistogram(List(CategoricalHistogramBucket("a", 11),
+      CategoricalHistogramBucket("b", 20),
+      CategoricalHistogramBucket("c", 25),
+      CategoricalHistogramBucket("d", 10),
+      CategoricalHistogramBucket("e", 10)))
+    assert(Distance.calculateLInfinityCategoricalDistance(sample1, sample2) == 0.0)
   }
 
   "Categorial distance should compute correct linf_simple with different bin value" in {
-    var sample1 = Categorical(List(CategoricalBucket("a", 10),
-      CategoricalBucket("b", 20),
-      CategoricalBucket("c", 25),
-      CategoricalBucket("d", 10),
-      CategoricalBucket("e", 5)))
-    var sample2 = Categorical(List(CategoricalBucket("a", 11),
-      CategoricalBucket("a", 20),
-      CategoricalBucket("c", 25),
-      CategoricalBucket("d", 10),
-      CategoricalBucket("e", 10)))
-    assert(Distance.distance.calculateCategoricalDistance(sample1,
+    var sample1 = CategoricalHistogram(List(CategoricalHistogramBucket("a", 10),
+      CategoricalHistogramBucket("b", 20),
+      CategoricalHistogramBucket("c", 25),
+      CategoricalHistogramBucket("d", 10),
+      CategoricalHistogramBucket("e", 5)))
+    var sample2 = CategoricalHistogram(List(CategoricalHistogramBucket("a", 11),
+      CategoricalHistogramBucket("a", 20),
+      CategoricalHistogramBucket("c", 25),
+      CategoricalHistogramBucket("d", 10),
+      CategoricalHistogramBucket("e", 10)))
+    assert(Distance.calculateLInfinityCategoricalDistance(sample1,
       sample2, true) == 0.2857142857142857)
   }
 
   "Categorial distance should compute correct linf_robust with different bin value" in {
-    var sample1 = Categorical(List(CategoricalBucket("a", 10),
-      CategoricalBucket("b", 20),
-      CategoricalBucket("c", 25),
-      CategoricalBucket("d", 10),
-      CategoricalBucket("e", 5)))
-    var sample2 = Categorical(List(CategoricalBucket("a", 11),
-      CategoricalBucket("a", 20),
-      CategoricalBucket("c", 25),
-      CategoricalBucket("d", 10),
-      CategoricalBucket("e", 10)))
-    assert(Distance.distance.calculateCategoricalDistance(sample1, sample2) == 0.0)
+    var sample1 = CategoricalHistogram(List(CategoricalHistogramBucket("a", 10),
+      CategoricalHistogramBucket("b", 20),
+      CategoricalHistogramBucket("c", 25),
+      CategoricalHistogramBucket("d", 10),
+      CategoricalHistogramBucket("e", 5)))
+    var sample2 = CategoricalHistogram(List(CategoricalHistogramBucket("a", 11),
+      CategoricalHistogramBucket("a", 20),
+      CategoricalHistogramBucket("c", 25),
+      CategoricalHistogramBucket("d", 10),
+      CategoricalHistogramBucket("e", 10)))
+    assert(Distance.calculateLInfinityCategoricalDistance(sample1, sample2) == 0.0)
   }
 }

--- a/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
+++ b/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
@@ -1,0 +1,100 @@
+/**
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.KLL
+
+import com.amazon.deequ.SparkContextSpec
+import com.amazon.deequ.analyzers.{Categorical, CategoricalBucket, Distance, QuantileNonSample}
+import com.amazon.deequ.utils.FixtureSupport
+import org.scalatest.{Matchers, WordSpec}
+
+class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
+  with FixtureSupport{
+
+  "KLL distance calculator should compute correct linf_simple" in {
+    var sample1 = new QuantileNonSample[Double](4, 0.64)
+    var sample2 = new QuantileNonSample[Double](4, 0.64)
+    sample1.reconstruct(4, 0.64, Array(Array(1, 2, 3, 4)))
+    sample2.reconstruct(4, 0.64, Array(Array(2, 3, 4, 5)))
+    assert(Distance.distance.calculateNumericalDistance(sample1, sample2, true) == 0.25)
+  }
+
+  "KLL distance calculator should compute correct linf_robust" in {
+    var sample1 = new QuantileNonSample[Double](4, 0.64)
+    var sample2 = new QuantileNonSample[Double](4, 0.64)
+    sample1.reconstruct(4, 0.64, Array(Array(1, 2, 3, 4)))
+    sample2.reconstruct(4, 0.64, Array(Array(2, 3, 4, 5)))
+    assert(Distance.distance.calculateNumericalDistance(sample1, sample2) == 0.0)
+  }
+
+  "Categorial distance should compute correct linf_simple" in {
+    var sample1 = Categorical(List(CategoricalBucket("a", 10),
+      CategoricalBucket("b", 20),
+      CategoricalBucket("c", 25),
+      CategoricalBucket("d", 10),
+      CategoricalBucket("e", 5)))
+    var sample2 = Categorical(List(CategoricalBucket("a", 11),
+      CategoricalBucket("b", 20),
+      CategoricalBucket("c", 25),
+      CategoricalBucket("d", 10),
+      CategoricalBucket("e", 10)))
+    assert(Distance.distance.calculateCategoricalDistance(sample1,
+      sample2, true) == 0.06015037593984962)
+  }
+
+  "Categorial distance should compute correct linf_robust" in {
+    var sample1 = Categorical(List(CategoricalBucket("a", 10),
+      CategoricalBucket("b", 20),
+      CategoricalBucket("c", 25),
+      CategoricalBucket("d", 10),
+      CategoricalBucket("e", 5)))
+    var sample2 = Categorical(List(CategoricalBucket("a", 11),
+      CategoricalBucket("b", 20),
+      CategoricalBucket("c", 25),
+      CategoricalBucket("d", 10),
+      CategoricalBucket("e", 10)))
+    assert(Distance.distance.calculateCategoricalDistance(sample1, sample2) == 0.0)
+  }
+
+  "Categorial distance should compute correct linf_simple with different bin value" in {
+    var sample1 = Categorical(List(CategoricalBucket("a", 10),
+      CategoricalBucket("b", 20),
+      CategoricalBucket("c", 25),
+      CategoricalBucket("d", 10),
+      CategoricalBucket("e", 5)))
+    var sample2 = Categorical(List(CategoricalBucket("a", 11),
+      CategoricalBucket("a", 20),
+      CategoricalBucket("c", 25),
+      CategoricalBucket("d", 10),
+      CategoricalBucket("e", 10)))
+    assert(Distance.distance.calculateCategoricalDistance(sample1,
+      sample2, true) == 0.2857142857142857)
+  }
+
+  "Categorial distance should compute correct linf_robust with different bin value" in {
+    var sample1 = Categorical(List(CategoricalBucket("a", 10),
+      CategoricalBucket("b", 20),
+      CategoricalBucket("c", 25),
+      CategoricalBucket("d", 10),
+      CategoricalBucket("e", 5)))
+    var sample2 = Categorical(List(CategoricalBucket("a", 11),
+      CategoricalBucket("a", 20),
+      CategoricalBucket("c", 25),
+      CategoricalBucket("d", 10),
+      CategoricalBucket("e", 10)))
+    assert(Distance.distance.calculateCategoricalDistance(sample1, sample2) == 0.0)
+  }
+}

--- a/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
+++ b/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
@@ -52,7 +52,7 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
       CategoricalHistogramBucket("c", 25),
       CategoricalHistogramBucket("d", 10),
       CategoricalHistogramBucket("e", 10)))
-    assert(Distance.calculateLInfinityCategoricalDistance(sample1,
+    assert(Distance.calculateCategoricalDistance(sample1,
       sample2, true) == 0.06015037593984962)
   }
 
@@ -67,7 +67,7 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
       CategoricalHistogramBucket("c", 25),
       CategoricalHistogramBucket("d", 10),
       CategoricalHistogramBucket("e", 10)))
-    assert(Distance.calculateLInfinityCategoricalDistance(sample1, sample2) == 0.0)
+    assert(Distance.calculateCategoricalDistance(sample1, sample2) == 0.0)
   }
 
   "Categorial distance should compute correct linf_simple with different bin value" in {
@@ -81,7 +81,7 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
       CategoricalHistogramBucket("c", 25),
       CategoricalHistogramBucket("d", 10),
       CategoricalHistogramBucket("e", 10)))
-    assert(Distance.calculateLInfinityCategoricalDistance(sample1,
+    assert(Distance.calculateCategoricalDistance(sample1,
       sample2, true) == 0.2857142857142857)
   }
 
@@ -96,6 +96,6 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
       CategoricalHistogramBucket("c", 25),
       CategoricalHistogramBucket("d", 10),
       CategoricalHistogramBucket("e", 10)))
-    assert(Distance.calculateLInfinityCategoricalDistance(sample1, sample2) == 0.0)
+    assert(Distance.calculateCategoricalDistance(sample1, sample2) == 0.0)
   }
 }

--- a/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
+++ b/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
@@ -30,7 +30,7 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
     var sample2 = new QuantileNonSample[Double](4, 0.64)
     sample1.reconstruct(4, 0.64, Array(Array(1, 2, 3, 4)))
     sample2.reconstruct(4, 0.64, Array(Array(2, 3, 4, 5)))
-    assert(Distance.calculateNumericalDistance(sample1, sample2, true) == 0.25)
+    assert(Distance.numericalDistance(sample1, sample2, true) == 0.25)
   }
 
   "KLL distance calculator should compute correct linf_robust" in {
@@ -38,7 +38,7 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
     var sample2 = new QuantileNonSample[Double](4, 0.64)
     sample1.reconstruct(4, 0.64, Array(Array(1, 2, 3, 4)))
     sample2.reconstruct(4, 0.64, Array(Array(2, 3, 4, 5)))
-    assert(Distance.calculateNumericalDistance(sample1, sample2) == 0.0)
+    assert(Distance.numericalDistance(sample1, sample2) == 0.0)
   }
 
   "Categorial distance should compute correct linf_simple" in {
@@ -52,7 +52,7 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
       CategoricalHistogramBucket("c", 25),
       CategoricalHistogramBucket("d", 10),
       CategoricalHistogramBucket("e", 10)))
-    assert(Distance.calculateCategoricalDistance(sample1,
+    assert(Distance.categoricalDistance(sample1,
       sample2, true) == 0.06015037593984962)
   }
 
@@ -67,7 +67,7 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
       CategoricalHistogramBucket("c", 25),
       CategoricalHistogramBucket("d", 10),
       CategoricalHistogramBucket("e", 10)))
-    assert(Distance.calculateCategoricalDistance(sample1, sample2) == 0.0)
+    assert(Distance.categoricalDistance(sample1, sample2) == 0.0)
   }
 
   "Categorial distance should compute correct linf_simple with different bin value" in {
@@ -81,7 +81,7 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
       CategoricalHistogramBucket("c", 25),
       CategoricalHistogramBucket("d", 10),
       CategoricalHistogramBucket("e", 10)))
-    assert(Distance.calculateCategoricalDistance(sample1,
+    assert(Distance.categoricalDistance(sample1,
       sample2, true) == 0.2857142857142857)
   }
 
@@ -96,6 +96,6 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
       CategoricalHistogramBucket("c", 25),
       CategoricalHistogramBucket("d", 10),
       CategoricalHistogramBucket("e", 10)))
-    assert(Distance.calculateCategoricalDistance(sample1, sample2) == 0.0)
+    assert(Distance.categoricalDistance(sample1, sample2) == 0.0)
   }
 }

--- a/src/test/scala/com/amazon/deequ/KLL/KLLProbTest.scala
+++ b/src/test/scala/com/amazon/deequ/KLL/KLLProbTest.scala
@@ -1,0 +1,123 @@
+/**
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.KLL
+
+import org.scalatest.FlatSpec
+import org.scalatest.Matchers
+import org.scalatest._
+
+import scala.util.Random
+import com.amazon.deequ.analyzers.QuantileNonSample
+
+class KLLProbTest extends FlatSpec with Matchers {
+
+  "sketch" should "not crash or have a huge error for simple stream" in {
+
+    for (k <- Array(100, 1000, 50000)) {
+      val qSketch = new QuantileNonSample[Int](k)
+      val streamLen = 1000000
+      val epsilon = 100 / k.toDouble
+
+      // test on zoom-in sketch: 1, n, 2, n-1, ...
+      (1 to streamLen / 2).foreach { i =>
+        qSketch.update(i)
+        qSketch.update(streamLen + 1 - i)
+      }
+      var count = 0
+      // select several items to check, save test time
+      val step = Math.ceil(Math.max(epsilon * 0.2 * streamLen, 1)).toInt
+      var counter = 1
+
+      while (counter < streamLen) {
+        val estimate_r = qSketch.getRank(counter)
+        val actual_r = counter
+        val diff_r = Math.abs(estimate_r - actual_r)
+        if (diff_r >= epsilon * streamLen) {
+          count += 1
+        }
+        counter += step
+      }
+      count == 0 should be(true)
+    }
+  }
+
+  "sketch" should "not crash or have a huge error for random stream" in {
+
+    for (k <- Array(100, 1000, 50000)) {
+      val qSketch = new QuantileNonSample[Int](k)
+      val streamLen = 1000000
+      val epsilon = 100 / k.toDouble
+
+      // test on random distribution
+      val seed = 1
+      val randomGenerator = new Random(seed)
+      val shuffleList = randomGenerator.shuffle(List.range(1, streamLen))
+      shuffleList.foreach(item => qSketch.update(item))
+      var count = 0
+      // select several items to check, save test time
+      val step = Math.ceil(Math.max(epsilon * 0.2 * streamLen, 1)).toInt
+      var counter = 1
+
+      while (counter < streamLen) {
+        val estimate_r = qSketch.getRank(counter)
+        val actual_r = counter
+        val diff_r = Math.abs(estimate_r - actual_r)
+        if (diff_r >= epsilon * streamLen) {
+          count += 1
+        }
+        counter += step
+      }
+      count == 0 should be(true)
+    }
+  }
+
+
+    "sketch" should "not crash or have a huge error for merged stream" in {
+
+      for (k <- Array(100, 1000, 50000)) {
+        var lastMerge = new QuantileNonSample[Int](k)
+        val partitionLen = 100000
+        val merges = 10
+        val epsilon = 100 / k.toDouble
+
+        // test on merged stream
+        for (merge <- 0 until merges) {
+          var newMerge = new QuantileNonSample[Int](k)
+          (1 to partitionLen / 2).foreach { i =>
+            newMerge.update(i + merge * partitionLen)
+            newMerge.update(merge * partitionLen + partitionLen + 1 - i)
+          }
+          lastMerge = lastMerge.merge(newMerge)
+        }
+        var count = 0
+        // select several items to check, save test time
+        val step = Math.ceil(Math.max(epsilon * 0.2 * partitionLen * merges, 1)).toInt
+        var counter = 1
+
+        while (counter < partitionLen * merges) {
+          val estimate_r = lastMerge.getRank(counter)
+          val actual_r = counter
+          val diff_r = Math.abs(estimate_r - actual_r)
+          if (diff_r >= epsilon * partitionLen * merges) {
+            count += 1
+          }
+          counter += step
+        }
+        count == 0 should be(true)
+      }
+    }
+}

--- a/src/test/scala/com/amazon/deequ/KLL/KLLProfileTest.scala
+++ b/src/test/scala/com/amazon/deequ/KLL/KLLProfileTest.scala
@@ -14,11 +14,12 @@
  *
  */
 
-package com.amazon.deequ.profiles
+package com.amazon.deequ.KLL
 
 import com.amazon.deequ.SparkContextSpec
 import com.amazon.deequ.analyzers.{DataTypeInstances, KLLParameters}
 import com.amazon.deequ.metrics.{BucketDistribution, BucketValue}
+import com.amazon.deequ.profiles.{ColumnProfiler, NumericColumnProfile}
 import com.amazon.deequ.utils.FixtureSupport
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._


### PR DESCRIPTION
*Issue #, if available:*
The unit tests for KLL Sketches, which tests the probability error, are yet to be implemented.

*Description of changes:*
Add distance comparison functions for numerical & categorical profiles.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
