### PR TITLE
Nested schema support in Predconditions

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
@@ -340,7 +340,9 @@ object Preconditions {
       dataType match {
         // nested type, enqueue all fields in it
         case st: StructType =>
-          st.fields.foreach(field => fieldQueue.enqueue(fieldName + "." + field.name -> field.dataType))
+          st.fields.foreach { field =>
+            fieldQueue.enqueue(fieldName + "." + field.name -> field.dataType)
+          }
         // if it is not a struct, the field has already been added to the set
         case _ =>
       }

--- a/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
@@ -333,12 +333,16 @@ object Preconditions {
 
     while(fieldQueue.nonEmpty) {
       val (fieldName, dataType) = fieldQueue.dequeue()
+
+      // add current fieldName
+      fieldNames.add(fieldName)
+
       dataType match {
-        // nested type
+        // nested type, enqueue all fields in it
         case st: StructType =>
           st.fields.foreach(field => fieldQueue.enqueue(fieldName + "." + field.name -> field.dataType))
-        // for all other types, use the fieldName as is
-        case _ => fieldNames.add(fieldName)
+        // if it is not a struct, the field has already been added to the set
+        case _ =>
       }
     }
 

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -395,6 +395,7 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
       val check =
         Check(CheckLevel.Warning, "Nested Data")
           .isComplete("name")
+          .isComplete("location")
           .hasCompleteness("location.city.name", _ == 0.5)
           .isComplete("location.city.zip")
           .isComplete("location.country")

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
@@ -758,6 +758,7 @@ class AnalyzerTests extends WordSpec with Matchers with SparkContextSpec with Fi
       val nestedDf = getDfWithNestedSchema(spark)
 
       noException should be thrownBy hasColumn("name")(nestedDf.schema)
+      noException should be thrownBy hasColumn("location")(nestedDf.schema)
       noException should be thrownBy hasColumn("location.city.name")(nestedDf.schema)
       noException should be thrownBy hasColumn("location.city.zip")(nestedDf.schema)
       noException should be thrownBy hasColumn("location.country")(nestedDf.schema)

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
@@ -17,6 +17,7 @@
 package com.amazon.deequ
 package analyzers
 
+import com.amazon.deequ.analyzers.Preconditions.hasColumn
 import com.amazon.deequ.analyzers.runners.NoSuchColumnException
 import com.amazon.deequ.metrics.{Distribution, DistributionValue, DoubleMetric, Entity}
 import com.amazon.deequ.utils.AssertionUtils.TryUtils
@@ -657,7 +658,6 @@ class AnalyzerTests extends WordSpec with Matchers with SparkContextSpec with Fi
     }
   }
 
-
   "Pattern compliance analyzer" should {
     val someColumnName = "some"
 
@@ -750,6 +750,17 @@ class AnalyzerTests extends WordSpec with Matchers with SparkContextSpec with Fi
         maybeSSN.map(Row(_)): _*)
       val analyzer = PatternMatch(someColumnName, Patterns.SOCIAL_SECURITY_NUMBER_US)
       analyzer.calculate(df).value shouldBe Success(2.0 / 8.0)
+    }
+  }
+
+  "Precondition column naming" should {
+    "support nested schemas" in withSparkSession { spark =>
+      val nestedDf = getDfWithNestedSchema(spark)
+
+      noException should be thrownBy hasColumn("name")(nestedDf.schema)
+      noException should be thrownBy hasColumn("location.city.name")(nestedDf.schema)
+      noException should be thrownBy hasColumn("location.city.zip")(nestedDf.schema)
+      noException should be thrownBy hasColumn("location.country")(nestedDf.schema)
     }
   }
 }

--- a/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
+++ b/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
@@ -16,8 +16,9 @@
 
 package com.amazon.deequ.utils
 
-import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+
 import scala.util.Random
 
 
@@ -265,5 +266,29 @@ trait FixtureSupport {
       "ccc",
       "dddd"
     ).toDF("att1")
+  }
+
+  def getDfWithNestedSchema(sparkSession: SparkSession): DataFrame = {
+    val schema = StructType(
+      Seq(
+        StructField("name", StringType),
+        StructField("location",
+          StructType(
+            Seq(
+              StructField("city",
+                StructType(Seq(StructField("name", StringType), StructField("zip", StringType)))),
+              StructField("country", StringType)
+            )
+          )
+        )
+      )
+    )
+
+    val data = sparkSession.sparkContext.parallelize(Seq(
+      Row("Lisa", Row(Row(null, "87348"), "DE")),
+      Row("Paul", Row(Row("NYC", "10033"), "US"))
+    ))
+
+    sparkSession.createDataFrame(data, schema)
   }
 }


### PR DESCRIPTION
*Description of changes:*

Prior to this change running checks against nested columns (with `some.column`) would falsely report a missing column and fail the check. With this change, checks can be run against data with nested schemas.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
