### PR TITLE
Adjusted name for count column in Histogram

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/Histogram.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Histogram.scala
@@ -64,6 +64,7 @@ case class Histogram(
     .na.fill(Histogram.NullFieldReplacement)
     .groupBy(column)
     .count()
+    .withColumnRenamed("count", Analyzers.COUNT_COL)
 
     Some(FrequenciesAndNumRows(frequencies, totalCount))
   }

--- a/src/main/scala/com/amazon/deequ/examples/ExampleUtils.scala
+++ b/src/main/scala/com/amazon/deequ/examples/ExampleUtils.scala
@@ -18,7 +18,7 @@ package com.amazon.deequ.examples
 
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
-private[examples] object ExampleUtils {
+private[deequ] object ExampleUtils {
 
   def withSpark(func: SparkSession => Unit): Unit = {
     val session = SparkSession.builder()

--- a/src/main/scala/com/amazon/deequ/examples/entities.scala
+++ b/src/main/scala/com/amazon/deequ/examples/entities.scala
@@ -16,7 +16,7 @@
 
 package com.amazon.deequ.examples
 
-private[examples] case class Item(
+private[deequ] case class Item(
     id: Long,
     productName: String,
     description: String,
@@ -24,7 +24,7 @@ private[examples] case class Item(
     numViews: Long
 )
 
-private[examples] case class Manufacturer(
+private[deequ] case class Manufacturer(
     id: Long,
     manufacturerName: String,
     countryCode: String

--- a/src/test/scala/com/amazon/deequ/analyzers/StateAggregationIntegrationTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/StateAggregationIntegrationTest.scala
@@ -19,6 +19,7 @@ package com.amazon.deequ.analyzers
 import com.amazon.deequ.{SparkContextSpec, VerificationSuite}
 import com.amazon.deequ.analyzers.runners.AnalysisRunner
 import com.amazon.deequ.checks.{Check, CheckLevel}
+import com.amazon.deequ.examples.{ExampleUtils, Item}
 import com.amazon.deequ.utils.FixtureSupport
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
@@ -244,6 +245,22 @@ class StateAggregationIntegrationTest extends WordSpec with Matchers with SparkC
         Seq(statesNA, statesEU, statesIN))
 
       assert(resultsFromStates == resultsDirect)
+    }
+
+    "not throw errors for the example from https://github.com/awslabs/deequ/issues/189" in withSparkSession { session =>
+
+      val data = ExampleUtils.itemsAsDataframe(session,
+        Item(1, "Thingy A", "awesome thing.", "high", 0),
+        Item(2, "Thingy B", "available at http://thingb.com", null, 0),
+        Item(3, null, null, "low", 5),
+        Item(4, "Thingy D", "checkout https://thingd.ca", "low", 10),
+        Item(5, "Thingy E", null, "high", 12))
+
+      val histogramOne = Histogram("id").computeStateFrom(data).get
+      val histogramTwo = Histogram("id").computeStateFrom(data).get
+
+      histogramOne.sum(histogramTwo)
+
     }
 
   }

--- a/src/test/scala/com/amazon/deequ/analyzers/StateAggregationIntegrationTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/StateAggregationIntegrationTest.scala
@@ -247,7 +247,7 @@ class StateAggregationIntegrationTest extends WordSpec with Matchers with SparkC
       assert(resultsFromStates == resultsDirect)
     }
 
-    "not throw errors for the example from https://github.com/awslabs/deequ/issues/189" in withSparkSession { session =>
+    "not throw errors for the example from DEEQU-189" in withSparkSession { session =>
 
       val data = ExampleUtils.itemsAsDataframe(session,
         Item(1, "Thingy A", "awesome thing.", "high", 0),


### PR DESCRIPTION
This fixes a wrong column name in Histogram as outlined in https://github.com/awslabs/deequ/issues/189




By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
