### PR TITLE
deequ-168: Improve approxQuantile metrics instance description

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/ApproxQuantile.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/ApproxQuantile.scala
@@ -87,14 +87,14 @@ case class ApproxQuantile(column: String, quantile: Double, relativeError: Doubl
     state match {
       case Some(theState) =>
         val percentile = theState.percentileDigest.getPercentiles(Array(quantile)).head
-        Analyzers.metricFromValue(percentile, "ApproxQuantile", column)
+        Analyzers.metricFromValue(percentile, s"ApproxQuantile-$quantile", column)
       case _ =>
-        Analyzers.metricFromEmpty(this, "ApproxQuantile", column)
+        Analyzers.metricFromEmpty(this, s"ApproxQuantile-$quantile", column)
     }
   }
 
   override def toFailureMetric(exception: Exception): DoubleMetric = {
-    Analyzers.metricFromFailure(exception, "ApproxQuantile", column)
+    Analyzers.metricFromFailure(exception, s"ApproxQuantile-$quantile", column)
   }
 
   override def preconditions: Seq[StructType => Unit] = {

--- a/src/main/scala/com/amazon/deequ/metrics/Metric.scala
+++ b/src/main/scala/com/amazon/deequ/metrics/Metric.scala
@@ -58,11 +58,11 @@ case class KeyedDoubleMetric(
   override def flatten(): Seq[DoubleMetric] = {
     if (value.isSuccess) {
       value.get.map { case (key, correspondingValue) =>
-        DoubleMetric(entity, s"name-$key", instance, Success(correspondingValue))
+        DoubleMetric(entity, s"$name-$key", instance, Success(correspondingValue))
       }
       .toSeq
     } else {
-      Seq(DoubleMetric(entity, s"name", instance, Failure(value.failed.get)))
+      Seq(DoubleMetric(entity, s"$name", instance, Failure(value.failed.get)))
     }
   }
 }

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalysisTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalysisTest.scala
@@ -92,7 +92,7 @@ class AnalysisTest extends WordSpec with Matchers with SparkContextSpec with Fix
         Success(6.0)))
       resultMetrics should contain(DoubleMetric(Entity.Column, "CountDistinct", "att1",
         Success(6.0)))
-      resultMetrics should contain(DoubleMetric(Entity.Column, "ApproxQuantile", "att1",
+      resultMetrics should contain(DoubleMetric(Entity.Column, "ApproxQuantile-0.5", "att1",
         Success(3.0)))
     }
 


### PR DESCRIPTION
*Issue:*
 #168

*Description of changes:*
- Quantile calculated was not represented on ApproxQuantile metric, making it confusing on the results. Quantile has been added.
- Metric name was not added on ApproxQuantiles when they where flattened. "Name" literal has been replaced by the metric name


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
