### PR TITLE
Fix duplicate analyzer for AnalysisRunner

### DIFF
--- a/src/main/scala/com/amazon/deequ/VerificationSuite.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationSuite.scala
@@ -116,7 +116,7 @@ class VerificationSuite {
         VerificationFileOutputOptions())
     : VerificationResult = {
 
-    val analyzers = requiredAnalyzers ++ checks.flatMap { _.requiredAnalyzers() }
+    val analyzers = (requiredAnalyzers ++ checks.flatMap { _.requiredAnalyzers() }).distinct
 
     val analysisResults = AnalysisRunner.doAnalysisRun(
       data,

--- a/src/main/scala/com/amazon/deequ/VerificationSuite.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationSuite.scala
@@ -116,7 +116,7 @@ class VerificationSuite {
         VerificationFileOutputOptions())
     : VerificationResult = {
 
-    val analyzers = (requiredAnalyzers ++ checks.flatMap { _.requiredAnalyzers() }).distinct
+    val analyzers = requiredAnalyzers ++ checks.flatMap { _.requiredAnalyzers() }
 
     val analysisResults = AnalysisRunner.doAnalysisRun(
       data,

--- a/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
@@ -111,9 +111,9 @@ object AnalysisRunner {
     }
 
     val allAnalyzers = analyzers.map { _.asInstanceOf[Analyzer[State[_], Metric[_]]] }
-    val distinctAnalyzer = allAnalyzers.distinct
-    require(distinctAnalyzer.size == allAnalyzers.size,
-      s"Duplicate analyzers found: ${allAnalyzers.diff(distinctAnalyzer).distinct}")
+    val distinctAnalyzers = allAnalyzers.distinct
+    require(distinctAnalyzers.size == allAnalyzers.size,
+      s"Duplicate analyzers found: ${allAnalyzers.diff(distinctAnalyzers).distinct}")
 
     /* We do not want to recalculate calculated metrics in the MetricsRepository */
     val resultsComputedPreviously: AnalyzerContext =

--- a/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
@@ -111,6 +111,9 @@ object AnalysisRunner {
     }
 
     val allAnalyzers = analyzers.map { _.asInstanceOf[Analyzer[State[_], Metric[_]]] }
+    val distinctAnalyzer = allAnalyzers.distinct
+    require(distinctAnalyzer.size == allAnalyzers.size,
+      s"Duplicate analyzers found: ${allAnalyzers.diff(distinctAnalyzer).distinct}")
 
     /* We do not want to recalculate calculated metrics in the MetricsRepository */
     val resultsComputedPreviously: AnalyzerContext =

--- a/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
@@ -339,7 +339,7 @@ object AnalysisRunner {
 
     /* Run non-shareable analyzers separately */
     val otherMetrics = others
-      .map { analyzer => analyzer -> analyzer.calculate(data) }
+      .map { analyzer => analyzer -> analyzer.calculate(data, aggregateWith, saveStatesTo) }
       .toMap[Analyzer[_, Metric[_]], Metric[_]]
 
     sharedResults ++ AnalyzerContext(otherMetrics)

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalysisTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalysisTest.scala
@@ -54,19 +54,6 @@ class AnalysisTest extends WordSpec with Matchers with SparkContextSpec with Fix
       assertSameRows(successMetricsAsDataFrame, expected)
     }
 
-    "run an individual analyzer only once" in withSparkSession { sparkSession =>
-      val df = getDfFull(sparkSession)
-
-      val analysis = Analysis()
-        .addAnalyzer(Size())
-        .addAnalyzer(Size())
-        .addAnalyzer(Size())
-
-      val analysisResult = analysis.run(df)
-      assert(analysisResult.allMetrics.length == 1)
-      assert(analysisResult.metric(Size()).get.value.get == 4)
-    }
-
     "return basic statistics" in withSparkSession { sparkSession =>
       val df = getDfWithNumericValues(sparkSession)
 

--- a/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
@@ -348,16 +348,24 @@ class AnalysisRunnerTests extends WordSpec with Matchers with SparkContextSpec w
 
       val analyzers = Size() :: Completeness("item") :: Size() :: Nil
 
-      try {
+      intercept[IllegalArgumentException] {
         AnalysisRunner.onData(df)
           .addAnalyzers(analyzers)
           .useSparkSession(sparkSession)
           .run()
-        assert(false)
-      } catch {
-        case error: IllegalArgumentException =>
-          assert(true)
       }
+    }
+
+    "should not give error for different analyzers with filtering options" in withSparkSession{ sparkSession =>
+      val df = getDfWithNumericValues(sparkSession)
+      val analyzers = Size() :: Size(Some("att1 = 0")) :: Size(Some("att2 > 0")) :: Nil
+
+      AnalysisRunner.onData(df)
+        .addAnalyzers(analyzers)
+        .useSparkSession(sparkSession)
+        .run()
+
+      assert(true)
     }
   }
 }

--- a/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
@@ -356,16 +356,17 @@ class AnalysisRunnerTests extends WordSpec with Matchers with SparkContextSpec w
       }
     }
 
-    "should not give error for different analyzers with filtering options" in withSparkSession{ sparkSession =>
+    "should not give error for different analyzers with filtering options" in withSparkSession {
+      sparkSession =>
       val df = getDfWithNumericValues(sparkSession)
       val analyzers = Size() :: Size(Some("att1 = 0")) :: Size(Some("att2 > 0")) :: Nil
 
-      AnalysisRunner.onData(df)
-        .addAnalyzers(analyzers)
-        .useSparkSession(sparkSession)
-        .run()
-
-      assert(true)
+      noException shouldBe thrownBy {
+        AnalysisRunner.onData(df)
+          .addAnalyzers(analyzers)
+          .useSparkSession(sparkSession)
+          .run()
+      }
     }
   }
 }

--- a/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
@@ -341,5 +341,23 @@ class AnalysisRunnerTests extends WordSpec with Matchers with SparkContextSpec w
         inputStream => assert(inputStream.read() > 0)
       }
     }
+
+    "should give error for duplicate analyzers" in withSparkSession { sparkSession =>
+
+      val df = getDfWithNumericValues(sparkSession)
+
+      val analyzers = Size() :: Completeness("item") :: Size() :: Nil
+
+      try {
+        AnalysisRunner.onData(df)
+          .addAnalyzers(analyzers)
+          .useSparkSession(sparkSession)
+          .run()
+        assert(false)
+      } catch {
+        case error: IllegalArgumentException =>
+          assert(true)
+      }
+    }
   }
 }


### PR DESCRIPTION
*Issue #, if available:* #227 

*Description of changes:*

For AnalysisRunner, now if user gives duplicates analyzers, then it will throw error with list of analyzers which were causing them

In VerificationSuite, as discussed in issue there is case when user can add "Checks" + "RequiredAnalyzer" because of which it creates analyzers list with duplicates and we can't stop it from user side so we take distinct values of it

In AnalysisTest, there was one test case which will fail because of this change hence removed and added new one

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
