### PR TITLE
Fix computation of uniqueness, distinctness, etc. for datasets with null values

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.amazon.deequ</groupId>
     <artifactId>deequ</artifactId>
-    <version>1.0.3-SNAPSHOT</version>
+    <version>1.1.0-SNAPSHOT</version>
 
     <name>deequ</name>
     <description>Deequ is a library built on top of Apache Spark for defining "unit tests for data",

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
@@ -92,18 +92,18 @@ class AnalyzerTests extends WordSpec with Matchers with SparkContextSpec with Fi
         "att2", Success(0.25)))
 
     }
-    "compute correct metrics on multi columns" in withSparkSession { sparkSession =>
+    "compute correct metrics on multiple columns" in withSparkSession { sparkSession =>
       val dfFull = getDfWithUniqueColumns(sparkSession)
 
       assert(Uniqueness("unique").calculate(dfFull) ==
         DoubleMetric(Entity.Column, "Uniqueness", "unique", Success(1.0)))
       assert(Uniqueness("uniqueWithNulls").calculate(dfFull) ==
-        DoubleMetric(Entity.Column, "Uniqueness", "uniqueWithNulls", Success(5 / 6.0)))
+        DoubleMetric(Entity.Column, "Uniqueness", "uniqueWithNulls", Success(1.0)))
       assert(Uniqueness(Seq("unique", "nonUnique")).calculate(dfFull) ==
         DoubleMetric(Entity.Mutlicolumn, "Uniqueness", "unique,nonUnique", Success(1.0)))
       assert(Uniqueness(Seq("unique", "nonUniqueWithNulls")).calculate(dfFull) ==
         DoubleMetric(Entity.Mutlicolumn, "Uniqueness", "unique,nonUniqueWithNulls",
-          Success(3 / 6.0)))
+          Success(1.0)))
       assert(Uniqueness(Seq("nonUnique", "onlyUniqueWithOtherNonUnique")).calculate(dfFull) ==
         DoubleMetric(Entity.Mutlicolumn, "Uniqueness", "nonUnique,onlyUniqueWithOtherNonUnique",
           Success(1.0)))

--- a/src/test/scala/com/amazon/deequ/analyzers/IncrementalAnalyzerTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/IncrementalAnalyzerTest.scala
@@ -19,7 +19,6 @@ package com.amazon.deequ.analyzers
 import com.amazon.deequ.SparkContextSpec
 import com.amazon.deequ.utils.FixtureSupport
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.apache.spark.sql.functions.expr
 import org.scalatest.{Matchers, WordSpec}
 
 import scala.util.Success
@@ -118,9 +117,9 @@ class IncrementalAnalyzerTest extends WordSpec with Matchers with SparkContextSp
 
       val uniqueness = analyzer.computeMetricFrom(mergedState)
 
-      assert(initialUniqueness.value == Success(0.6666666666666666))
-      assert(deltaUniqueness.value == Success(0.5))
-      assert(uniqueness.value == Success(0.2))
+      assert(initialUniqueness.value == Success(1.0))
+      assert(deltaUniqueness.value == Success(1.0))
+      assert(uniqueness.value == Success(1.0 / 3))
     }
 
     "compute correct metrics for column combinations" in withSparkSession { session =>
@@ -140,8 +139,8 @@ class IncrementalAnalyzerTest extends WordSpec with Matchers with SparkContextSp
 
       val uniqueness = analyzer.computeMetricFrom(mergedState)
 
-      assert(initialUniqueness.value == Success(0.6666666666666666))
-      assert(deltaUniqueness.value == Success(0.5))
+      assert(initialUniqueness.value == Success(1.0))
+      assert(deltaUniqueness.value == Success(1.0))
       assert(uniqueness.value == Success(0.2))
     }
   }

--- a/src/test/scala/com/amazon/deequ/analyzers/NullHandlingTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/NullHandlingTests.scala
@@ -16,9 +16,8 @@
 
 package com.amazon.deequ.analyzers
 
-import com.amazon.deequ.{SparkContextSpec, VerificationSuite}
+import com.amazon.deequ.SparkContextSpec
 import com.amazon.deequ.analyzers.runners.EmptyStateException
-import com.amazon.deequ.checks.{Check, CheckLevel}
 import com.amazon.deequ.metrics.DoubleMetric
 import com.amazon.deequ.utils.FixtureSupport
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
@@ -78,7 +77,7 @@ class NullHandlingTests extends WordSpec with Matchers with SparkContextSpec wit
       val stringColFrequenciesAndNumRows = CountDistinct("stringCol").computeStateFrom(data)
       assert(stringColFrequenciesAndNumRows.isDefined)
 
-      stringColFrequenciesAndNumRows.get.numRows shouldBe 8
+      stringColFrequenciesAndNumRows.get.numRows shouldBe 0L
       stringColFrequenciesAndNumRows.get.frequencies.count() shouldBe 0L
 
       val numericColFrequenciesAndNumRows = MutualInformation("numericCol", "numericCol2")
@@ -86,7 +85,7 @@ class NullHandlingTests extends WordSpec with Matchers with SparkContextSpec wit
 
       assert(numericColFrequenciesAndNumRows.isDefined)
 
-      numericColFrequenciesAndNumRows.get.numRows shouldBe 8
+      numericColFrequenciesAndNumRows.get.numRows shouldBe 0L
       numericColFrequenciesAndNumRows.get.frequencies.count() shouldBe 0L
 
 

--- a/src/test/scala/com/amazon/deequ/analyzers/UniquenessTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/UniquenessTest.scala
@@ -1,0 +1,64 @@
+/**
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.analyzers
+
+import com.amazon.deequ.analyzers.runners.AnalysisRunner
+import com.amazon.deequ.SparkContextSpec
+import com.amazon.deequ.metrics.DoubleMetric
+import com.amazon.deequ.utils.FixtureSupport
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.scalatest.{Matchers, WordSpec}
+
+class UniquenessTest extends WordSpec with Matchers with SparkContextSpec with FixtureSupport {
+
+  def uniquenessSampleData(sparkSession: SparkSession): DataFrame = {
+    import sparkSession.implicits._
+
+    // Example from https://github.com/awslabs/deequ/issues/178
+    Seq(
+      ("India", "Xavier House, 2nd Floor", "St. Peter Colony, Perry Road", "Bandra (West)"),
+      ("India", "503 Godavari", "Sir Pochkhanwala Road", "Worli"),
+      ("India", "4/4 Seema Society", "N Dutta Road, Four Bungalows", "Andheri"),
+      ("India", "1001D Abhishek Apartments", "Juhu Versova Road", "Andheri"),
+      ("India", "95, Hill Road", null, null),
+      ("India", "90 Cuffe Parade", "Taj President Hotel", "Cuffe Parade"),
+      ("India", "4, Seven PM", "Sir Pochkhanwala Rd", "Worli"),
+      ("India", "1453 Sahar Road", null, null)
+    )
+      .toDF("Country", "Address Line 1", "Address Line 2", "Address Line 3")
+  }
+
+  "Uniqueness" should {
+
+    "be correct for multiple fields" in withSparkSession { session =>
+
+      val data = uniquenessSampleData(session)
+
+      val stateStore = InMemoryStateProvider()
+
+      val uniquenessA1 = Uniqueness("Address Line 1")
+      val uniquenessA13 = Uniqueness(Seq("Address Line 1", "Address Line 2", "Address Line 3"))
+
+      val analysis = Analysis(Seq(uniquenessA1, uniquenessA13))
+
+      val result = AnalysisRunner.run(data, analysis, saveStatesWith = Some(stateStore))
+
+      assert(result.metric(uniquenessA1).get.asInstanceOf[DoubleMetric].value.get == 1.0)
+      assert(result.metric(uniquenessA13).get.asInstanceOf[DoubleMetric].value.get == 1.0)
+    }
+  }
+}

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -69,10 +69,8 @@ class CheckTest extends WordSpec with Matchers with SparkContextSpec with Fixtur
         .isUnique("nonUnique")
         .isUnique("nonUniqueWithNulls")
 
-      val (context, states) = runChecksWithState(getDfWithUniqueColumns(sparkSession), check)
+      val context = runChecks(getDfWithUniqueColumns(sparkSession), check)
       val result = check.evaluate(context)
-
-      states.load(Uniqueness("uniqueWithNulls")).get.frequencies.show(20)
 
       assert(result.status == CheckStatus.Error)
       val constraintStatuses = result.constraintResults.map(_.status)

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -69,13 +69,18 @@ class CheckTest extends WordSpec with Matchers with SparkContextSpec with Fixtur
         .isUnique("nonUnique")
         .isUnique("nonUniqueWithNulls")
 
-      val context = runChecks(getDfWithUniqueColumns(sparkSession), check)
+      val (context, states) = runChecksWithState(getDfWithUniqueColumns(sparkSession), check)
       val result = check.evaluate(context)
+
+      states.load(Uniqueness("uniqueWithNulls")).get.frequencies.show(20)
 
       assert(result.status == CheckStatus.Error)
       val constraintStatuses = result.constraintResults.map(_.status)
       assert(constraintStatuses.head == ConstraintStatus.Success)
-      assert(constraintStatuses(1) == ConstraintStatus.Failure)
+      assert(constraintStatuses(1) == ConstraintStatus.Success)
+
+
+
       assert(constraintStatuses(2) == ConstraintStatus.Failure)
       assert(constraintStatuses(3) == ConstraintStatus.Failure)
     }
@@ -83,8 +88,8 @@ class CheckTest extends WordSpec with Matchers with SparkContextSpec with Fixtur
     "return the correct check status for distinctness" in withSparkSession { sparkSession =>
 
       val check = Check(CheckLevel.Error, "distinctness-check")
-        .hasDistinctness(Seq("att1"), _ == 0.5)
-        .hasDistinctness(Seq("att1", "att2"), _ == 1.0 / 3)
+        .hasDistinctness(Seq("att1"), _ == 3.0 / 5)
+        .hasDistinctness(Seq("att1", "att2"), _ == 4.0 / 6)
         .hasDistinctness(Seq("att2"), _ == 1.0)
 
       val context = runChecks(getDfWithDistinctValues(sparkSession), check)
@@ -111,7 +116,7 @@ class CheckTest extends WordSpec with Matchers with SparkContextSpec with Fixtur
       val context = runChecks(getDfWithUniqueColumns(sparkSession), check)
       val result = check.evaluate(context)
 
-      assert(result.status == CheckStatus.Error)
+      assert(result.status == CheckStatus.Success)
       val constraintStatuses = result.constraintResults.map { _.status }
       // Half of nonUnique column are duplicates
       assert(constraintStatuses.head == ConstraintStatus.Success)
@@ -122,7 +127,7 @@ class CheckTest extends WordSpec with Matchers with SparkContextSpec with Fixtur
       assert(constraintStatuses(3) == ConstraintStatus.Success)
       assert(constraintStatuses(4) == ConstraintStatus.Success)
       // Nulls are duplicated so this will not be unique
-      assert(constraintStatuses(5) == ConstraintStatus.Failure)
+      assert(constraintStatuses(5) == ConstraintStatus.Success)
     }
 
     "return the correct check status for size" in withSparkSession { sparkSession =>


### PR DESCRIPTION
 * Fixes computation of uniqueness, distinctness, etc for datasets with null values, as a response to #178 
 * Bumps version number to 1.1 to indicate that some existing tests might break due to the corrected semantics


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
