### PR TITLE
Set predefined data type to respect customer's customized data type in baseline

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/DataType.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/DataType.scala
@@ -29,7 +29,7 @@ import org.apache.spark.sql.{Column, Row}
 import scala.util.{Failure, Success}
 
 /** Data type instances */
-private[deequ] object DataTypeInstances extends Enumeration {
+object DataTypeInstances extends Enumeration {
   val Unknown: Value = Value(0)
   val Fractional: Value = Value(1)
   val Integral: Value = Value(2)

--- a/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
+++ b/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
@@ -34,15 +34,11 @@ private[deequ] case class GenericColumnStatistics(
     typeDetectionHistograms: Map[String, Map[String, Long]],
     approximateNumDistincts: Map[String, Long],
     completenesses: Map[String, Double],
-    predefinedColumnDataTypes: Option[Map[String, DataTypeInstances.Value]]) {
+    predefinedColumnDataTypes: Map[String, DataTypeInstances.Value]) {
 
   def typeOf(column: String): DataTypeInstances.Value = {
-    if (predefinedColumnDataTypes.isDefined && predefinedColumnDataTypes.get.contains(column)) {
-      predefinedColumnDataTypes.get(column)
-    } else {
-      val inferredAndKnown = inferredTypes ++ knownTypes
-      inferredAndKnown(column)
-    }
+    val inferredAndKnown = inferredTypes ++ knownTypes ++ predefinedColumnDataTypes
+    inferredAndKnown(column)
   }
 }
 
@@ -103,7 +99,8 @@ object ColumnProfiler {
       failIfResultsForReusingMissing: Boolean = false,
       saveInMetricsRepositoryUsingKey: Option[ResultKey] = None,
       kllParameters: Option[KLLParameters] = None,
-      predefinedColumnDataTypes: Option[Map[String, String]] = None)
+      predefinedColumnDataTypes: Map[String, DataTypeInstances.Value] =
+      Map[String, DataTypeInstances.Value]())
     : ColumnProfiles = {
 
     // Ensure that all desired columns exist
@@ -358,7 +355,7 @@ object ColumnProfiler {
       columns: Seq[String],
       schema: StructType,
       results: AnalyzerContext,
-      predefinedColumnDataTypes: Option[Map[String, String]])
+      predefinedColumnDataTypes: Map[String, DataTypeInstances.Value])
     : GenericColumnStatistics = {
 
     val numRecords = results.metricMap
@@ -367,29 +364,19 @@ object ColumnProfiler {
       .toLong
 
 
-    val inferredTypes =
-      if (predefinedColumnDataTypes.isDefined) {
-        results.metricMap
-          .collect { case (analyzer: DataType, metric: HistogramMetric)
-            if (!predefinedColumnDataTypes.get.contains(analyzer.column)) =>
-            // only infer dataType of a column when it is not predefined
-              val typeHistogram = metric.value.get
-              analyzer.column -> DataTypeHistogram.determineType(typeHistogram)
-          }
-      } else {
-        results.metricMap
-          .collect { case (analyzer: DataType, metric: HistogramMetric) =>
-            val typeHistogram = metric.value.get
-            analyzer.column -> DataTypeHistogram.determineType(typeHistogram)
-          }
+    val inferredTypes = results.metricMap
+      .collect { case (analyzer: DataType, metric: HistogramMetric)
+        if !predefinedColumnDataTypes.contains(analyzer.column) =>
+          val typeHistogram = metric.value.get
+          analyzer.column -> DataTypeHistogram.determineType(typeHistogram)
       }
 
     val typeDetectionHistograms = results.metricMap
-      .collect { case (analyzer: DataType, metric: HistogramMetric) =>
-        val typeCounts = metric.value.get.values
-          .map { case (key, distValue) => key -> distValue.absolute }
-
-        analyzer.column -> typeCounts
+      .collect { case (analyzer: DataType, metric: HistogramMetric)
+        if !predefinedColumnDataTypes.contains(analyzer.column) =>
+          val typeCounts = metric.value.get.values
+            .map { case (key, distValue) => key -> distValue.absolute }
+          analyzer.column -> typeCounts
       }
 
     val approximateNumDistincts = results.metricMap
@@ -402,81 +389,29 @@ object ColumnProfiler {
         analyzer.column -> metric.value.get
       }
 
-    val knownTypes =
-      if (predefinedColumnDataTypes.isDefined) {
-        schema.fields
-          .filter { column => columns.contains(column.name) }
-          .filter { column => !predefinedColumnDataTypes.get.contains(column.name)}
-          .filter {
-            _.dataType != StringType
-          }
-          .map { field =>
-            val knownType = field.dataType match {
-              case ShortType | LongType | IntegerType => Integral
-              case DecimalType() | FloatType | DoubleType => Fractional
-              case BooleanType => Boolean
-              case TimestampType => String // TODO We should have support for dates in deequ...
-              case _ =>
-                println(s"Unable to map type ${field.dataType}")
-                Unknown
-            }
-
-            field.name -> knownType
-          }
-          .toMap
-      } else {
-        schema.fields
-          .filter { column => columns.contains(column.name) }
-          .filter {
-            _.dataType != StringType
-          }
-          .map { field =>
-            val knownType = field.dataType match {
-              case ShortType | LongType | IntegerType => Integral
-              case DecimalType() | FloatType | DoubleType => Fractional
-              case BooleanType => Boolean
-              case TimestampType => String // TODO We should have support for dates in deequ...
-              case _ =>
-                println(s"Unable to map type ${field.dataType}")
-                Unknown
-            }
-
-            field.name -> knownType
-          }
-          .toMap
+    val knownTypes = schema.fields
+      .filter { column => columns.contains(column.name) }
+      .filter { column => !predefinedColumnDataTypes.contains(column.name)}
+      .filter {
+        _.dataType != StringType
       }
-
-    // convert predefinedDataTypes from Option[Map[String, String]]
-    // to Option[Map[String, DataTypeInstances.Value]]
-    val predefinedTypes =
-      if (predefinedColumnDataTypes.isDefined) {
-        val predefinedDataTypeStringMap = predefinedColumnDataTypes.get
-        val predefinedConvertedMap =
-        predefinedDataTypeStringMap.collect {
-          case (column: String, predefinedDataTypeString: String) =>
-          val predefinedDataType = predefinedDataTypeString match {
-            case "Integral" => Integral
-            case "Fractional" => Fractional
-            case "String" => String
-            case "Boolean" => Boolean
-            case "Unknown" => Unknown
-            case _ =>
-              val message = s"Unable to map predefined dataType " +
-                s"${predefinedColumnDataTypes.get(column)} for column ${column}. " +
-                s"Currently Deequ only accepts these baseline dataType: " +
-                s"Integral, Fractional, String, Boolean, Unknown." +
-                s"Please double check your baseline dataType."
-              println(message)
-              throw new Exception(message)
-          }
-          column -> predefinedDataType
+      .map { field =>
+        val knownType = field.dataType match {
+          case ShortType | LongType | IntegerType => Integral
+          case DecimalType() | FloatType | DoubleType => Fractional
+          case BooleanType => Boolean
+          case TimestampType => String // TODO We should have support for dates in deequ...
+          case _ =>
+            println(s"Unable to map type ${field.dataType}")
+            Unknown
         }
-        Some(predefinedConvertedMap)
-      } else {
-        None
+
+        field.name -> knownType
       }
+      .toMap
+
     GenericColumnStatistics(numRecords, inferredTypes, knownTypes, typeDetectionHistograms,
-      approximateNumDistincts, completenesses, predefinedTypes)
+      approximateNumDistincts, completenesses, predefinedColumnDataTypes)
   }
 
 

--- a/src/main/scala/com/amazon/deequ/profiles/ColumnProfilerRunBuilder.scala
+++ b/src/main/scala/com/amazon/deequ/profiles/ColumnProfilerRunBuilder.scala
@@ -108,11 +108,21 @@ class ColumnProfilerRunBuilder(val data: DataFrame) {
     this
   }
 
+  /**
+   * Set KLL parameters.
+   *
+   * @param kllParameters kllParameters(sketchSize, shrinkingFactor, numberOfBuckets)
+   */
   def setKLLParameters(kllParameters: Option[KLLParameters]): this.type = {
     this.kllParameters = kllParameters
     this
   }
 
+  /**
+   * Set predefined data types for each column (e.g. baseline)
+   *
+   * @param dataTypes dataType map for baseline columns
+   */
   def setPredefinedColumnDataTypes(dataTypes: Option[Map[String, String]]): this.type = {
     this.predefinedColumnDataTypes = dataTypes
     this

--- a/src/main/scala/com/amazon/deequ/profiles/ColumnProfilerRunBuilder.scala
+++ b/src/main/scala/com/amazon/deequ/profiles/ColumnProfilerRunBuilder.scala
@@ -17,7 +17,7 @@
 package com.amazon.deequ.profiles
 
 import com.amazon.deequ.repository._
-import com.amazon.deequ.analyzers.KLLParameters
+import com.amazon.deequ.analyzers.{DataTypeInstances, KLLParameters}
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 /** A class to build a Constraint Suggestion run using a fluent API */
@@ -40,7 +40,8 @@ class ColumnProfilerRunBuilder(val data: DataFrame) {
   protected var saveConstraintSuggestionsJsonPath: Option[String] = None
   protected var saveEvaluationResultsJsonPath: Option[String] = None
   protected var kllParameters: Option[KLLParameters] = None
-  protected var predefinedColumnDataTypes: Option[Map[String, String]] = None
+  protected var predefinedColumnDataTypes: Map[String, DataTypeInstances.Value] =
+    Map[String, DataTypeInstances.Value]()
 
   protected def this(constraintSuggestionRunBuilder: ColumnProfilerRunBuilder) {
 
@@ -123,7 +124,7 @@ class ColumnProfilerRunBuilder(val data: DataFrame) {
    *
    * @param dataTypes dataType map for baseline columns
    */
-  def setPredefinedColumnDataTypes(dataTypes: Option[Map[String, String]]): this.type = {
+  def setPredefinedColumnDataTypes(dataTypes: Map[String, DataTypeInstances.Value]): this.type = {
     this.predefinedColumnDataTypes = dataTypes
     this
   }

--- a/src/main/scala/com/amazon/deequ/profiles/ColumnProfilerRunBuilder.scala
+++ b/src/main/scala/com/amazon/deequ/profiles/ColumnProfilerRunBuilder.scala
@@ -40,6 +40,7 @@ class ColumnProfilerRunBuilder(val data: DataFrame) {
   protected var saveConstraintSuggestionsJsonPath: Option[String] = None
   protected var saveEvaluationResultsJsonPath: Option[String] = None
   protected var kllParameters: Option[KLLParameters] = None
+  protected var predefinedColumnDataTypes: Option[Map[String, String]] = None
 
   protected def this(constraintSuggestionRunBuilder: ColumnProfilerRunBuilder) {
 
@@ -63,6 +64,7 @@ class ColumnProfilerRunBuilder(val data: DataFrame) {
       .saveConstraintSuggestionsJsonPath
     saveEvaluationResultsJsonPath = constraintSuggestionRunBuilder.saveEvaluationResultsJsonPath
     kllParameters = constraintSuggestionRunBuilder.kllParameters
+    predefinedColumnDataTypes = constraintSuggestionRunBuilder.predefinedColumnDataTypes
   }
 
   /**
@@ -111,6 +113,12 @@ class ColumnProfilerRunBuilder(val data: DataFrame) {
     this
   }
 
+  def setPredefinedColumnDataTypes(dataTypes: Option[Map[String, String]]): this.type = {
+    this.predefinedColumnDataTypes = dataTypes
+    this
+  }
+
+
   /**
     * Set a metrics repository associated with the current data to enable features like reusing
     * previously computed results and storing the results of the current run.
@@ -152,7 +160,8 @@ class ColumnProfilerRunBuilder(val data: DataFrame) {
         reuseExistingResultsKey,
         failIfResultsForReusingMissing,
         saveOrAppendResultsKey),
-      kllParameters
+      kllParameters,
+      predefinedColumnDataTypes
     )
   }
 }

--- a/src/main/scala/com/amazon/deequ/profiles/ColumnProfilerRunBuilder.scala
+++ b/src/main/scala/com/amazon/deequ/profiles/ColumnProfilerRunBuilder.scala
@@ -40,8 +40,7 @@ class ColumnProfilerRunBuilder(val data: DataFrame) {
   protected var saveConstraintSuggestionsJsonPath: Option[String] = None
   protected var saveEvaluationResultsJsonPath: Option[String] = None
   protected var kllParameters: Option[KLLParameters] = None
-  protected var predefinedColumnDataTypes: Map[String, DataTypeInstances.Value] =
-    Map[String, DataTypeInstances.Value]()
+  protected var predefinedTypes: Map[String, DataTypeInstances.Value] = Map.empty
 
   protected def this(constraintSuggestionRunBuilder: ColumnProfilerRunBuilder) {
 
@@ -65,7 +64,7 @@ class ColumnProfilerRunBuilder(val data: DataFrame) {
       .saveConstraintSuggestionsJsonPath
     saveEvaluationResultsJsonPath = constraintSuggestionRunBuilder.saveEvaluationResultsJsonPath
     kllParameters = constraintSuggestionRunBuilder.kllParameters
-    predefinedColumnDataTypes = constraintSuggestionRunBuilder.predefinedColumnDataTypes
+    predefinedTypes = constraintSuggestionRunBuilder.predefinedTypes
   }
 
   /**
@@ -124,8 +123,8 @@ class ColumnProfilerRunBuilder(val data: DataFrame) {
    *
    * @param dataTypes dataType map for baseline columns
    */
-  def setPredefinedColumnDataTypes(dataTypes: Map[String, DataTypeInstances.Value]): this.type = {
-    this.predefinedColumnDataTypes = dataTypes
+  def setPredefinedTypes(dataTypes: Map[String, DataTypeInstances.Value]): this.type = {
+    this.predefinedTypes = dataTypes
     this
   }
 
@@ -172,7 +171,7 @@ class ColumnProfilerRunBuilder(val data: DataFrame) {
         failIfResultsForReusingMissing,
         saveOrAppendResultsKey),
       kllParameters,
-      predefinedColumnDataTypes
+      predefinedTypes
     )
   }
 }

--- a/src/main/scala/com/amazon/deequ/profiles/ColumnProfilerRunner.scala
+++ b/src/main/scala/com/amazon/deequ/profiles/ColumnProfilerRunner.scala
@@ -48,7 +48,8 @@ class ColumnProfilerRunner {
       cacheInputs: Boolean,
       fileOutputOptions: ColumnProfilerRunBuilderFileOutputOptions,
       metricsRepositoryOptions: ColumnProfilerRunBuilderMetricsRepositoryOptions,
-      kllParameters: Option[KLLParameters])
+      kllParameters: Option[KLLParameters],
+      predefinedColumnDataTypes: Option[Map[String, String]])
     : ColumnProfiles = {
 
     if (cacheInputs) {
@@ -65,7 +66,8 @@ class ColumnProfilerRunner {
         metricsRepositoryOptions.reuseExistingResultsKey,
         metricsRepositoryOptions.failIfResultsForReusingMissing,
         metricsRepositoryOptions.saveOrAppendResultsKey,
-        kllParameters
+        kllParameters,
+        predefinedColumnDataTypes
       )
 
     saveColumnProfilesJsonToFileSystemIfNecessary(

--- a/src/main/scala/com/amazon/deequ/profiles/ColumnProfilerRunner.scala
+++ b/src/main/scala/com/amazon/deequ/profiles/ColumnProfilerRunner.scala
@@ -49,7 +49,7 @@ class ColumnProfilerRunner {
       fileOutputOptions: ColumnProfilerRunBuilderFileOutputOptions,
       metricsRepositoryOptions: ColumnProfilerRunBuilderMetricsRepositoryOptions,
       kllParameters: Option[KLLParameters],
-      predefinedColumnDataTypes: Map[String, DataTypeInstances.Value])
+      predefinedTypes: Map[String, DataTypeInstances.Value])
     : ColumnProfiles = {
 
     if (cacheInputs) {
@@ -67,7 +67,7 @@ class ColumnProfilerRunner {
         metricsRepositoryOptions.failIfResultsForReusingMissing,
         metricsRepositoryOptions.saveOrAppendResultsKey,
         kllParameters,
-        predefinedColumnDataTypes
+        predefinedTypes
       )
 
     saveColumnProfilesJsonToFileSystemIfNecessary(

--- a/src/main/scala/com/amazon/deequ/profiles/ColumnProfilerRunner.scala
+++ b/src/main/scala/com/amazon/deequ/profiles/ColumnProfilerRunner.scala
@@ -16,7 +16,7 @@
 
 package com.amazon.deequ.profiles
 
-import com.amazon.deequ.analyzers.KLLParameters
+import com.amazon.deequ.analyzers.{DataTypeInstances, KLLParameters}
 import com.amazon.deequ.io.DfsUtils
 import com.amazon.deequ.repository.{MetricsRepository, ResultKey}
 import org.apache.spark.annotation.Experimental
@@ -49,7 +49,7 @@ class ColumnProfilerRunner {
       fileOutputOptions: ColumnProfilerRunBuilderFileOutputOptions,
       metricsRepositoryOptions: ColumnProfilerRunBuilderMetricsRepositoryOptions,
       kllParameters: Option[KLLParameters],
-      predefinedColumnDataTypes: Option[Map[String, String]])
+      predefinedColumnDataTypes: Map[String, DataTypeInstances.Value])
     : ColumnProfiles = {
 
     if (cacheInputs) {

--- a/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunBuilder.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunBuilder.scala
@@ -45,8 +45,7 @@ class ConstraintSuggestionRunBuilder(val data: DataFrame) {
   protected var saveConstraintSuggestionsJsonPath: Option[String] = None
   protected var saveEvaluationResultsJsonPath: Option[String] = None
   protected var kllParameters: Option[KLLParameters] = None
-  protected var predefinedColumnDataTypes: Map[String, DataTypeInstances.Value] =
-    Map[String, DataTypeInstances.Value]()
+  protected var predefinedTypes: Map[String, DataTypeInstances.Value] = Map.empty
 
   protected def this(constraintSuggestionRunBuilder: ConstraintSuggestionRunBuilder) {
 
@@ -73,7 +72,7 @@ class ConstraintSuggestionRunBuilder(val data: DataFrame) {
       .saveConstraintSuggestionsJsonPath
     saveEvaluationResultsJsonPath = constraintSuggestionRunBuilder.saveEvaluationResultsJsonPath
     kllParameters = constraintSuggestionRunBuilder.kllParameters
-    predefinedColumnDataTypes = constraintSuggestionRunBuilder.predefinedColumnDataTypes
+    predefinedTypes = constraintSuggestionRunBuilder.predefinedTypes
   }
 
   /**
@@ -169,8 +168,8 @@ class ConstraintSuggestionRunBuilder(val data: DataFrame) {
    *
    * @param dataType dataType map for baseline columns
    */
-  def setPredefinedColumnDataTypes(dataType: Map[String, DataTypeInstances.Value]): this.type = {
-    this.predefinedColumnDataTypes = dataType
+  def setPredefinedTypes(dataType: Map[String, DataTypeInstances.Value]): this.type = {
+    this.predefinedTypes = dataType
     this
   }
 
@@ -224,7 +223,7 @@ class ConstraintSuggestionRunBuilder(val data: DataFrame) {
         saveOrAppendResultsKey),
         kllWrapper(
           kllParameters,
-          predefinedColumnDataTypes)
+          predefinedTypes)
     )
   }
 
@@ -232,18 +231,18 @@ class ConstraintSuggestionRunBuilder(val data: DataFrame) {
   private def testsetWrapper(
     testsetRatio: Option[Double],
     testsetSplitRandomSeed: Option[Long])
-  : List[Any] = {
+  : (Option[Double], Option[Long]) = {
 
-    List[Any](testsetRatio, testsetSplitRandomSeed)
+    (testsetRatio, testsetSplitRandomSeed)
   }
 
   // implement this wrapper to not violate scalastyle requirement on argcount
   private def kllWrapper(
     kllParameters: Option[KLLParameters],
-    predefinedColumnDataTypes: Map[String, DataTypeInstances.Value])
-  : List[Any] = {
+    predefinedTypes: Map[String, DataTypeInstances.Value])
+  : (Option[KLLParameters], Map[String, DataTypeInstances.Value]) = {
 
-    List[Any](kllParameters, predefinedColumnDataTypes)
+    (kllParameters, predefinedTypes)
   }
 }
 

--- a/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunBuilder.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunBuilder.scala
@@ -163,8 +163,13 @@ class ConstraintSuggestionRunBuilder(val data: DataFrame) {
     this
   }
 
-  def setPredefinedColumnDataTypes(dataType: Map[String, String]): this.type = {
-    this.predefinedColumnDataTypes = Option(dataType)
+  /**
+   * Set predefined data types for each column (e.g. baseline)
+   *
+   * @param dataType dataType map for baseline columns
+   */
+  def setPredefinedColumnDataTypes(dataType: Option[Map[String, String]]): this.type = {
+    this.predefinedColumnDataTypes = dataType
     this
   }
 

--- a/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunBuilder.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunBuilder.scala
@@ -16,7 +16,7 @@
 
 package com.amazon.deequ.suggestions
 
-import com.amazon.deequ.analyzers.KLLParameters
+import com.amazon.deequ.analyzers.{DataTypeInstances, KLLParameters}
 import com.amazon.deequ.profiles.{ColumnProfile, ColumnProfiler}
 import com.amazon.deequ.repository._
 import com.amazon.deequ.suggestions.rules.ConstraintRule
@@ -45,7 +45,8 @@ class ConstraintSuggestionRunBuilder(val data: DataFrame) {
   protected var saveConstraintSuggestionsJsonPath: Option[String] = None
   protected var saveEvaluationResultsJsonPath: Option[String] = None
   protected var kllParameters: Option[KLLParameters] = None
-  protected var predefinedColumnDataTypes: Option[Map[String, String]] = None
+  protected var predefinedColumnDataTypes: Map[String, DataTypeInstances.Value] =
+    Map[String, DataTypeInstances.Value]()
 
   protected def this(constraintSuggestionRunBuilder: ConstraintSuggestionRunBuilder) {
 
@@ -168,7 +169,7 @@ class ConstraintSuggestionRunBuilder(val data: DataFrame) {
    *
    * @param dataType dataType map for baseline columns
    */
-  def setPredefinedColumnDataTypes(dataType: Option[Map[String, String]]): this.type = {
+  def setPredefinedColumnDataTypes(dataType: Map[String, DataTypeInstances.Value]): this.type = {
     this.predefinedColumnDataTypes = dataType
     this
   }
@@ -239,7 +240,7 @@ class ConstraintSuggestionRunBuilder(val data: DataFrame) {
   // implement this wrapper to not violate scalastyle requirement on argcount
   private def kllWrapper(
     kllParameters: Option[KLLParameters],
-    predefinedColumnDataTypes: Option[Map[String, String]])
+    predefinedColumnDataTypes: Map[String, DataTypeInstances.Value])
   : List[Any] = {
 
     List[Any](kllParameters, predefinedColumnDataTypes)

--- a/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunBuilder.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunBuilder.scala
@@ -45,6 +45,7 @@ class ConstraintSuggestionRunBuilder(val data: DataFrame) {
   protected var saveConstraintSuggestionsJsonPath: Option[String] = None
   protected var saveEvaluationResultsJsonPath: Option[String] = None
   protected var kllParameters: Option[KLLParameters] = None
+  protected var predefinedColumnDataTypes: Option[Map[String, String]] = None
 
   protected def this(constraintSuggestionRunBuilder: ConstraintSuggestionRunBuilder) {
 
@@ -71,6 +72,7 @@ class ConstraintSuggestionRunBuilder(val data: DataFrame) {
       .saveConstraintSuggestionsJsonPath
     saveEvaluationResultsJsonPath = constraintSuggestionRunBuilder.saveEvaluationResultsJsonPath
     kllParameters = constraintSuggestionRunBuilder.kllParameters
+    predefinedColumnDataTypes = constraintSuggestionRunBuilder.predefinedColumnDataTypes
   }
 
   /**
@@ -161,6 +163,11 @@ class ConstraintSuggestionRunBuilder(val data: DataFrame) {
     this
   }
 
+  def setPredefinedColumnDataTypes(dataType: Map[String, String]): this.type = {
+    this.predefinedColumnDataTypes = Option(dataType)
+    this
+  }
+
   /**
     * Set a metrics repository associated with the current data to enable features like reusing
     * previously computed results and storing the results of the current run.
@@ -187,7 +194,8 @@ class ConstraintSuggestionRunBuilder(val data: DataFrame) {
   }
 
   def run(): ConstraintSuggestionResult = {
-    ConstraintSuggestionRunner().run(
+    ConstraintSuggestionRunner().
+      run(
       data,
       constraintRules,
       restrictToColumns,
@@ -208,7 +216,9 @@ class ConstraintSuggestionRunBuilder(val data: DataFrame) {
         reuseExistingResultsKey,
         failIfResultsForReusingMissing,
         saveOrAppendResultsKey),
-      kllParameters
+        kllWrapper(
+          kllParameters,
+          predefinedColumnDataTypes)
     )
   }
 
@@ -219,6 +229,15 @@ class ConstraintSuggestionRunBuilder(val data: DataFrame) {
   : List[Any] = {
 
     List[Any](testsetRatio, testsetSplitRandomSeed)
+  }
+
+  // implement this wrapper to not violate scalastyle requirement on argcount
+  private def kllWrapper(
+    kllParameters: Option[KLLParameters],
+    predefinedColumnDataTypes: Option[Map[String, String]])
+  : List[Any] = {
+
+    List[Any](kllParameters, predefinedColumnDataTypes)
   }
 }
 

--- a/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunner.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunner.scala
@@ -66,20 +66,19 @@ class ConstraintSuggestionRunner {
       restrictToColumns: Option[Seq[String]],
       lowCardinalityHistogramThreshold: Int,
       printStatusUpdates: Boolean,
-      testsetWrapper: List[Any],
+      testsetWrapper: (Option[Double], Option[Long]),
       cacheInputs: Boolean,
       fileOutputOptions: ConstraintSuggestionFileOutputOptions,
       metricsRepositoryOptions: ConstraintSuggestionMetricsRepositoryOptions,
-      kllWrapper: List[Any])
+      kllWrapper: (Option[KLLParameters], Map[String, DataTypeInstances.Value]))
     : ConstraintSuggestionResult = {
 
     // get testset related data from wrapper
-    val testsetRatio: Option[Double] = testsetWrapper(0).asInstanceOf[Option[Double]]
-    val testsetSplitRandomSeed: Option[Long] = testsetWrapper(1).asInstanceOf[Option[Long]]
+    val testsetRatio: Option[Double] = testsetWrapper._1
+    val testsetSplitRandomSeed: Option[Long] = testsetWrapper._2
 
-    val kllParameters: Option[KLLParameters] = kllWrapper(0).asInstanceOf[Option[KLLParameters]]
-    val predefinedColumnDataTypes: Map[String, DataTypeInstances.Value] =
-      kllWrapper(1).asInstanceOf[Map[String, DataTypeInstances.Value]]
+    val kllParameters: Option[KLLParameters] = kllWrapper._1
+    val predefinedTypes: Map[String, DataTypeInstances.Value] = kllWrapper._2
 
     testsetRatio.foreach { testsetRatio =>
       require(testsetRatio > 0 && testsetRatio < 1.0, "Testset ratio must be in ]0, 1[")
@@ -100,7 +99,7 @@ class ConstraintSuggestionRunner {
       printStatusUpdates,
       metricsRepositoryOptions,
       kllParameters,
-      predefinedColumnDataTypes
+      predefinedTypes
     )
 
     saveColumnProfilesJsonToFileSystemIfNecessary(
@@ -167,7 +166,7 @@ class ConstraintSuggestionRunner {
       printStatusUpdates: Boolean,
       metricsRepositoryOptions: ConstraintSuggestionMetricsRepositoryOptions,
       kllParameters: Option[KLLParameters],
-      predefinedColumnDataTypes: Map[String, DataTypeInstances.Value])
+      predefinedTypes: Map[String, DataTypeInstances.Value])
     : (ColumnProfiles, Seq[ConstraintSuggestion]) = {
 
     var columnProfilerRunner = ColumnProfilerRunner()
@@ -182,7 +181,7 @@ class ConstraintSuggestionRunner {
     columnProfilerRunner = columnProfilerRunner.setKLLParameters(kllParameters)
 
     columnProfilerRunner =
-      columnProfilerRunner.setPredefinedColumnDataTypes(predefinedColumnDataTypes)
+      columnProfilerRunner.setPredefinedTypes(predefinedTypes)
 
     metricsRepositoryOptions.metricsRepository.foreach { metricsRepository =>
       var columnProfilerRunnerWithRepository = columnProfilerRunner.useRepository(metricsRepository)

--- a/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunner.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunner.scala
@@ -16,7 +16,7 @@
 
 package com.amazon.deequ.suggestions
 
-import com.amazon.deequ.analyzers.KLLParameters
+import com.amazon.deequ.analyzers.{DataTypeInstances, KLLParameters}
 import com.amazon.deequ.{VerificationResult, VerificationSuite}
 import com.amazon.deequ.checks.{Check, CheckLevel}
 import com.amazon.deequ.io.DfsUtils
@@ -78,8 +78,8 @@ class ConstraintSuggestionRunner {
     val testsetSplitRandomSeed: Option[Long] = testsetWrapper(1).asInstanceOf[Option[Long]]
 
     val kllParameters: Option[KLLParameters] = kllWrapper(0).asInstanceOf[Option[KLLParameters]]
-    val predefinedColumnDataTypes: Option[Map[String, String]] =
-      kllWrapper(1).asInstanceOf[Option[Map[String, String]]]
+    val predefinedColumnDataTypes: Map[String, DataTypeInstances.Value] =
+      kllWrapper(1).asInstanceOf[Map[String, DataTypeInstances.Value]]
 
     testsetRatio.foreach { testsetRatio =>
       require(testsetRatio > 0 && testsetRatio < 1.0, "Testset ratio must be in ]0, 1[")
@@ -167,7 +167,7 @@ class ConstraintSuggestionRunner {
       printStatusUpdates: Boolean,
       metricsRepositoryOptions: ConstraintSuggestionMetricsRepositoryOptions,
       kllParameters: Option[KLLParameters],
-      predefinedColumnDataTypes: Option[Map[String, String]])
+      predefinedColumnDataTypes: Map[String, DataTypeInstances.Value])
     : (ColumnProfiles, Seq[ConstraintSuggestion]) = {
 
     var columnProfilerRunner = ColumnProfilerRunner()

--- a/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerTest.scala
+++ b/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerTest.scala
@@ -74,6 +74,55 @@ class ColumnProfilerTest extends WordSpec with Matchers with SparkContextSpec
       assert(actualColumnProfile == expectedColumnProfile)
     }
 
+    "return correct columnProfiles with predefined dataType" in withSparkSession { session =>
+
+      val data = getDfCompleteAndInCompleteColumns(session)
+
+      val actualColumnProfile = ColumnProfiler.profile(data, Option(Seq("item")), false, 1,
+        predefinedColumnDataTypes =
+          Map[String, DataTypeInstances.Value]("item"-> DataTypeInstances.String))
+        .profiles("item")
+
+      val expectedColumnProfile = StandardColumnProfile(
+        "item",
+        1.0,
+        6,
+        DataTypeInstances.String,
+        false,
+        Map(),
+        None)
+
+      assert(actualColumnProfile == expectedColumnProfile)
+    }
+
+    "return correct columnProfiles without predefined dataType" in withSparkSession { session =>
+
+      val data = getDfCompleteAndInCompleteColumns(session)
+
+      val actualColumnProfile = ColumnProfiler.profile(data, Option(Seq("att2")), false, 1,
+        predefinedColumnDataTypes =
+          Map[String, DataTypeInstances.Value]("item"-> DataTypeInstances.String))
+        .profiles("att2")
+
+      val expectedColumnProfile = StandardColumnProfile(
+        "att2",
+        2.0 / 3.0,
+        2,
+        DataTypeInstances.String,
+        true,
+        Map(
+          "Boolean" -> 0,
+          "Fractional" -> 0,
+          "Integral" -> 0,
+          "Unknown" -> 2,
+          "String" -> 4
+        ),
+        None)
+
+      assert(actualColumnProfile == expectedColumnProfile)
+    }
+
+
     "return correct NumericColumnProfiles for numeric String DataType columns" in
       withSparkSession { session =>
 

--- a/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerTest.scala
+++ b/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerTest.scala
@@ -79,7 +79,7 @@ class ColumnProfilerTest extends WordSpec with Matchers with SparkContextSpec
       val data = getDfCompleteAndInCompleteColumns(session)
 
       val actualColumnProfile = ColumnProfiler.profile(data, Option(Seq("item")), false, 1,
-        predefinedColumnDataTypes =
+        predefinedTypes =
           Map[String, DataTypeInstances.Value]("item"-> DataTypeInstances.String))
         .profiles("item")
 
@@ -100,7 +100,7 @@ class ColumnProfilerTest extends WordSpec with Matchers with SparkContextSpec
       val data = getDfCompleteAndInCompleteColumns(session)
 
       val actualColumnProfile = ColumnProfiler.profile(data, Option(Seq("att2")), false, 1,
-        predefinedColumnDataTypes =
+        predefinedTypes =
           Map[String, DataTypeInstances.Value]("item"-> DataTypeInstances.String))
         .profiles("att2")
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
This pull request is mainly focusing on respecting the data types customers set in baseline constraints. One simple example would be that there's one column named "Zip Code", customers would like it to have dataType "String", but if the dataType in df.schema is StringType, then Deequ would infer the dataType to be "Integral" and run a numerical analysis. After this change, if a baseline dataType is given for a column, it will be respected. I am making the parameter to be optional so that it won't affect the cases when a baseline is not given.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
