### PR TITLE
Determine any data completeness over a set of columns

### DIFF
--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -169,8 +169,8 @@ case class Check(
    * @return
    */
   def areAnyComplete(
-                   columns: Seq[String],
-                   hint: Option[String] = None)
+      columns: Seq[String],
+      hint: Option[String] = None)
   : CheckWithLastConstraintFilterable = {
     satisfies(isAnyNotNull(columns), "Any Completeness", Check.IsOne, hint)
   }
@@ -184,9 +184,9 @@ case class Check(
    * @return
    */
   def haveAnyCompleteness(
-                        columns: Seq[String],
-                        assertion: Double => Boolean,
-                        hint: Option[String] = None)
+      columns: Seq[String],
+      assertion: Double => Boolean,
+      hint: Option[String] = None)
   : CheckWithLastConstraintFilterable = {
     satisfies(isAnyNotNull(columns), "Any Completeness", assertion, hint)
   }

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -25,7 +25,7 @@ import com.amazon.deequ.metrics.{BucketDistribution, Distribution, Metric}
 import com.amazon.deequ.repository.MetricsRepository
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import com.amazon.deequ.anomalydetection.HistoryUtils
-import com.amazon.deequ.checks.ColumnCondition.isEachNotNull
+import com.amazon.deequ.checks.ColumnCondition.{isEachNotNull, isAnyNotNull}
 
 import scala.util.matching.Regex
 
@@ -159,6 +159,36 @@ case class Check(
       hint: Option[String] = None)
     : CheckWithLastConstraintFilterable = {
     satisfies(isEachNotNull(columns), "Combined Completeness", assertion, hint)
+  }
+
+  /**
+   * Creates a constraint that asserts on completion in combined set of columns.
+   *
+   * @param columns Columns to run the assertion on
+   * @param hint A hint to provide additional context why a constraint could have failed
+   * @return
+   */
+  def areAnyComplete(
+                   columns: Seq[String],
+                   hint: Option[String] = None)
+  : CheckWithLastConstraintFilterable = {
+    satisfies(isAnyNotNull(columns), "Any Completeness", Check.IsOne, hint)
+  }
+
+  /**
+   * Creates a constraint that assert on completion in combined set of columns.
+   *
+   * @param columns Columns to run the assertion on
+   * @param assertion Function that receives a double input parameter and returns a boolean
+   * @param hint A hint to provide additional context why a constraint could have failed
+   * @return
+   */
+  def haveAnyCompleteness(
+                        columns: Seq[String],
+                        assertion: Double => Boolean,
+                        hint: Option[String] = None)
+  : CheckWithLastConstraintFilterable = {
+    satisfies(isAnyNotNull(columns), "Any Completeness", assertion, hint)
   }
 
   /**

--- a/src/main/scala/com/amazon/deequ/checks/ColumnCondition.scala
+++ b/src/main/scala/com/amazon/deequ/checks/ColumnCondition.scala
@@ -1,22 +1,21 @@
 /**
- * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License"). You may not
- * use this file except in compliance with the License. A copy of the License
- * is located at
- *
- *     http://aws.amazon.com/apache2.0/
- *
- * or in the "license" file accompanying this file. This file is distributed on
- * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
- *
- */
-
+  * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+  * use this file except in compliance with the License. A copy of the License
+  * is located at
+  *
+  *     http://aws.amazon.com/apache2.0/
+  *
+  * or in the "license" file accompanying this file. This file is distributed on
+  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  * express or implied. See the License for the specific language governing
+  * permissions and limitations under the License.
+  *
+  */
 package com.amazon.deequ.checks
 
-import org.apache.spark.sql.functions.{col}
+import org.apache.spark.sql.functions.col
 
 private[checks] object ColumnCondition {
 
@@ -24,6 +23,13 @@ private[checks] object ColumnCondition {
     cols
       .map(col(_).isNotNull)
       .reduce(_ and _)
+      .toString()
+  }
+
+  def isAnyNotNull(cols: Seq[String]): String = {
+    cols
+      .map(col(_).isNotNull)
+      .reduce(_ or _)
       .toString()
   }
 }

--- a/src/main/scala/com/amazon/deequ/checks/ColumnCondition.scala
+++ b/src/main/scala/com/amazon/deequ/checks/ColumnCondition.scala
@@ -13,9 +13,10 @@
  * permissions and limitations under the License.
  *
  */
+
 package com.amazon.deequ.checks
 
-import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions.{col}
 
 private[checks] object ColumnCondition {
 

--- a/src/main/scala/com/amazon/deequ/checks/ColumnCondition.scala
+++ b/src/main/scala/com/amazon/deequ/checks/ColumnCondition.scala
@@ -1,18 +1,18 @@
 /**
-  * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
-  *
-  * Licensed under the Apache License, Version 2.0 (the "License"). You may not
-  * use this file except in compliance with the License. A copy of the License
-  * is located at
-  *
-  *     http://aws.amazon.com/apache2.0/
-  *
-  * or in the "license" file accompanying this file. This file is distributed on
-  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
-  * express or implied. See the License for the specific language governing
-  * permissions and limitations under the License.
-  *
-  */
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
 package com.amazon.deequ.checks
 
 import org.apache.spark.sql.functions.col

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -84,6 +84,29 @@ class CheckTest extends WordSpec with Matchers with SparkContextSpec with Fixtur
         assertEvaluatesTo(check3, context, CheckStatus.Warning)
     }
 
+    "return the correct check status for any completeness" in
+      withSparkSession { sparkSession =>
+
+        val check1 = Check(CheckLevel.Error, "group-1")
+          .areAnyComplete(Seq("item", "att1")) // 1.0
+          .haveAnyCompleteness(Seq("item", "att1"), _ == 1.0) // 1.0
+
+        val check2 = Check(CheckLevel.Error, "group-2-E")
+          .haveAnyCompleteness(Seq("att1", "att2"), _ > 0.917) // 11/12 (0.91666)
+
+        val check3 = Check(CheckLevel.Warning, "group-2-W")
+          .haveAnyCompleteness(Seq("att1", "att2"), _ > 0.917) // 11/12 (0.91666)
+
+        val context = runChecks(getDfMissing(sparkSession),
+          check1, check2, check3)
+
+        context.metricMap.foreach { println }
+
+        assertEvaluatesTo(check1, context, CheckStatus.Success)
+        assertEvaluatesTo(check2, context, CheckStatus.Error)
+        assertEvaluatesTo(check3, context, CheckStatus.Warning)
+      }
+
     "return the correct check status for uniqueness" in withSparkSession { sparkSession =>
 
       val check = Check(CheckLevel.Error, "group-1")

--- a/src/test/scala/com/amazon/deequ/checks/ColumnConditionTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/ColumnConditionTest.scala
@@ -28,6 +28,13 @@ class ColumnConditionTest extends WordSpec {
         "(((att1 IS NOT NULL) AND (att2 IS NOT NULL)) AND (att3 IS NOT NULL))"
       )
     }
+
+    "return the correct isAnyNotNull condition" in {
+      assert(
+        ColumnCondition.isAnyNotNull(Seq("att1", "att2", "att3")) ==
+          "(((att1 IS NOT NULL) OR (att2 IS NOT NULL)) OR (att3 IS NOT NULL))"
+      )
+    }
   }
 
 }


### PR DESCRIPTION
*Issue #, if available:*
#220 

*Description of changes:*
Adds isAnyNotNull ColumnCondition which allows checking for if data exist in a set of columns. Example use case would be mutually exclusive data in a denormalized table populated with nulls for the column without data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
