### PR TITLE
Repositories to use AnalyzerId instead of Analyzer

### DIFF
--- a/src/main/scala/com/amazon/deequ/VerificationResult.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationResult.scala
@@ -16,12 +16,13 @@
 
 package com.amazon.deequ
 
-import com.amazon.deequ.analyzers.{Analyzer, AnalyzerId}
+import com.amazon.deequ.analyzers.{Analyzer, AnalyzerName}
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
+import com.amazon.deequ.analyzers.runners.AnalyzerContext.SimpleMetricOutput
 import com.amazon.deequ.checks.{Check, CheckResult, CheckStatus}
 import com.amazon.deequ.metrics.Metric
 import com.amazon.deequ.repository.SimpleResultSerde
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 
 /**
   * The result returned from the VerificationSuite
@@ -33,15 +34,14 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 case class VerificationResult(
     status: CheckStatus.Value,
     checkResults: Map[Check, CheckResult],
-    metrics: Map[AnalyzerId, Metric[_]])
+    metrics: Map[AnalyzerName, Metric[_]])
 
 object VerificationResult {
 
   def successMetricsAsDataFrame(
       sparkSession: SparkSession,
       verificationResult: VerificationResult,
-      forAnalyzers: Seq[Analyzer[_, Metric[_]]] = Seq.empty)
-    : DataFrame = {
+      forAnalyzers: Seq[Analyzer[_, Metric[_]]] = Seq.empty): Dataset[SimpleMetricOutput] = {
 
     val metricsAsAnalyzerContext = AnalyzerContext(verificationResult.metrics)
 

--- a/src/main/scala/com/amazon/deequ/VerificationResult.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationResult.scala
@@ -16,7 +16,7 @@
 
 package com.amazon.deequ
 
-import com.amazon.deequ.analyzers.Analyzer
+import com.amazon.deequ.analyzers.{Analyzer, AnalyzerId}
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
 import com.amazon.deequ.checks.{Check, CheckResult, CheckStatus}
 import com.amazon.deequ.metrics.Metric
@@ -33,7 +33,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
 case class VerificationResult(
     status: CheckStatus.Value,
     checkResults: Map[Check, CheckResult],
-    metrics: Map[Analyzer[_, Metric[_]], Metric[_]])
+    metrics: Map[AnalyzerId, Metric[_]])
 
 object VerificationResult {
 

--- a/src/main/scala/com/amazon/deequ/VerificationResult.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationResult.scala
@@ -16,7 +16,7 @@
 
 package com.amazon.deequ
 
-import com.amazon.deequ.analyzers.{Analyzer, AnalyzerName}
+import com.amazon.deequ.analyzers.{Analyzer, AnalyzerId}
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
 import com.amazon.deequ.analyzers.runners.AnalyzerContext.SimpleMetricOutput
 import com.amazon.deequ.checks.{Check, CheckResult, CheckStatus}
@@ -34,7 +34,7 @@ import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 case class VerificationResult(
     status: CheckStatus.Value,
     checkResults: Map[Check, CheckResult],
-    metrics: Map[AnalyzerName, Metric[_]])
+    metrics: Map[AnalyzerId, Metric[_]])
 
 object VerificationResult {
 

--- a/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
@@ -16,6 +16,7 @@
 
 package com.amazon.deequ.analyzers
 
+import com.amazon.deequ.analyzers.AnalyzerName.AnalyzerName
 import com.amazon.deequ.analyzers.Analyzers._
 import com.amazon.deequ.metrics.{DoubleMetric, Entity, Metric}
 import org.apache.spark.sql.functions._
@@ -52,8 +53,24 @@ trait DoubleValuedState[S <: DoubleValuedState[S]] extends State[S] {
   def metricValue(): Double
 }
 
+/** Data type instances */
+object AnalyzerName extends Enumeration {
+
+  type AnalyzerName = Value
+  val Histogram, Size, DataType, ApproxCountDistinct, Completeness, Mean, StandardDeviation, Maximum, Minimum, Sum,
+  KLLSketch = Value
+}
+
+case class AnalyzerId(name: AnalyzerName, instance: String)
+
 /** Common trait for all analyzers which generates metrics from states computed on data frames */
 trait Analyzer[S <: State[_], +M <: Metric[_]] {
+
+  def id = AnalyzerId(name, instance)
+
+  def name: AnalyzerName = AnalyzerName.Histogram // TODO: Remove this and implement in sub-typed
+
+  def instance: String = "" // TODO: Remove this and implement in sub-typed
 
   /**
     * Compute the state (sufficient statistics) from the data

--- a/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
@@ -52,42 +52,42 @@ trait DoubleValuedState[S <: DoubleValuedState[S]] extends State[S] {
   def metricValue(): Double
 }
 
-sealed trait AnalyzerName {
+sealed trait AnalyzerId {
   def name: String = productPrefix
   protected def productPrefix: String
 }
 
-object AnalyzerName {
-  sealed trait Filterable extends AnalyzerName {
+object AnalyzerId {
+  sealed trait Filterable extends AnalyzerId {
     def filterCondition: Option[String]
   }
-  sealed trait SingleColumn extends AnalyzerName {
+  sealed trait SingleColumn extends AnalyzerId {
     def column: String
   }
-  sealed trait MultiColumn extends AnalyzerName {
+  sealed trait MultiColumn extends AnalyzerId {
     def columns: Seq[String]
   }
-  sealed trait Binned extends AnalyzerName {
+  sealed trait Binned extends AnalyzerId {
     def maxDetailBins: Int
   }
-  sealed trait InstanceBased extends AnalyzerName {
+  sealed trait InstanceBased extends AnalyzerId {
     def instance: String
   }
-  sealed trait PredicateBased extends AnalyzerName {
+  sealed trait PredicateBased extends AnalyzerId {
     def predicate: String
   }
-  sealed trait PatternBased extends AnalyzerName {
+  sealed trait PatternBased extends AnalyzerId {
     def pattern: String
   }
-  sealed trait TwoColumn extends AnalyzerName {
+  sealed trait TwoColumn extends AnalyzerId {
     def column1: String
     def column2: String
   }
-  sealed trait Quantile extends AnalyzerName {
+  sealed trait Quantile extends AnalyzerId {
     def quantile: Double
     def relativeError: Double
   }
-  sealed trait Quantiles extends AnalyzerName {
+  sealed trait Quantiles extends AnalyzerId {
     def quantiles: Seq[Double]
     def relativeError: Double
   }
@@ -124,7 +124,7 @@ object AnalyzerName {
   case class Correlation(column1: String, column2: String, filterCondition: Option[String]) extends Filterable with TwoColumn
 
   // Analyzer names with a column parameter
-  case class KLLSketch(column: String) extends AnalyzerName
+  case class KLLSketch(column: String) extends AnalyzerId
 
   case class ApproxQuantiles(column: String, quantiles: Seq[Double], relativeError: Double) extends SingleColumn with Quantiles
   // Grouping Analyzer Names
@@ -134,14 +134,18 @@ object AnalyzerName {
   case class Compliance(instance: String, filterCondition: Option[String], predicate: String) extends Filterable with InstanceBased with PredicateBased
 
   // Custom Analyzer Name to enable extensibility
-  case class CustomAnalyzerName[T](override val name: String, instance: T) extends AnalyzerName
+  case class CustomAnalyzerId[T](override val name: String, instance: T) extends AnalyzerId
 
 }
 
 /** Common trait for all analyzers which generates metrics from states computed on data frames */
 trait Analyzer[S <: State[_], +M <: Metric[_]] {
 
-  def name: AnalyzerName
+  /**
+   * Identifier for the Analyzer
+   * @return
+   */
+  def id: AnalyzerId
 
   /**
     * Compute the state (sufficient statistics) from the data

--- a/src/main/scala/com/amazon/deequ/analyzers/ApproxCountDistinct.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/ApproxCountDistinct.scala
@@ -65,5 +65,5 @@ case class ApproxCountDistinct(column: String, where: Option[String] = None)
 
   override def filterCondition: Option[String] = where
 
-  override def name: AnalyzerName = AnalyzerName.ApproxCountDistinct(column, filterCondition)
+  override def id: AnalyzerId = AnalyzerId.ApproxCountDistinct(column, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/ApproxCountDistinct.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/ApproxCountDistinct.scala
@@ -64,4 +64,6 @@ case class ApproxCountDistinct(column: String, where: Option[String] = None)
   }
 
   override def filterCondition: Option[String] = where
+
+  override def name: AnalyzerName = AnalyzerName.ApproxCountDistinct(column, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/ApproxQuantile.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/ApproxQuantile.scala
@@ -55,6 +55,8 @@ case class ApproxQuantile(
   extends ScanShareableAnalyzer[ApproxQuantileState, DoubleMetric]
   with FilterableAnalyzer {
 
+  override def name: AnalyzerName = AnalyzerName.ApproxQuantile(column, filterCondition, quantile, relativeError)
+
   val PARAM_CHECKS: StructType => Unit = { _ =>
     if (quantile < 0.0 || quantile > 1.0) {
       throw new IllegalAnalyzerParameterException(MetricCalculationException

--- a/src/main/scala/com/amazon/deequ/analyzers/ApproxQuantile.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/ApproxQuantile.scala
@@ -55,7 +55,7 @@ case class ApproxQuantile(
   extends ScanShareableAnalyzer[ApproxQuantileState, DoubleMetric]
   with FilterableAnalyzer {
 
-  override def name: AnalyzerName = AnalyzerName.ApproxQuantile(column, filterCondition, quantile, relativeError)
+  override def id: AnalyzerId = AnalyzerId.ApproxQuantile(column, filterCondition, quantile, relativeError)
 
   val PARAM_CHECKS: StructType => Unit = { _ =>
     if (quantile < 0.0 || quantile > 1.0) {

--- a/src/main/scala/com/amazon/deequ/analyzers/ApproxQuantiles.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/ApproxQuantiles.scala
@@ -39,7 +39,7 @@ import scala.util.{Failure, Success}
 case class ApproxQuantiles(column: String, quantiles: Seq[Double], relativeError: Double = 0.01)
   extends ScanShareableAnalyzer[ApproxQuantileState, KeyedDoubleMetric] {
 
-  override def name: AnalyzerName = AnalyzerName.ApproxQuantiles(column, quantiles, relativeError)
+  override def id: AnalyzerId = AnalyzerId.ApproxQuantiles(column, quantiles, relativeError)
 
   val PARAM_CHECKS: StructType => Unit = { _ =>
     quantiles.foreach { quantile =>

--- a/src/main/scala/com/amazon/deequ/analyzers/ApproxQuantiles.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/ApproxQuantiles.scala
@@ -39,6 +39,8 @@ import scala.util.{Failure, Success}
 case class ApproxQuantiles(column: String, quantiles: Seq[Double], relativeError: Double = 0.01)
   extends ScanShareableAnalyzer[ApproxQuantileState, KeyedDoubleMetric] {
 
+  override def name: AnalyzerName = AnalyzerName.ApproxQuantiles(column, quantiles, relativeError)
+
   val PARAM_CHECKS: StructType => Unit = { _ =>
     quantiles.foreach { quantile =>
       if (quantile < 0.0 || quantile > 1.0) {

--- a/src/main/scala/com/amazon/deequ/analyzers/Completeness.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Completeness.scala
@@ -47,5 +47,5 @@ case class Completeness(column: String, where: Option[String] = None) extends
 
   override def filterCondition: Option[String] = where
 
-  override def name: AnalyzerName = AnalyzerName.Completeness(column, filterCondition)
+  override def id: AnalyzerId = AnalyzerId.Completeness(column, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Completeness.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Completeness.scala
@@ -46,4 +46,6 @@ case class Completeness(column: String, where: Option[String] = None) extends
   }
 
   override def filterCondition: Option[String] = where
+
+  override def name: AnalyzerName = AnalyzerName.Completeness(column, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Compliance.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Compliance.scala
@@ -54,5 +54,5 @@ case class Compliance(instance: String, predicate: String, where: Option[String]
 
   override def filterCondition: Option[String] = where
 
-  override def name: AnalyzerName = AnalyzerName.Compliance(instance, filterCondition, predicate)
+  override def id: AnalyzerId = AnalyzerId.Compliance(instance, filterCondition, predicate)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Compliance.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Compliance.scala
@@ -34,7 +34,7 @@ import Analyzers._
   * @param predicate SQL-predicate to apply per row
   * @param where Additional filter to apply before the analyzer is run.
   */
-case class Compliance(override val instance: String, predicate: String, where: Option[String] = None)
+case class Compliance(instance: String, predicate: String, where: Option[String] = None)
   extends StandardScanShareableAnalyzer[NumMatchesAndCount]("Compliance", instance)
   with FilterableAnalyzer {
 
@@ -53,4 +53,6 @@ case class Compliance(override val instance: String, predicate: String, where: O
   }
 
   override def filterCondition: Option[String] = where
+
+  override def name: AnalyzerName = AnalyzerName.Compliance(instance, filterCondition, predicate)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Compliance.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Compliance.scala
@@ -34,7 +34,7 @@ import Analyzers._
   * @param predicate SQL-predicate to apply per row
   * @param where Additional filter to apply before the analyzer is run.
   */
-case class Compliance(instance: String, predicate: String, where: Option[String] = None)
+case class Compliance(override val instance: String, predicate: String, where: Option[String] = None)
   extends StandardScanShareableAnalyzer[NumMatchesAndCount]("Compliance", instance)
   with FilterableAnalyzer {
 

--- a/src/main/scala/com/amazon/deequ/analyzers/Correlation.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Correlation.scala
@@ -105,4 +105,6 @@ case class Correlation(
   }
 
   override def filterCondition: Option[String] = where
+
+  override def name: AnalyzerName = AnalyzerName.Correlation(firstColumn, secondColumn, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Correlation.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Correlation.scala
@@ -106,5 +106,5 @@ case class Correlation(
 
   override def filterCondition: Option[String] = where
 
-  override def name: AnalyzerName = AnalyzerName.Correlation(firstColumn, secondColumn, filterCondition)
+  override def id: AnalyzerId = AnalyzerId.Correlation(firstColumn, secondColumn, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/CountDistinct.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/CountDistinct.scala
@@ -32,7 +32,7 @@ case class CountDistinct(columns: Seq[String])
     toSuccessMetric(result.getLong(offset).toDouble)
   }
 
-  override def name: AnalyzerName = AnalyzerName.CountDistinct(columns)
+  override def id: AnalyzerId = AnalyzerId.CountDistinct(columns)
 }
 
 object CountDistinct {

--- a/src/main/scala/com/amazon/deequ/analyzers/CountDistinct.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/CountDistinct.scala
@@ -31,6 +31,8 @@ case class CountDistinct(columns: Seq[String])
   override def fromAggregationResult(result: Row, offset: Int): DoubleMetric = {
     toSuccessMetric(result.getLong(offset).toDouble)
   }
+
+  override def name: AnalyzerName = AnalyzerName.CountDistinct(columns)
 }
 
 object CountDistinct {

--- a/src/main/scala/com/amazon/deequ/analyzers/DataType.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/DataType.scala
@@ -183,4 +183,6 @@ case class DataType(
   }
 
   override def filterCondition: Option[String] = where
+
+  override def name: AnalyzerName = AnalyzerName.DataType(column, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/DataType.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/DataType.scala
@@ -184,5 +184,5 @@ case class DataType(
 
   override def filterCondition: Option[String] = where
 
-  override def name: AnalyzerName = AnalyzerName.DataType(column, filterCondition)
+  override def id: AnalyzerId = AnalyzerId.DataType(column, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Distinctness.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Distinctness.scala
@@ -36,7 +36,7 @@ case class Distinctness(columns: Seq[String], where: Option[String] = None)
 
   override def filterCondition: Option[String] = where
 
-  override def name: AnalyzerName = AnalyzerName.Distinctness(columns, filterCondition)
+  override def id: AnalyzerId = AnalyzerId.Distinctness(columns, filterCondition)
 }
 
 object Distinctness {

--- a/src/main/scala/com/amazon/deequ/analyzers/Distinctness.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Distinctness.scala
@@ -35,6 +35,8 @@ case class Distinctness(columns: Seq[String], where: Option[String] = None)
   }
 
   override def filterCondition: Option[String] = where
+
+  override def name: AnalyzerName = AnalyzerName.Distinctness(columns, filterCondition)
 }
 
 object Distinctness {

--- a/src/main/scala/com/amazon/deequ/analyzers/Entropy.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Entropy.scala
@@ -42,4 +42,6 @@ case class Entropy(column: String, where: Option[String] = None)
   }
 
   override def filterCondition: Option[String] = where
+
+  override def name: AnalyzerName = AnalyzerName.Entropy(column, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Entropy.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Entropy.scala
@@ -43,5 +43,5 @@ case class Entropy(column: String, where: Option[String] = None)
 
   override def filterCondition: Option[String] = where
 
-  override def name: AnalyzerName = AnalyzerName.Entropy(column, filterCondition)
+  override def id: AnalyzerId = AnalyzerId.Entropy(column, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Histogram.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Histogram.scala
@@ -121,7 +121,7 @@ case class Histogram(
     }
   }
 
-  override def name: AnalyzerName = AnalyzerName.Histogram(column, filterCondition, maxDetailBins)
+  override def id: AnalyzerId = AnalyzerId.Histogram(column, filterCondition, maxDetailBins)
 }
 
 object Histogram {

--- a/src/main/scala/com/amazon/deequ/analyzers/Histogram.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Histogram.scala
@@ -120,6 +120,8 @@ case class Histogram(
       case _ => data
     }
   }
+
+  override def name: AnalyzerName = AnalyzerName.Histogram(column, filterCondition, maxDetailBins)
 }
 
 object Histogram {

--- a/src/main/scala/com/amazon/deequ/analyzers/KLLSketch.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/KLLSketch.scala
@@ -167,6 +167,8 @@ case class KLLSketch(
   override def preconditions(): Seq[StructType => Unit] = {
     PARAM_CHECK :: hasColumn(column) :: isNumeric(column) :: Nil
   }
+
+  override def name: AnalyzerName = AnalyzerName.KLLSketch(column)
 }
 
 object KLLSketch {

--- a/src/main/scala/com/amazon/deequ/analyzers/KLLSketch.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/KLLSketch.scala
@@ -168,7 +168,7 @@ case class KLLSketch(
     PARAM_CHECK :: hasColumn(column) :: isNumeric(column) :: Nil
   }
 
-  override def name: AnalyzerName = AnalyzerName.KLLSketch(column)
+  override def id: AnalyzerId = AnalyzerId.KLLSketch(column)
 }
 
 object KLLSketch {

--- a/src/main/scala/com/amazon/deequ/analyzers/MaxLength.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/MaxLength.scala
@@ -41,4 +41,6 @@ case class MaxLength(column: String, where: Option[String] = None)
   }
 
   override def filterCondition: Option[String] = where
+
+  override def name: AnalyzerName = AnalyzerName.MaxLength(column, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/MaxLength.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/MaxLength.scala
@@ -42,5 +42,5 @@ case class MaxLength(column: String, where: Option[String] = None)
 
   override def filterCondition: Option[String] = where
 
-  override def name: AnalyzerName = AnalyzerName.MaxLength(column, filterCondition)
+  override def id: AnalyzerId = AnalyzerId.MaxLength(column, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Maximum.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Maximum.scala
@@ -53,4 +53,6 @@ case class Maximum(column: String, where: Option[String] = None)
   }
 
   override def filterCondition: Option[String] = where
+
+  override def name: AnalyzerName = AnalyzerName.Maximum(column, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Maximum.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Maximum.scala
@@ -54,5 +54,5 @@ case class Maximum(column: String, where: Option[String] = None)
 
   override def filterCondition: Option[String] = where
 
-  override def name: AnalyzerName = AnalyzerName.Maximum(column, filterCondition)
+  override def id: AnalyzerId = AnalyzerId.Maximum(column, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Mean.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Mean.scala
@@ -54,4 +54,6 @@ case class Mean(column: String, where: Option[String] = None)
   }
 
   override def filterCondition: Option[String] = where
+
+  override def name: AnalyzerName = AnalyzerName.Mean(column, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Mean.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Mean.scala
@@ -55,5 +55,5 @@ case class Mean(column: String, where: Option[String] = None)
 
   override def filterCondition: Option[String] = where
 
-  override def name: AnalyzerName = AnalyzerName.Mean(column, filterCondition)
+  override def id: AnalyzerId = AnalyzerId.Mean(column, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/MinLength.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/MinLength.scala
@@ -42,5 +42,5 @@ case class MinLength(column: String, where: Option[String] = None)
 
   override def filterCondition: Option[String] = where
 
-  override def name: AnalyzerName = AnalyzerName.MinLength(column, filterCondition)
+  override def id: AnalyzerId = AnalyzerId.MinLength(column, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/MinLength.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/MinLength.scala
@@ -41,4 +41,6 @@ case class MinLength(column: String, where: Option[String] = None)
   }
 
   override def filterCondition: Option[String] = where
+
+  override def name: AnalyzerName = AnalyzerName.MinLength(column, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Minimum.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Minimum.scala
@@ -54,5 +54,5 @@ case class Minimum(column: String, where: Option[String] = None)
 
   override def filterCondition: Option[String] = where
 
-  override def name: AnalyzerName = AnalyzerName.Minimum(column, filterCondition)
+  override def id: AnalyzerId = AnalyzerId.Minimum(column, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Minimum.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Minimum.scala
@@ -53,4 +53,6 @@ case class Minimum(column: String, where: Option[String] = None)
   }
 
   override def filterCondition: Option[String] = where
+
+  override def name: AnalyzerName = AnalyzerName.Minimum(column, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/MutualInformation.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/MutualInformation.scala
@@ -97,6 +97,8 @@ case class MutualInformation(columns: Seq[String], where: Option[String] = None)
   }
 
   override def filterCondition: Option[String] = where
+
+  override def name: AnalyzerName = AnalyzerName.MutualInformation(columns, filterCondition)
 }
 
 object MutualInformation {

--- a/src/main/scala/com/amazon/deequ/analyzers/MutualInformation.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/MutualInformation.scala
@@ -98,7 +98,7 @@ case class MutualInformation(columns: Seq[String], where: Option[String] = None)
 
   override def filterCondition: Option[String] = where
 
-  override def name: AnalyzerName = AnalyzerName.MutualInformation(columns, filterCondition)
+  override def id: AnalyzerId = AnalyzerId.MutualInformation(columns, filterCondition)
 }
 
 object MutualInformation {

--- a/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
@@ -61,7 +61,7 @@ case class PatternMatch(column: String, pattern: Regex, where: Option[String] = 
     hasColumn(column) :: isString(column) :: Nil
   }
 
-  override def name: AnalyzerName = AnalyzerName.PatternMatch(column, filterCondition, pattern.toString)
+  override def id: AnalyzerId = AnalyzerId.PatternMatch(column, filterCondition, pattern.toString)
 }
 
 object Patterns {

--- a/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
@@ -60,6 +60,8 @@ case class PatternMatch(column: String, pattern: Regex, where: Option[String] = 
   override protected def additionalPreconditions(): Seq[StructType => Unit] = {
     hasColumn(column) :: isString(column) :: Nil
   }
+
+  override def name: AnalyzerName = AnalyzerName.PatternMatch(column, filterCondition, pattern.toString)
 }
 
 object Patterns {

--- a/src/main/scala/com/amazon/deequ/analyzers/Size.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Size.scala
@@ -48,4 +48,6 @@ case class Size(where: Option[String] = None)
   }
 
   override def filterCondition: Option[String] = where
+
+  override def name: AnalyzerName = AnalyzerName.Size(filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Size.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Size.scala
@@ -49,5 +49,5 @@ case class Size(where: Option[String] = None)
 
   override def filterCondition: Option[String] = where
 
-  override def name: AnalyzerName = AnalyzerName.Size(filterCondition)
+  override def id: AnalyzerId = AnalyzerId.Size(filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/StandardDeviation.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/StandardDeviation.scala
@@ -73,4 +73,6 @@ case class StandardDeviation(column: String, where: Option[String] = None)
   }
 
   override def filterCondition: Option[String] = where
+
+  override def name: AnalyzerName = AnalyzerName.StandardDeviation(column, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/StandardDeviation.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/StandardDeviation.scala
@@ -74,5 +74,5 @@ case class StandardDeviation(column: String, where: Option[String] = None)
 
   override def filterCondition: Option[String] = where
 
-  override def name: AnalyzerName = AnalyzerName.StandardDeviation(column, filterCondition)
+  override def id: AnalyzerId = AnalyzerId.StandardDeviation(column, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Sum.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Sum.scala
@@ -53,5 +53,5 @@ case class Sum(column: String, where: Option[String] = None)
 
   override def filterCondition: Option[String] = where
 
-  override def name: AnalyzerName = AnalyzerName.Sum(column, filterCondition)
+  override def id: AnalyzerId = AnalyzerId.Sum(column, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Sum.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Sum.scala
@@ -52,4 +52,6 @@ case class Sum(column: String, where: Option[String] = None)
   }
 
   override def filterCondition: Option[String] = where
+
+  override def name: AnalyzerName = AnalyzerName.Sum(column, filterCondition)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/UniqueValueRatio.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/UniqueValueRatio.scala
@@ -38,6 +38,8 @@ case class UniqueValueRatio(columns: Seq[String], where: Option[String] = None)
   }
 
   override def filterCondition: Option[String] = where
+
+  override def name: AnalyzerName = AnalyzerName.UniqueValueRatio(columns, filterCondition)
 }
 
 object UniqueValueRatio {

--- a/src/main/scala/com/amazon/deequ/analyzers/UniqueValueRatio.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/UniqueValueRatio.scala
@@ -39,7 +39,7 @@ case class UniqueValueRatio(columns: Seq[String], where: Option[String] = None)
 
   override def filterCondition: Option[String] = where
 
-  override def name: AnalyzerName = AnalyzerName.UniqueValueRatio(columns, filterCondition)
+  override def id: AnalyzerId = AnalyzerId.UniqueValueRatio(columns, filterCondition)
 }
 
 object UniqueValueRatio {

--- a/src/main/scala/com/amazon/deequ/analyzers/Uniqueness.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Uniqueness.scala
@@ -33,7 +33,7 @@ case class Uniqueness(columns: Seq[String], where: Option[String] = None)
 
   override def filterCondition: Option[String] = where
 
-  override def name: AnalyzerName = AnalyzerName.Uniqueness(columns, filterCondition)
+  override def id: AnalyzerId = AnalyzerId.Uniqueness(columns, filterCondition)
 }
 
 object Uniqueness {

--- a/src/main/scala/com/amazon/deequ/analyzers/Uniqueness.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Uniqueness.scala
@@ -32,6 +32,8 @@ case class Uniqueness(columns: Seq[String], where: Option[String] = None)
   }
 
   override def filterCondition: Option[String] = where
+
+  override def name: AnalyzerName = AnalyzerName.Uniqueness(columns, filterCondition)
 }
 
 object Uniqueness {

--- a/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
@@ -127,7 +127,7 @@ object AnalysisRunner {
 
     val analyzersAlreadyRan = resultsComputedPreviously.metricMap.keys.toSet
 
-    val analyzersToRun = allAnalyzers.filterNot(analyzer => analyzersAlreadyRan.contains(analyzer.id))
+    val analyzersToRun = allAnalyzers.filterNot(analyzer => analyzersAlreadyRan.contains(analyzer.name))
 
     /* Throw an error if all needed metrics should have gotten calculated before but did not */
     if (metricsRepositoryOptions.failIfResultsForReusingMissing && analyzersToRun.nonEmpty) {
@@ -260,9 +260,9 @@ object AnalysisRunner {
       val firstException = Preconditions
         .findFirstFailing(schema, analyzer.preconditions).get
 
-      analyzer.id -> analyzer.toFailureMetric(firstException)
+      analyzer.name -> analyzer.toFailureMetric(firstException)
     }
-    .toMap[AnalyzerId, Metric[_]]
+    .toMap[AnalyzerName, Metric[_]]
 
     AnalyzerContext(failures)
   }
@@ -326,24 +326,24 @@ object AnalysisRunner {
         val results = data.agg(aggregations.head, aggregations.tail: _*).collect().head
 
         shareableAnalyzers.zip(offsets).map { case (analyzer, offset) =>
-          analyzer.id ->
+          analyzer.name ->
             successOrFailureMetricFrom(analyzer, results, offset, aggregateWith, saveStatesTo)
         }
 
       } catch {
         case error: Exception =>
-          shareableAnalyzers.map { analyzer => analyzer.id -> analyzer.toFailureMetric(error) }
+          shareableAnalyzers.map { analyzer => analyzer.name -> analyzer.toFailureMetric(error) }
       }
 
-      AnalyzerContext(metricsByAnalyzer.toMap[AnalyzerId, Metric[_]])
+      AnalyzerContext(metricsByAnalyzer.toMap[AnalyzerName, Metric[_]])
     } else {
       AnalyzerContext.empty
     }
 
     /* Run non-shareable analyzers separately */
     val otherMetrics = others
-      .map { analyzer => analyzer.id -> analyzer.calculate(data, aggregateWith, saveStatesTo) }
-      .toMap[AnalyzerId, Metric[_]]
+      .map { analyzer => analyzer.name -> analyzer.calculate(data, aggregateWith, saveStatesTo) }
+      .toMap[AnalyzerName, Metric[_]]
 
     sharedResults ++ AnalyzerContext(otherMetrics)
   }
@@ -444,9 +444,9 @@ object AnalysisRunner {
         /* Store aggregated state if a 'saveStatesWith' has been provided */
         saveStatesWith.foreach { persister => analyzer.copyStateTo(aggregatedStates, persister) }
 
-        metrics.map { metric => analyzer.id -> metric }
+        metrics.map { metric => analyzer.name -> metric }
       }
-      .toMap[AnalyzerId, Metric[_]]
+      .toMap[AnalyzerName, Metric[_]]
 
 
     val groupedResults = if (groupingAnalyzers.isEmpty) {
@@ -528,12 +528,12 @@ object AnalysisRunner {
 
         shareableAnalyzers.zip(offsets)
           .map { case (analyzer, offset) =>
-            analyzer.id -> successOrFailureMetricFrom(analyzer, results, offset)
+            analyzer.name -> successOrFailureMetricFrom(analyzer, results, offset)
           }
       } catch {
         case error: Exception =>
           shareableAnalyzers
-            .map { analyzer => analyzer.id -> analyzer.toFailureMetric(error) }
+            .map { analyzer => analyzer.name -> analyzer.toFailureMetric(error) }
       }
 
     } else {
@@ -544,12 +544,12 @@ object AnalysisRunner {
     val otherMetrics = try {
       others
         .map { _.asInstanceOf[FrequencyBasedAnalyzer] }
-        .map { analyzer => analyzer.id ->
+        .map { analyzer => analyzer.name ->
           analyzer.computeMetricFrom(Option(frequenciesAndNumRows))
         }
     } catch {
       case error: Exception =>
-        others.map { analyzer => analyzer.id -> analyzer.toFailureMetric(error) }
+        others.map { analyzer => analyzer.name -> analyzer.toFailureMetric(error) }
     }
 
     /* Potentially store states */
@@ -557,7 +557,7 @@ object AnalysisRunner {
 
     frequenciesAndNumRows.frequencies.unpersist()
 
-    AnalyzerContext((metricsByAnalyzer ++ otherMetrics).toMap[AnalyzerId, Metric[_]])
+    AnalyzerContext((metricsByAnalyzer ++ otherMetrics).toMap[AnalyzerName, Metric[_]])
   }
 
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
@@ -127,7 +127,7 @@ object AnalysisRunner {
 
     val analyzersAlreadyRan = resultsComputedPreviously.metricMap.keys.toSet
 
-    val analyzersToRun = allAnalyzers.filterNot(analyzersAlreadyRan.contains)
+    val analyzersToRun = allAnalyzers.filterNot(analyzer => analyzersAlreadyRan.contains(analyzer.id))
 
     /* Throw an error if all needed metrics should have gotten calculated before but did not */
     if (metricsRepositoryOptions.failIfResultsForReusingMissing && analyzersToRun.nonEmpty) {
@@ -260,9 +260,9 @@ object AnalysisRunner {
       val firstException = Preconditions
         .findFirstFailing(schema, analyzer.preconditions).get
 
-      analyzer -> analyzer.toFailureMetric(firstException)
+      analyzer.id -> analyzer.toFailureMetric(firstException)
     }
-    .toMap[Analyzer[_, Metric[_]], Metric[_]]
+    .toMap[AnalyzerId, Metric[_]]
 
     AnalyzerContext(failures)
   }
@@ -326,24 +326,24 @@ object AnalysisRunner {
         val results = data.agg(aggregations.head, aggregations.tail: _*).collect().head
 
         shareableAnalyzers.zip(offsets).map { case (analyzer, offset) =>
-          analyzer ->
+          analyzer.id ->
             successOrFailureMetricFrom(analyzer, results, offset, aggregateWith, saveStatesTo)
         }
 
       } catch {
         case error: Exception =>
-          shareableAnalyzers.map { analyzer => analyzer -> analyzer.toFailureMetric(error) }
+          shareableAnalyzers.map { analyzer => analyzer.id -> analyzer.toFailureMetric(error) }
       }
 
-      AnalyzerContext(metricsByAnalyzer.toMap[Analyzer[_, Metric[_]], Metric[_]])
+      AnalyzerContext(metricsByAnalyzer.toMap[AnalyzerId, Metric[_]])
     } else {
       AnalyzerContext.empty
     }
 
     /* Run non-shareable analyzers separately */
     val otherMetrics = others
-      .map { analyzer => analyzer -> analyzer.calculate(data, aggregateWith, saveStatesTo) }
-      .toMap[Analyzer[_, Metric[_]], Metric[_]]
+      .map { analyzer => analyzer.id -> analyzer.calculate(data, aggregateWith, saveStatesTo) }
+      .toMap[AnalyzerId, Metric[_]]
 
     sharedResults ++ AnalyzerContext(otherMetrics)
   }
@@ -444,9 +444,9 @@ object AnalysisRunner {
         /* Store aggregated state if a 'saveStatesWith' has been provided */
         saveStatesWith.foreach { persister => analyzer.copyStateTo(aggregatedStates, persister) }
 
-        metrics.map { metric => analyzer -> metric }
+        metrics.map { metric => analyzer.id -> metric }
       }
-      .toMap[Analyzer[_, Metric[_]], Metric[_]]
+      .toMap[AnalyzerId, Metric[_]]
 
 
     val groupedResults = if (groupingAnalyzers.isEmpty) {
@@ -528,12 +528,12 @@ object AnalysisRunner {
 
         shareableAnalyzers.zip(offsets)
           .map { case (analyzer, offset) =>
-            analyzer -> successOrFailureMetricFrom(analyzer, results, offset)
+            analyzer.id -> successOrFailureMetricFrom(analyzer, results, offset)
           }
       } catch {
         case error: Exception =>
           shareableAnalyzers
-            .map { analyzer => analyzer -> analyzer.toFailureMetric(error) }
+            .map { analyzer => analyzer.id -> analyzer.toFailureMetric(error) }
       }
 
     } else {
@@ -544,12 +544,12 @@ object AnalysisRunner {
     val otherMetrics = try {
       others
         .map { _.asInstanceOf[FrequencyBasedAnalyzer] }
-        .map { analyzer => analyzer ->
+        .map { analyzer => analyzer.id ->
           analyzer.computeMetricFrom(Option(frequenciesAndNumRows))
         }
     } catch {
       case error: Exception =>
-        others.map { analyzer => analyzer -> analyzer.toFailureMetric(error) }
+        others.map { analyzer => analyzer.id -> analyzer.toFailureMetric(error) }
     }
 
     /* Potentially store states */
@@ -557,7 +557,7 @@ object AnalysisRunner {
 
     frequenciesAndNumRows.frequencies.unpersist()
 
-    AnalyzerContext((metricsByAnalyzer ++ otherMetrics).toMap[Analyzer[_, Metric[_]], Metric[_]])
+    AnalyzerContext((metricsByAnalyzer ++ otherMetrics).toMap[AnalyzerId, Metric[_]])
   }
 
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/runners/AnalyzerContext.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/runners/AnalyzerContext.scala
@@ -16,7 +16,7 @@
 
 package com.amazon.deequ.analyzers.runners
 
-import com.amazon.deequ.analyzers.{Analyzer, FilterableAnalyzer}
+import com.amazon.deequ.analyzers.{Analyzer, AnalyzerId, FilterableAnalyzer}
 import com.amazon.deequ.metrics.{DoubleMetric, Metric}
 import com.amazon.deequ.repository.SimpleResultSerde
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -26,7 +26,7 @@ import org.apache.spark.sql.{DataFrame, SparkSession}
   *
   * @param metricMap Analyzers and their Metric results
   */
-case class AnalyzerContext(metricMap: Map[Analyzer[_, Metric[_]], Metric[_]]) {
+case class AnalyzerContext(metricMap: Map[AnalyzerId, Metric[_]]) {
 
   def allMetrics: Seq[Metric[_]] = {
     metricMap.values.toSeq
@@ -37,7 +37,7 @@ case class AnalyzerContext(metricMap: Map[Analyzer[_, Metric[_]], Metric[_]]) {
   }
 
   def metric(analyzer: Analyzer[_, Metric[_]]): Option[Metric[_]] = {
-    metricMap.get(analyzer)
+    metricMap.get(analyzer.id)
   }
 }
 

--- a/src/main/scala/com/amazon/deequ/analyzers/runners/AnalyzerContext.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/runners/AnalyzerContext.scala
@@ -16,17 +16,17 @@
 
 package com.amazon.deequ.analyzers.runners
 
-import com.amazon.deequ.analyzers.{Analyzer, AnalyzerId, FilterableAnalyzer}
+import com.amazon.deequ.analyzers.{Analyzer, AnalyzerName, FilterableAnalyzer}
 import com.amazon.deequ.metrics.{DoubleMetric, Metric}
 import com.amazon.deequ.repository.SimpleResultSerde
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 
 /**
   * The result returned from AnalysisRunner and Analysis
   *
   * @param metricMap Analyzers and their Metric results
   */
-case class AnalyzerContext(metricMap: Map[AnalyzerId, Metric[_]]) {
+case class AnalyzerContext(metricMap: Map[AnalyzerName, Metric[_]]) {
 
   def allMetrics: Seq[Metric[_]] = {
     metricMap.values.toSeq
@@ -37,7 +37,7 @@ case class AnalyzerContext(metricMap: Map[AnalyzerId, Metric[_]]) {
   }
 
   def metric(analyzer: Analyzer[_, Metric[_]]): Option[Metric[_]] = {
-    metricMap.get(analyzer.id)
+    metricMap.get(analyzer.name)
   }
 }
 
@@ -48,14 +48,13 @@ object AnalyzerContext {
   def successMetricsAsDataFrame(
       sparkSession: SparkSession,
       analyzerContext: AnalyzerContext,
-      forAnalyzers: Seq[Analyzer[_, Metric[_]]] = Seq.empty)
-    : DataFrame = {
+      forAnalyzers: Seq[Analyzer[_, Metric[_]]] = Seq.empty): Dataset[SimpleMetricOutput] = {
 
     val metricsList = getSimplifiedMetricOutputForSelectedAnalyzers(analyzerContext, forAnalyzers)
 
     import sparkSession.implicits._
 
-    metricsList.toDF("entity", "instance", "name", "value")
+    metricsList.toDS
   }
 
   def successMetricsAsJson(analyzerContext: AnalyzerContext,
@@ -82,12 +81,12 @@ object AnalyzerContext {
 
     analyzerContext.metricMap
       // Get matching analyzers
-      .filterKeys(analyzer => forAnalyzers.isEmpty || forAnalyzers.contains(analyzer))
+      .filterKeys(analyzerName => forAnalyzers.isEmpty || forAnalyzers.map(_.name).contains(analyzerName))
       // Get analyzers with successful results
       .filter({ case (_, metrics) => metrics.value.isSuccess })
       // Get metrics as Double and replace simple name with description
-      .flatMap({ case (analyzer, metrics) =>
-        metrics.flatten().map(renameMetric(_, describeAnalyzer(analyzer))) })
+      .flatMap({ case (analyzerName, metrics) =>
+        metrics.flatten().map(renameMetric(_, describeAnalyzer(analyzerName))) })
       // Simplify metrics
       .map(SimpleMetricOutput(_))
       .toSeq
@@ -103,14 +102,14 @@ object AnalyzerContext {
     * It helps us to show more readable success metrics
     * (see https://github.com/awslabs/deequ/issues/177 for details)
     *
-    * @param analyzer the Analyzer to be described
+    * @param analyzerName the name of the Analyzer to be described
     * @return the description of the Analyzer
     */
-  private[this] def describeAnalyzer(analyzer: Any): String = {
-    val name = analyzer.getClass.getSimpleName
+  private[this] def describeAnalyzer(analyzerName: AnalyzerName): String = {
+    val name = analyzerName.getClass.getSimpleName
 
-    val filterCondition: Option[String] = analyzer match {
-      case x : FilterableAnalyzer => x.filterCondition
+    val filterCondition: Option[String] = analyzerName match {
+      case analyzerName: AnalyzerName.Filterable => analyzerName.filterCondition
       case _ => None
     }
 
@@ -120,7 +119,7 @@ object AnalyzerContext {
     }
   }
 
-  private[this] case class SimpleMetricOutput(
+  case class SimpleMetricOutput(
     entity: String,
     instance: String,
     name: String,

--- a/src/main/scala/com/amazon/deequ/analyzers/runners/AnalyzerContext.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/runners/AnalyzerContext.scala
@@ -16,7 +16,7 @@
 
 package com.amazon.deequ.analyzers.runners
 
-import com.amazon.deequ.analyzers.{Analyzer, AnalyzerName, FilterableAnalyzer}
+import com.amazon.deequ.analyzers.{Analyzer, AnalyzerId, FilterableAnalyzer}
 import com.amazon.deequ.metrics.{DoubleMetric, Metric}
 import com.amazon.deequ.repository.SimpleResultSerde
 import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
@@ -26,7 +26,7 @@ import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
   *
   * @param metricMap Analyzers and their Metric results
   */
-case class AnalyzerContext(metricMap: Map[AnalyzerName, Metric[_]]) {
+case class AnalyzerContext(metricMap: Map[AnalyzerId, Metric[_]]) {
 
   def allMetrics: Seq[Metric[_]] = {
     metricMap.values.toSeq
@@ -37,7 +37,7 @@ case class AnalyzerContext(metricMap: Map[AnalyzerName, Metric[_]]) {
   }
 
   def metric(analyzer: Analyzer[_, Metric[_]]): Option[Metric[_]] = {
-    metricMap.get(analyzer.name)
+    metricMap.get(analyzer.id)
   }
 }
 
@@ -81,12 +81,12 @@ object AnalyzerContext {
 
     analyzerContext.metricMap
       // Get matching analyzers
-      .filterKeys(analyzerName => forAnalyzers.isEmpty || forAnalyzers.map(_.name).contains(analyzerName))
+      .filterKeys(analyzerId => forAnalyzers.isEmpty || forAnalyzers.map(_.id).contains(analyzerId))
       // Get analyzers with successful results
       .filter({ case (_, metrics) => metrics.value.isSuccess })
       // Get metrics as Double and replace simple name with description
-      .flatMap({ case (analyzerName, metrics) =>
-        metrics.flatten().map(renameMetric(_, describeAnalyzer(analyzerName))) })
+      .flatMap({ case (analyzerId, metrics) =>
+        metrics.flatten().map(renameMetric(_, describeAnalyzer(analyzerId))) })
       // Simplify metrics
       .map(SimpleMetricOutput(_))
       .toSeq
@@ -102,14 +102,14 @@ object AnalyzerContext {
     * It helps us to show more readable success metrics
     * (see https://github.com/awslabs/deequ/issues/177 for details)
     *
-    * @param analyzerName the name of the Analyzer to be described
+    * @param analyzerId the ID of the Analyzer to be described
     * @return the description of the Analyzer
     */
-  private[this] def describeAnalyzer(analyzerName: AnalyzerName): String = {
-    val name = analyzerName.getClass.getSimpleName
+  private[this] def describeAnalyzer(analyzerId: AnalyzerId): String = {
+    val name = analyzerId.getClass.getSimpleName
 
-    val filterCondition: Option[String] = analyzerName match {
-      case analyzerName: AnalyzerName.Filterable => analyzerName.filterCondition
+    val filterCondition: Option[String] = analyzerId match {
+      case analyzerId: AnalyzerId.Filterable => analyzerId.filterCondition
       case _ => None
     }
 

--- a/src/main/scala/com/amazon/deequ/analyzers/runners/KLLRunner.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/runners/KLLRunner.scala
@@ -16,7 +16,7 @@
 
 package com.amazon.deequ.analyzers.runners
 
-import com.amazon.deequ.analyzers.{Analyzer, AnalyzerName, KLLParameters, KLLSketch, KLLState, QuantileNonSample, State, StateLoader, StatePersister}
+import com.amazon.deequ.analyzers.{Analyzer, AnalyzerId, KLLParameters, KLLSketch, KLLState, QuantileNonSample, State, StateLoader, StatePersister}
 import com.amazon.deequ.metrics.Metric
 import org.apache.spark.sql.types.{ByteType, DoubleType, FloatType, IntegerType, LongType, ShortType, StructType}
 import org.apache.spark.sql.{DataFrame, Row}
@@ -115,10 +115,10 @@ object KLLRunner {
       val kllState = sketchPerColumn(analyzer.column).asKLLState()
       val metric = analyzer.calculateMetric(Some(kllState), aggregateWith, saveStatesTo)
 
-      analyzer.name -> metric
+      analyzer.id -> metric
     }
 
-    AnalyzerContext(metricsByAnalyzer.toMap[AnalyzerName, Metric[_]])
+    AnalyzerContext(metricsByAnalyzer.toMap[AnalyzerId, Metric[_]])
   }
 
   private[this] def emptySketches(

--- a/src/main/scala/com/amazon/deequ/analyzers/runners/KLLRunner.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/runners/KLLRunner.scala
@@ -16,7 +16,7 @@
 
 package com.amazon.deequ.analyzers.runners
 
-import com.amazon.deequ.analyzers.{Analyzer, KLLParameters, KLLSketch, KLLState, QuantileNonSample, State, StateLoader, StatePersister}
+import com.amazon.deequ.analyzers.{Analyzer, AnalyzerId, KLLParameters, KLLSketch, KLLState, QuantileNonSample, State, StateLoader, StatePersister}
 import com.amazon.deequ.metrics.Metric
 import org.apache.spark.sql.types.{ByteType, DoubleType, FloatType, IntegerType, LongType, ShortType, StructType}
 import org.apache.spark.sql.{DataFrame, Row}
@@ -115,10 +115,10 @@ object KLLRunner {
       val kllState = sketchPerColumn(analyzer.column).asKLLState()
       val metric = analyzer.calculateMetric(Some(kllState), aggregateWith, saveStatesTo)
 
-      analyzer -> metric
+      analyzer.id -> metric
     }
 
-    AnalyzerContext(metricsByAnalyzer.toMap[Analyzer[_, Metric[_]], Metric[_]])
+    AnalyzerContext(metricsByAnalyzer.toMap[AnalyzerId, Metric[_]])
   }
 
   private[this] def emptySketches(

--- a/src/main/scala/com/amazon/deequ/analyzers/runners/KLLRunner.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/runners/KLLRunner.scala
@@ -16,7 +16,7 @@
 
 package com.amazon.deequ.analyzers.runners
 
-import com.amazon.deequ.analyzers.{Analyzer, AnalyzerId, KLLParameters, KLLSketch, KLLState, QuantileNonSample, State, StateLoader, StatePersister}
+import com.amazon.deequ.analyzers.{Analyzer, AnalyzerName, KLLParameters, KLLSketch, KLLState, QuantileNonSample, State, StateLoader, StatePersister}
 import com.amazon.deequ.metrics.Metric
 import org.apache.spark.sql.types.{ByteType, DoubleType, FloatType, IntegerType, LongType, ShortType, StructType}
 import org.apache.spark.sql.{DataFrame, Row}
@@ -115,10 +115,10 @@ object KLLRunner {
       val kllState = sketchPerColumn(analyzer.column).asKLLState()
       val metric = analyzer.calculateMetric(Some(kllState), aggregateWith, saveStatesTo)
 
-      analyzer.id -> metric
+      analyzer.name -> metric
     }
 
-    AnalyzerContext(metricsByAnalyzer.toMap[AnalyzerId, Metric[_]])
+    AnalyzerContext(metricsByAnalyzer.toMap[AnalyzerName, Metric[_]])
   }
 
   private[this] def emptySketches(

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -1090,7 +1090,7 @@ object Check {
     afterDate.foreach { afterDate =>
       repositoryLoader = repositoryLoader.after(afterDate) }
 
-    repositoryLoader = repositoryLoader.forAnalyzers(Seq(analyzer.id))
+    repositoryLoader = repositoryLoader.forAnalyzers(Seq(analyzer.name))
 
     val analysisResults = repositoryLoader.get()
 

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -1090,7 +1090,7 @@ object Check {
     afterDate.foreach { afterDate =>
       repositoryLoader = repositoryLoader.after(afterDate) }
 
-    repositoryLoader = repositoryLoader.forAnalyzers(Seq(analyzer))
+    repositoryLoader = repositoryLoader.forAnalyzers(Seq(analyzer.id))
 
     val analysisResults = repositoryLoader.get()
 

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -1090,7 +1090,7 @@ object Check {
     afterDate.foreach { afterDate =>
       repositoryLoader = repositoryLoader.after(afterDate) }
 
-    repositoryLoader = repositoryLoader.forAnalyzers(Seq(analyzer.name))
+    repositoryLoader = repositoryLoader.forAnalyzers(Seq(analyzer.id))
 
     val analysisResults = repositoryLoader.get()
 

--- a/src/main/scala/com/amazon/deequ/constraints/AnalysisBasedConstraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/AnalysisBasedConstraint.scala
@@ -16,7 +16,7 @@
 
 package com.amazon.deequ.constraints
 
-import com.amazon.deequ.analyzers.{Analyzer, AnalyzerName, State}
+import com.amazon.deequ.analyzers.{Analyzer, AnalyzerId, State}
 import com.amazon.deequ.metrics.Metric
 import org.apache.spark.sql.DataFrame
 
@@ -49,14 +49,14 @@ private[deequ] case class AnalysisBasedConstraint[S <: State[S], M, V](
 
   private[deequ] def calculateAndEvaluate(data: DataFrame) = {
     val metric = analyzer.calculate(data)
-    evaluate(Map(analyzer.name -> metric))
+    evaluate(Map(analyzer.id -> metric))
   }
 
   override def evaluate(
-      analysisResults: Map[AnalyzerName, Metric[_]])
+      analysisResults: Map[AnalyzerId, Metric[_]])
     : ConstraintResult = {
 
-    val metric = analysisResults.get(analyzer.name).map(_.asInstanceOf[Metric[M]])
+    val metric = analysisResults.get(analyzer.id).map(_.asInstanceOf[Metric[M]])
 
     metric.map(pickValueAndAssert).getOrElse(
       // Analysis is missing

--- a/src/main/scala/com/amazon/deequ/constraints/AnalysisBasedConstraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/AnalysisBasedConstraint.scala
@@ -16,7 +16,7 @@
 
 package com.amazon.deequ.constraints
 
-import com.amazon.deequ.analyzers.{Analyzer, AnalyzerId, State}
+import com.amazon.deequ.analyzers.{Analyzer, AnalyzerName, State}
 import com.amazon.deequ.metrics.Metric
 import org.apache.spark.sql.DataFrame
 
@@ -49,14 +49,14 @@ private[deequ] case class AnalysisBasedConstraint[S <: State[S], M, V](
 
   private[deequ] def calculateAndEvaluate(data: DataFrame) = {
     val metric = analyzer.calculate(data)
-    evaluate(Map(analyzer.id -> metric))
+    evaluate(Map(analyzer.name -> metric))
   }
 
   override def evaluate(
-      analysisResults: Map[AnalyzerId, Metric[_]])
+      analysisResults: Map[AnalyzerName, Metric[_]])
     : ConstraintResult = {
 
-    val metric = analysisResults.get(analyzer.id).map(_.asInstanceOf[Metric[M]])
+    val metric = analysisResults.get(analyzer.name).map(_.asInstanceOf[Metric[M]])
 
     metric.map(pickValueAndAssert).getOrElse(
       // Analysis is missing

--- a/src/main/scala/com/amazon/deequ/constraints/AnalysisBasedConstraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/AnalysisBasedConstraint.scala
@@ -16,10 +16,11 @@
 
 package com.amazon.deequ.constraints
 
-import com.amazon.deequ.analyzers.{Analyzer, State}
+import com.amazon.deequ.analyzers.{Analyzer, AnalyzerId, State}
 import com.amazon.deequ.metrics.Metric
 import org.apache.spark.sql.DataFrame
-import scala.util.{Failure, Success, Try}
+
+import scala.util.{Failure, Success}
 
 /**
   * Common trait for all analysis based constraints that provides unified way to access
@@ -48,14 +49,14 @@ private[deequ] case class AnalysisBasedConstraint[S <: State[S], M, V](
 
   private[deequ] def calculateAndEvaluate(data: DataFrame) = {
     val metric = analyzer.calculate(data)
-    evaluate(Map(analyzer -> metric))
+    evaluate(Map(analyzer.id -> metric))
   }
 
   override def evaluate(
-      analysisResults: Map[Analyzer[_, Metric[_]], Metric[_]])
+      analysisResults: Map[AnalyzerId, Metric[_]])
     : ConstraintResult = {
 
-    val metric = analysisResults.get(analyzer).map(_.asInstanceOf[Metric[M]])
+    val metric = analysisResults.get(analyzer.id).map(_.asInstanceOf[Metric[M]])
 
     metric.map(pickValueAndAssert).getOrElse(
       // Analysis is missing

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -34,7 +34,7 @@ case class ConstraintResult(
 
 /** Common trait for all data quality constraints */
 trait Constraint {
-  def evaluate(analysisResults: Map[AnalyzerId, Metric[_]]): ConstraintResult
+  def evaluate(analysisResults: Map[AnalyzerName, Metric[_]]): ConstraintResult
 }
 
 /** Common trait for constraint decorators */
@@ -47,7 +47,7 @@ class ConstraintDecorator(protected val _inner: Constraint) extends Constraint {
   }
 
   override def evaluate(
-      analysisResults: Map[AnalyzerId, Metric[_]])
+      analysisResults: Map[AnalyzerName, Metric[_]])
     : ConstraintResult = {
 
     // most of the constraints are of type NamedConstraint

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -34,7 +34,7 @@ case class ConstraintResult(
 
 /** Common trait for all data quality constraints */
 trait Constraint {
-  def evaluate(analysisResults: Map[Analyzer[_, Metric[_]], Metric[_]]): ConstraintResult
+  def evaluate(analysisResults: Map[AnalyzerId, Metric[_]]): ConstraintResult
 }
 
 /** Common trait for constraint decorators */
@@ -47,7 +47,7 @@ class ConstraintDecorator(protected val _inner: Constraint) extends Constraint {
   }
 
   override def evaluate(
-      analysisResults: Map[Analyzer[_, Metric[_]], Metric[_]])
+      analysisResults: Map[AnalyzerId, Metric[_]])
     : ConstraintResult = {
 
     // most of the constraints are of type NamedConstraint

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -34,7 +34,7 @@ case class ConstraintResult(
 
 /** Common trait for all data quality constraints */
 trait Constraint {
-  def evaluate(analysisResults: Map[AnalyzerName, Metric[_]]): ConstraintResult
+  def evaluate(analysisResults: Map[AnalyzerId, Metric[_]]): ConstraintResult
 }
 
 /** Common trait for constraint decorators */
@@ -47,7 +47,7 @@ class ConstraintDecorator(protected val _inner: Constraint) extends Constraint {
   }
 
   override def evaluate(
-      analysisResults: Map[AnalyzerName, Metric[_]])
+      analysisResults: Map[AnalyzerId, Metric[_]])
     : ConstraintResult = {
 
     // most of the constraints are of type NamedConstraint

--- a/src/main/scala/com/amazon/deequ/examples/AnomalyDetectionExample.scala
+++ b/src/main/scala/com/amazon/deequ/examples/AnomalyDetectionExample.scala
@@ -17,12 +17,12 @@
 package com.amazon.deequ.examples
 
 import com.amazon.deequ.VerificationSuite
-import com.amazon.deequ.analyzers.Size
+import com.amazon.deequ.analyzers.{AnalyzerName, Size}
 import com.amazon.deequ.anomalydetection.RelativeRateOfChangeStrategy
+import com.amazon.deequ.checks.CheckStatus._
 import com.amazon.deequ.examples.ExampleUtils.{itemsAsDataframe, withSpark}
 import com.amazon.deequ.repository.ResultKey
 import com.amazon.deequ.repository.memory.InMemoryMetricsRepository
-import com.amazon.deequ.checks.CheckStatus._
 
 private[examples] object AnomalyDetectionExample extends App {
 
@@ -85,7 +85,7 @@ private[examples] object AnomalyDetectionExample extends App {
       /* Lets have a look at the actual metrics. */
       metricsRepository
         .load()
-        .forAnalyzers(Seq(Size()))
+        .forAnalyzers(Seq(AnalyzerName.Size(None)))
         .getSuccessMetricsAsDataFrame(session)
         .show()
     }

--- a/src/main/scala/com/amazon/deequ/examples/AnomalyDetectionExample.scala
+++ b/src/main/scala/com/amazon/deequ/examples/AnomalyDetectionExample.scala
@@ -17,7 +17,7 @@
 package com.amazon.deequ.examples
 
 import com.amazon.deequ.VerificationSuite
-import com.amazon.deequ.analyzers.{AnalyzerName, Size}
+import com.amazon.deequ.analyzers.{AnalyzerId, Size}
 import com.amazon.deequ.anomalydetection.RelativeRateOfChangeStrategy
 import com.amazon.deequ.checks.CheckStatus._
 import com.amazon.deequ.examples.ExampleUtils.{itemsAsDataframe, withSpark}
@@ -85,7 +85,7 @@ private[examples] object AnomalyDetectionExample extends App {
       /* Lets have a look at the actual metrics. */
       metricsRepository
         .load()
-        .forAnalyzers(Seq(AnalyzerName.Size(None)))
+        .forAnalyzers(Seq(AnalyzerId.Size(None)))
         .getSuccessMetricsAsDataFrame(session)
         .show()
     }

--- a/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
+++ b/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
@@ -191,8 +191,9 @@ object ColumnProfiler {
     )
 
     // The columns we need to calculate the histograms for
+    val existingHistCols = analyzerContextExistingValues.metricMap.collect { case (AnalyzerName.Histogram(c, _, _), _) => c}.toSeq
     val nonExistingHistogramColumns = targetColumnsForHistograms
-      .filter { column => analyzerContextExistingValues.metricMap.get(AnalyzerId(AnalyzerName.Histogram, column)).isEmpty }
+      .filter { column => !existingHistCols.contains(column) }
 
     // Calculate and save/append results if necessary
     val histograms: Map[String, Distribution] = getHistogramsForThirdPass(
@@ -312,7 +313,7 @@ object ColumnProfiler {
 
           val relevantEntries = analyzerContextWithAllPreviousResults.metricMap
             .filterKeys {
-              case AnalyzerId(AnalyzerName.Histogram, column) =>
+              case AnalyzerName.Histogram(column, _, _) =>
                 targetColumnsForHistograms.contains(column)
               case _ => false
             }
@@ -326,7 +327,7 @@ object ColumnProfiler {
 
   private[this] def convertColumnNamesAndDistributionToHistogramWithMetric(
     columnNamesAndDistribution: Map[String, Distribution])
-  : Map[AnalyzerId, Metric[_]] = {
+  : Map[AnalyzerName, Metric[_]] = {
 
     columnNamesAndDistribution
       .map { case (columnName, distribution) =>
@@ -334,7 +335,7 @@ object ColumnProfiler {
         val analyzer = Histogram(columnName)
         val metric = HistogramMetric(columnName, Success(distribution))
 
-        analyzer.id -> metric
+        analyzer.name -> metric
       }
   }
 
@@ -378,39 +379,39 @@ object ColumnProfiler {
     : GenericColumnStatistics = {
 
     val numRecords = results.metricMap
-      .collect { case (AnalyzerId(AnalyzerName.Size, _), metric: DoubleMetric) => metric.value.get }
+      .collect { case (AnalyzerName.Size(None), metric: DoubleMetric) => metric.value.get }
       .head
       .toLong
 
 
     val inferredTypes = results.metricMap
       .filterNot{
-        case (AnalyzerId(AnalyzerName.DataType, column), _) => predefinedTypes.contains(column)
+        case (AnalyzerName.DataType(column, None), _) => predefinedTypes.contains(column)
         case _ => true
       }
-      .collect { case (AnalyzerId(AnalyzerName.DataType, column), metric: HistogramMetric) =>
+      .collect { case (AnalyzerName.DataType(column, None), metric: HistogramMetric) =>
           val typeHistogram = metric.value.get
           column -> DataTypeHistogram.determineType(typeHistogram)
       }
 
     val typeDetectionHistograms = results.metricMap
       .filterNot{
-        case (AnalyzerId(AnalyzerName.DataType, column), _) => predefinedTypes.contains(column)
+        case (AnalyzerName.DataType(column, None), _) => predefinedTypes.contains(column)
         case _ => true
       }
-      .collect { case (AnalyzerId(AnalyzerName.DataType, column), metric: HistogramMetric) =>
+      .collect { case (AnalyzerName.DataType(column, None), metric: HistogramMetric) =>
           val typeCounts = metric.value.get.values
             .map { case (key, distValue) => key -> distValue.absolute }
           column -> typeCounts
       }
 
     val approximateNumDistincts = results.metricMap
-      .collect { case (AnalyzerId(AnalyzerName.ApproxCountDistinct, column), metric: DoubleMetric) =>
+      .collect { case (AnalyzerName.ApproxCountDistinct(column, None), metric: DoubleMetric) =>
         column -> metric.value.get.toLong
       }
 
     val completenesses = results.metricMap
-      .collect { case (AnalyzerId(AnalyzerName.Completeness, column), metric: DoubleMetric) =>
+      .collect { case (AnalyzerName.Completeness(column, None), metric: DoubleMetric) =>
         column -> metric.value.get
       }
 
@@ -464,7 +465,7 @@ object ColumnProfiler {
   private[this] def extractNumericStatistics(results: AnalyzerContext): NumericColumnStatistics = {
 
     val means = results.metricMap
-      .collect { case (AnalyzerId(AnalyzerName.Mean, column), metric: DoubleMetric) =>
+      .collect { case (AnalyzerName.Mean(column, None), metric: DoubleMetric) =>
         metric.value match {
           case Success(metricValue) => Some(column -> metricValue)
           case _ => None
@@ -474,7 +475,7 @@ object ColumnProfiler {
       .toMap
 
     val stdDevs = results.metricMap
-      .collect { case (AnalyzerId(AnalyzerName.StandardDeviation, column), metric: DoubleMetric) =>
+      .collect { case (AnalyzerName.StandardDeviation(column, None), metric: DoubleMetric) =>
         metric.value match {
           case Success(metricValue) => Some(column -> metricValue)
           case _ => None
@@ -484,7 +485,7 @@ object ColumnProfiler {
       .toMap
 
     val maxima = results.metricMap
-      .collect { case (AnalyzerId(AnalyzerName.Maximum, column), metric: DoubleMetric) =>
+      .collect { case (AnalyzerName.Maximum(column, None), metric: DoubleMetric) =>
         metric.value match {
           case Success(metricValue) => Some(column -> metricValue)
           case _ => None
@@ -494,7 +495,7 @@ object ColumnProfiler {
       .toMap
 
     val minima = results.metricMap
-      .collect { case (AnalyzerId(AnalyzerName.Minimum, column), metric: DoubleMetric) =>
+      .collect { case (AnalyzerName.Minimum(column, None), metric: DoubleMetric) =>
         metric.value match {
           case Success(metricValue) => Some(column -> metricValue)
           case _ => None
@@ -504,7 +505,7 @@ object ColumnProfiler {
       .toMap
 
     val sums = results.metricMap
-      .collect { case (AnalyzerId(AnalyzerName.Sum, column), metric: DoubleMetric) =>
+      .collect { case (AnalyzerName.Sum(column, None), metric: DoubleMetric) =>
         metric.value match {
           case Success(metricValue) => Some(column -> metricValue)
           case _ => None
@@ -515,7 +516,7 @@ object ColumnProfiler {
 
 
     val kll = results.metricMap
-      .collect { case (AnalyzerId(AnalyzerName.KLLSketch, column), metric: KLLMetric) if metric.value.isSuccess =>
+      .collect { case (AnalyzerName.KLLSketch(column), metric: KLLMetric) if metric.value.isSuccess =>
         metric.value match {
           case Success(bucketDistribution) =>
             Some(column -> bucketDistribution)
@@ -526,7 +527,7 @@ object ColumnProfiler {
       .toMap
 
     val approxPercentiles = results.metricMap
-      .collect {  case (AnalyzerId(AnalyzerName.KLLSketch, column), metric: KLLMetric) =>
+      .collect {  case (AnalyzerName.KLLSketch(column), metric: KLLMetric) =>
         metric.value match {
           case Success(bucketDistribution) =>
 
@@ -656,7 +657,7 @@ object ColumnProfiler {
 
       // Return overall results using the more simple Distribution format
       analyzerContext.metricMap
-        .map { case (AnalyzerId(AnalyzerName.Histogram, column), metric: HistogramMetric) if metric.value.isSuccess =>
+        .map { case (AnalyzerName.Histogram(column, _, _), metric: HistogramMetric) if metric.value.isSuccess =>
           column -> metric.value.get
         }
     } else {
@@ -665,7 +666,7 @@ object ColumnProfiler {
         println("### PROFILING: Skipping pass (3/3), no new histograms need to be calculated.")
       }
       analyzerContextExistingValues.metricMap
-        .map { case (AnalyzerId(AnalyzerName.Histogram, column), metric: HistogramMetric) if metric.value.isSuccess =>
+        .map { case (AnalyzerName.Histogram(column, _, _), metric: HistogramMetric) if metric.value.isSuccess =>
           column -> metric.value.get
         }
     }

--- a/src/main/scala/com/amazon/deequ/repository/AnalysisResult.scala
+++ b/src/main/scala/com/amazon/deequ/repository/AnalysisResult.scala
@@ -5,7 +5,7 @@
  * use this file except in compliance with the License. A copy of the License
  * is located at
  *
- *     http://aws.amazon.com/apache2.0/
+ * http://aws.amazon.com/apache2.0/
  *
  * or in the "license" file accompanying this file. This file is distributed on
  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
@@ -23,28 +23,28 @@ import com.amazon.deequ.analyzers.runners.AnalyzerContext
 import org.apache.spark.sql.functions.lit
 
 case class AnalysisResult(
-    resultKey: ResultKey,
-    analyzerContext: AnalyzerContext
-)
+                           resultKey: ResultKey,
+                           analyzerContext: AnalyzerContext
+                         )
 
 object AnalysisResult {
 
   private val DATASET_DATE_FIELD = "dataset_date"
 
   /**
-    * Get a AnalysisResult as DataFrame containing the success metrics
-    *
-    * @param analysisResult      The AnalysisResult to convert
-    * @param forAnalyzers Only include metrics for these Analyzers in the DataFrame
-    * @param withTags            Only include these Tags in the DataFrame
-    */
+   * Get a AnalysisResult as DataFrame containing the success metrics
+   *
+   * @param analysisResult The AnalysisResult to convert
+   * @param forAnalyzers   Only include metrics for these Analyzers in the DataFrame
+   * @param withTags       Only include these Tags in the DataFrame
+   */
   def getSuccessMetricsAsDataFrame(
-      sparkSession: SparkSession,
-      analysisResult: AnalysisResult,
-      forAnalyzers: Seq[Analyzer[_, Metric[_]]] = Seq.empty,
-      withTags: Seq[String] = Seq.empty)
-    : DataFrame = {
-
+                                    sparkSession: SparkSession,
+                                    analysisResult: AnalysisResult,
+                                    forAnalyzers: Seq[Analyzer[_, Metric[_]]] = Seq.empty,
+                                    withTags: Seq[String] = Seq.empty)
+  : DataFrame = {
+    import sparkSession.implicits.newProductEncoder
     var analyzerContextDF = AnalyzerContext
       .successMetricsAsDataFrame(sparkSession, analysisResult.analyzerContext, forAnalyzers)
       .withColumn(DATASET_DATE_FIELD, lit(analysisResult.resultKey.dataSetDate))
@@ -61,20 +61,20 @@ object AnalysisResult {
   }
 
   /**
-    * Get a AnalysisResult as Json containing the success metrics
-    *
-    * @param analysisResult      The AnalysisResult to convert
-    * @param forAnalyzers Only include metrics for these Analyzers in the DataFrame
-    * @param withTags            Only include these Tags in the DataFrame
-    */
+   * Get a AnalysisResult as Json containing the success metrics
+   *
+   * @param analysisResult The AnalysisResult to convert
+   * @param forAnalyzers   Only include metrics for these Analyzers in the DataFrame
+   * @param withTags       Only include these Tags in the DataFrame
+   */
   def getSuccessMetricsAsJson(
-      analysisResult: AnalysisResult,
-      forAnalyzers: Seq[Analyzer[_, Metric[_]]] = Seq.empty,
-      withTags: Seq[String] = Seq.empty)
-    : String = {
+                               analysisResult: AnalysisResult,
+                               forAnalyzers: Seq[Analyzer[_, Metric[_]]] = Seq.empty,
+                               withTags: Seq[String] = Seq.empty)
+  : String = {
 
     var serializableResult = SimpleResultSerde.deserialize(
-        AnalyzerContext.successMetricsAsJson(analysisResult.analyzerContext, forAnalyzers))
+      AnalyzerContext.successMetricsAsJson(analysisResult.analyzerContext, forAnalyzers))
       .asInstanceOf[Seq[Map[String, Any]]]
 
     serializableResult = addColumnToSerializableResult(
@@ -83,7 +83,8 @@ object AnalysisResult {
     analysisResult.resultKey.tags
       .filterKeys(tagName => withTags.isEmpty || withTags.contains(tagName))
       .map { case (tagName, tagValue) =>
-        (formatTagColumnNameInJson(tagName, serializableResult), tagValue)}
+        (formatTagColumnNameInJson(tagName, serializableResult), tagValue)
+      }
       .foreach { case (key, value) => serializableResult = addColumnToSerializableResult(
         serializableResult, key, value)
       }
@@ -92,10 +93,10 @@ object AnalysisResult {
   }
 
   private[this] def addColumnToSerializableResult(
-      serializableResult: Seq[Map[String, Any]],
-      tagName: String,
-      serializableTagValue: Any)
-    : Seq[Map[String, Any]] = {
+                                                   serializableResult: Seq[Map[String, Any]],
+                                                   tagName: String,
+                                                   serializableTagValue: Any)
+  : Seq[Map[String, Any]] = {
 
     if (serializableResult.headOption.nonEmpty &&
       !serializableResult.head.keySet.contains(tagName)) {
@@ -109,9 +110,9 @@ object AnalysisResult {
   }
 
   private[this] def formatTagColumnNameInDataFrame(
-      tagName : String,
-      dataFrame: DataFrame)
-    : String = {
+                                                    tagName: String,
+                                                    dataFrame: DataFrame)
+  : String = {
 
     var tagColumnName = tagName.replaceAll("[^A-Za-z0-9_]", "").toLowerCase
     if (dataFrame.columns.contains(tagColumnName)) {
@@ -121,9 +122,9 @@ object AnalysisResult {
   }
 
   private[this] def formatTagColumnNameInJson(
-      tagName : String,
-      serializableResult : Seq[Map[String, Any]])
-    : String = {
+                                               tagName: String,
+                                               serializableResult: Seq[Map[String, Any]])
+  : String = {
 
     var tagColumnName = tagName.replaceAll("[^A-Za-z0-9_]", "").toLowerCase
 

--- a/src/main/scala/com/amazon/deequ/repository/AnalysisResult.scala
+++ b/src/main/scala/com/amazon/deequ/repository/AnalysisResult.scala
@@ -44,7 +44,6 @@ object AnalysisResult {
                                     forAnalyzers: Seq[Analyzer[_, Metric[_]]] = Seq.empty,
                                     withTags: Seq[String] = Seq.empty)
   : DataFrame = {
-    import sparkSession.implicits.newProductEncoder
     var analyzerContextDF = AnalyzerContext
       .successMetricsAsDataFrame(sparkSession, analysisResult.analyzerContext, forAnalyzers)
       .withColumn(DATASET_DATE_FIELD, lit(analysisResult.resultKey.dataSetDate))

--- a/src/main/scala/com/amazon/deequ/repository/AnalysisResult.scala
+++ b/src/main/scala/com/amazon/deequ/repository/AnalysisResult.scala
@@ -27,7 +27,7 @@ case class AnalysisResult(
     analyzerContext: AnalyzerContext
 )
 
-private[repository] object AnalysisResult {
+object AnalysisResult {
 
   private val DATASET_DATE_FIELD = "dataset_date"
 

--- a/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
+++ b/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
@@ -41,7 +41,6 @@ private[repository] object JsonSerializationConstants {
   val STRING_LIST_TYPE: Type = new TypeToken[JList[String]]() {}.getType
 
   val ANALYZER_FIELD = "analyzer"
-  val ANALYZER_ID_FIELD = "analyzerId"
   val ANALYZER_NAME_FIELD = "analyzerName"
   val FIRST_COLUMN_FIELD = "firstColumn"
   val SECOND_COLUMN_FIELD = "secondColumn"
@@ -190,7 +189,7 @@ private[deequ] object AnalyzerContextSerializer extends JsonSerializer[AnalyzerC
     analyzerContext.metricMap.foreach { case (analyzerId, metric) =>
       val entry = new JsonObject()
 
-      entry.add(ANALYZER_ID_FIELD, context.serialize(analyzerId, classOf[AnalyzerId]))
+      entry.add(ANALYZER_FIELD, context.serialize(analyzerId, classOf[AnalyzerId]))
       entry.add(METRIC_FIELD, context.serialize(metric, classOf[Metric[_]]))
 
       metricMap.add(entry)
@@ -212,7 +211,7 @@ private[deequ] object AnalyzerContextDeserializer extends JsonDeserializer[Analy
     val metricMap = jsonObject.get(METRIC_MAP_FIELD).getAsJsonArray.asScala
       .map { entry =>
 
-        val serializedAnalyzer = entry.getAsJsonObject.get(ANALYZER_ID_FIELD)
+        val serializedAnalyzer = entry.getAsJsonObject.get(ANALYZER_FIELD)
 
         val analyzerId = context.deserialize(serializedAnalyzer,
           classOf[AnalyzerId]).asInstanceOf[AnalyzerId]
@@ -380,10 +379,6 @@ private[deequ] object AnalyzerIdSerializer
     result.addProperty(ANALYZER_NAME_FIELD, analyzerId.name)
 
     analyzerId match {
-      case name: AnalyzerId.Filterable => result.addProperty(WHERE_FIELD, name.filterCondition.orNull)
-      case _ =>
-    }
-    analyzerId match {
       case name: AnalyzerId.SingleColumn => result.addProperty(COLUMN_FIELD, name.column)
       case _ =>
     }
@@ -424,6 +419,10 @@ private[deequ] object AnalyzerIdSerializer
       case name: AnalyzerId.Quantiles =>
         result.addProperty(QUANTILES_FIELD, name.quantiles.mkString(","))
         result.addProperty(RELATIVE_ERROR_FIELD, name.relativeError)
+      case _ =>
+    }
+    analyzerId match {
+      case name: AnalyzerId.Filterable => result.addProperty(WHERE_FIELD, name.filterCondition.orNull)
       case _ =>
     }
 

--- a/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
+++ b/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
@@ -41,7 +41,7 @@ private[repository] object JsonSerializationConstants {
   val STRING_LIST_TYPE: Type = new TypeToken[JList[String]]() {}.getType
 
   val ANALYZER_FIELD = "analyzer"
-  val ANALYZER_ID_FIELD = "name"
+  val ANALYZER_ID_FIELD = "analyzerId"
   val ANALYZER_NAME_FIELD = "analyzerName"
   val FIRST_COLUMN_FIELD = "firstColumn"
   val SECOND_COLUMN_FIELD = "secondColumn"
@@ -61,8 +61,6 @@ private[repository] object JsonSerializationConstants {
   val TAGS_FIELD = "tags"
   val RESULT_KEY_FIELD = "resultKey"
   val ANALYZER_CONTEXT_FIELD = "analyzerContext"
-
-  // Constants for AnalyzerName
 }
 
 private[deequ] object SimpleResultSerde {
@@ -93,7 +91,7 @@ object AnalysisResultSerde {
       .registerTypeAdapter(classOf[AnalyzerContext], AnalyzerContextSerializer)
       .registerTypeAdapter(classOf[Analyzer[State[_], Metric[_]]],
         AnalyzerSerializer)
-      .registerTypeAdapter(classOf[AnalyzerName], AnalyzerNameSerializer)
+      .registerTypeAdapter(classOf[AnalyzerId], AnalyzerIdSerializer)
       .registerTypeAdapter(classOf[Metric[_]], MetricSerializer)
       .registerTypeAdapter(classOf[Distribution], DistributionSerializer)
       .setPrettyPrinting()
@@ -108,7 +106,7 @@ object AnalysisResultSerde {
       .registerTypeAdapter(classOf[AnalysisResult], AnalysisResultDeserializer)
       .registerTypeAdapter(classOf[AnalyzerContext], AnalyzerContextDeserializer)
       .registerTypeAdapter(classOf[Analyzer[State[_], Metric[_]]], AnalyzerDeserializer)
-      .registerTypeAdapter(classOf[AnalyzerName], AnalyzerNameDeserializer)
+      .registerTypeAdapter(classOf[AnalyzerId], AnalyzerIdDeserializer)
       .registerTypeAdapter(classOf[Metric[_]], MetricDeserializer)
       .registerTypeAdapter(classOf[Distribution], DistributionDeserializer)
       .create
@@ -189,12 +187,10 @@ private[deequ] object AnalyzerContextSerializer extends JsonSerializer[AnalyzerC
 
     val metricMap = new JsonArray()
 
-    context.serialize(AnalyzerName.Size(None), classOf[AnalyzerName])
-
-    analyzerContext.metricMap.foreach { case (analyzerName, metric) =>
+    analyzerContext.metricMap.foreach { case (analyzerId, metric) =>
       val entry = new JsonObject()
 
-      entry.add(ANALYZER_ID_FIELD, context.serialize(analyzerName, classOf[AnalyzerName]))
+      entry.add(ANALYZER_ID_FIELD, context.serialize(analyzerId, classOf[AnalyzerId]))
       entry.add(METRIC_FIELD, context.serialize(metric, classOf[Metric[_]]))
 
       metricMap.add(entry)
@@ -218,15 +214,15 @@ private[deequ] object AnalyzerContextDeserializer extends JsonDeserializer[Analy
 
         val serializedAnalyzer = entry.getAsJsonObject.get(ANALYZER_ID_FIELD)
 
-        val analyzerName = context.deserialize(serializedAnalyzer,
-          classOf[AnalyzerName]).asInstanceOf[AnalyzerName]
+        val analyzerId = context.deserialize(serializedAnalyzer,
+          classOf[AnalyzerId]).asInstanceOf[AnalyzerId]
 
         val metric = context.deserialize(entry.getAsJsonObject.get(METRIC_FIELD),
           classOf[Metric[_]]).asInstanceOf[Metric[_]]
 
-        analyzerName -> metric
+        analyzerId -> metric
       }
-      .asInstanceOf[Seq[(AnalyzerName, Metric[_])]]
+      .asInstanceOf[Seq[(AnalyzerId, Metric[_])]]
       .toMap
 
     AnalyzerContext(metricMap)
@@ -373,59 +369,59 @@ private[deequ] object AnalyzerSerializer
   }
 }
 
-private[deequ] object AnalyzerNameSerializer
-  extends JsonSerializer[AnalyzerName] {
+private[deequ] object AnalyzerIdSerializer
+  extends JsonSerializer[AnalyzerId] {
 
-  override def serialize(analyzerName: AnalyzerName, t: Type,
+  override def serialize(analyzerId: AnalyzerId, t: Type,
                          context: JsonSerializationContext): JsonElement = {
 
     val result = new JsonObject()
 
-    result.addProperty(ANALYZER_NAME_FIELD, analyzerName.name)
+    result.addProperty(ANALYZER_NAME_FIELD, analyzerId.name)
 
-    analyzerName match {
-      case name: AnalyzerName.Filterable => result.addProperty(WHERE_FIELD, name.filterCondition.orNull)
+    analyzerId match {
+      case name: AnalyzerId.Filterable => result.addProperty(WHERE_FIELD, name.filterCondition.orNull)
       case _ =>
     }
-    analyzerName match {
-      case name: AnalyzerName.SingleColumn => result.addProperty(COLUMN_FIELD, name.column)
+    analyzerId match {
+      case name: AnalyzerId.SingleColumn => result.addProperty(COLUMN_FIELD, name.column)
       case _ =>
     }
-    analyzerName match {
-      case name: AnalyzerName.InstanceBased => result.addProperty(INSTANCE_FIELD, name.instance)
+    analyzerId match {
+      case name: AnalyzerId.InstanceBased => result.addProperty(INSTANCE_FIELD, name.instance)
       case _ =>
     }
-    analyzerName match {
-      case name: AnalyzerName.PredicateBased => result.addProperty(PREDICATE_FIELD, name.predicate)
+    analyzerId match {
+      case name: AnalyzerId.PredicateBased => result.addProperty(PREDICATE_FIELD, name.predicate)
       case _ =>
     }
 
-    analyzerName match {
-      case name: AnalyzerName.PatternBased => result.addProperty(PATTERN_FIELD, name.pattern)
+    analyzerId match {
+      case name: AnalyzerId.PatternBased => result.addProperty(PATTERN_FIELD, name.pattern)
       case _ =>
     }
-    analyzerName match {
-      case name: AnalyzerName.MultiColumn => result.add(COLUMNS_FIELD, context.serialize(name.columns.asJava, new TypeToken[JList[String]]() {}.getType))
+    analyzerId match {
+      case name: AnalyzerId.MultiColumn => result.add(COLUMNS_FIELD, context.serialize(name.columns.asJava, new TypeToken[JList[String]]() {}.getType))
       case _ =>
     }
-    analyzerName match {
-      case name: AnalyzerName.Binned => result.addProperty(MAX_DETAIL_BINS_FIELD, name.maxDetailBins)
+    analyzerId match {
+      case name: AnalyzerId.Binned => result.addProperty(MAX_DETAIL_BINS_FIELD, name.maxDetailBins)
       case _ =>
     }
-    analyzerName match {
-      case name: AnalyzerName.TwoColumn =>
+    analyzerId match {
+      case name: AnalyzerId.TwoColumn =>
         result.addProperty(FIRST_COLUMN_FIELD, name.column1)
         result.addProperty(SECOND_COLUMN_FIELD, name.column2)
       case _ =>
     }
-    analyzerName match {
-      case name: AnalyzerName.Quantile =>
+    analyzerId match {
+      case name: AnalyzerId.Quantile =>
         result.addProperty(QUANTILE_FIELD, name.quantile)
         result.addProperty(RELATIVE_ERROR_FIELD, name.relativeError)
       case _ =>
     }
-    analyzerName match {
-      case name: AnalyzerName.Quantiles =>
+    analyzerId match {
+      case name: AnalyzerId.Quantiles =>
         result.addProperty(QUANTILES_FIELD, name.quantiles.mkString(","))
         result.addProperty(RELATIVE_ERROR_FIELD, name.relativeError)
       case _ =>
@@ -557,8 +553,8 @@ private[deequ] object AnalyzerDeserializer
           json.get(COLUMN_FIELD).getAsString,
           getOptionalWhereParam(json))
 
-      case analyzerName =>
-        throw new IllegalArgumentException(s"Unable to deserialize analyzer $analyzerName.")
+      case analyzerId =>
+        throw new IllegalArgumentException(s"Unable to deserialize analyzer $analyzerId.")
     }
 
     analyzer.asInstanceOf[Analyzer[State[_], Metric[_]]]
@@ -573,8 +569,8 @@ private[deequ] object AnalyzerDeserializer
   }
 }
 
-private[deequ] object AnalyzerNameDeserializer
-  extends JsonDeserializer[AnalyzerName] {
+private[deequ] object AnalyzerIdDeserializer
+  extends JsonDeserializer[AnalyzerId] {
 
   private[this] def getColumnsAsSeq(context: JsonDeserializationContext,
     json: JsonObject): Seq[String] = {
@@ -584,92 +580,92 @@ private[deequ] object AnalyzerNameDeserializer
   }
 
   override def deserialize(jsonElement: JsonElement, t: Type,
-    context: JsonDeserializationContext): AnalyzerName = {
+    context: JsonDeserializationContext): AnalyzerId = {
 
     val json = jsonElement.getAsJsonObject
 
     val analyzer = json.get(ANALYZER_NAME_FIELD).getAsString match {
 
       case "Size" =>
-        AnalyzerName.Size(getOptionalWhereParam(json))
+        AnalyzerId.Size(getOptionalWhereParam(json))
 
       case "Completeness" =>
-        AnalyzerName.Completeness(json.get(COLUMN_FIELD).getAsString, getOptionalWhereParam(json))
+        AnalyzerId.Completeness(json.get(COLUMN_FIELD).getAsString, getOptionalWhereParam(json))
 
       case "Compliance" =>
-        AnalyzerName.Compliance(
+        AnalyzerId.Compliance(
           json.get("instance").getAsString,
           getOptionalWhereParam(json),
           json.get("predicate").getAsString)
 
       case "PatternMatch" =>
-        AnalyzerName.PatternMatch(
+        AnalyzerId.PatternMatch(
           json.get(COLUMN_FIELD).getAsString,
           getOptionalWhereParam(json),
           json.get("pattern").getAsString)
 
       case "Sum" =>
-        AnalyzerName.Sum(
+        AnalyzerId.Sum(
           json.get(COLUMN_FIELD).getAsString,
           getOptionalWhereParam(json))
 
       case "Mean" =>
-        AnalyzerName.Mean(
+        AnalyzerId.Mean(
           json.get(COLUMN_FIELD).getAsString,
           getOptionalWhereParam(json))
 
       case "Minimum" =>
-        AnalyzerName.Minimum(
+        AnalyzerId.Minimum(
           json.get(COLUMN_FIELD).getAsString,
           getOptionalWhereParam(json))
 
       case "Maximum" =>
-        AnalyzerName.Maximum(
+        AnalyzerId.Maximum(
           json.get(COLUMN_FIELD).getAsString,
           getOptionalWhereParam(json))
 
       case "CountDistinct" =>
-        AnalyzerName.CountDistinct(getColumnsAsSeq(context, json))
+        AnalyzerId.CountDistinct(getColumnsAsSeq(context, json))
 
       case "Distinctness" =>
-        AnalyzerName.Distinctness(getColumnsAsSeq(context, json), getOptionalWhereParam(json))
+        AnalyzerId.Distinctness(getColumnsAsSeq(context, json), getOptionalWhereParam(json))
 
       case "Entropy" =>
-        AnalyzerName.Entropy(json.get(COLUMN_FIELD).getAsString, getOptionalWhereParam(json))
+        AnalyzerId.Entropy(json.get(COLUMN_FIELD).getAsString, getOptionalWhereParam(json))
 
       case "MutualInformation" =>
-        AnalyzerName.MutualInformation(getColumnsAsSeq(context, json), getOptionalWhereParam(json))
+        AnalyzerId.MutualInformation(getColumnsAsSeq(context, json), getOptionalWhereParam(json))
 
       case "UniqueValueRatio" =>
-        AnalyzerName.UniqueValueRatio(getColumnsAsSeq(context, json), getOptionalWhereParam(json))
+        AnalyzerId.UniqueValueRatio(getColumnsAsSeq(context, json), getOptionalWhereParam(json))
 
       case "Uniqueness" =>
-        AnalyzerName.Uniqueness(getColumnsAsSeq(context, json), getOptionalWhereParam(json))
+        AnalyzerId.Uniqueness(getColumnsAsSeq(context, json), getOptionalWhereParam(json))
 
       case "Histogram" =>
-        AnalyzerName.Histogram(
+        AnalyzerId.Histogram(
           json.get(COLUMN_FIELD).getAsString,
           None,
           json.get("maxDetailBins").getAsInt)
 
       case "DataType" =>
-        AnalyzerName.DataType(
+        AnalyzerId.DataType(
           json.get(COLUMN_FIELD).getAsString,
           getOptionalWhereParam(json))
 
       case "ApproxCountDistinct" =>
-        AnalyzerName.ApproxCountDistinct(
+        AnalyzerId.ApproxCountDistinct(
           json.get(COLUMN_FIELD).getAsString,
           getOptionalWhereParam(json))
 
       case "Correlation" =>
-        AnalyzerName.Correlation(
+        AnalyzerId.Correlation(
           json.get("firstColumn").getAsString,
           json.get("secondColumn").getAsString,
           getOptionalWhereParam(json))
 
       case "StandardDeviation" =>
-        AnalyzerName.StandardDeviation(
+        AnalyzerId.StandardDeviation(
           json.get(COLUMN_FIELD).getAsString,
           getOptionalWhereParam(json))
 
@@ -677,26 +673,26 @@ private[deequ] object AnalyzerNameDeserializer
         val column = json.get(COLUMN_FIELD).getAsString
         val quantile = json.get("quantile").getAsDouble
         val relativeError = json.get("relativeError").getAsDouble
-        AnalyzerName.ApproxQuantile(column, getOptionalWhereParam(json), quantile, relativeError)
+        AnalyzerId.ApproxQuantile(column, getOptionalWhereParam(json), quantile, relativeError)
 
       case "ApproxQuantiles" =>
         val column = json.get(COLUMN_FIELD).getAsString
         val quantile = json.get("quantiles").getAsString.split(",").map { _.toDouble }
         val relativeError = json.get("relativeError").getAsDouble
-        AnalyzerName.ApproxQuantiles(column, quantile, relativeError)
+        AnalyzerId.ApproxQuantiles(column, quantile, relativeError)
 
       case "MinLength" =>
-        AnalyzerName.MinLength(
+        AnalyzerId.MinLength(
           json.get(COLUMN_FIELD).getAsString,
           getOptionalWhereParam(json))
 
       case "MaxLength" =>
-        AnalyzerName.MaxLength(
+        AnalyzerId.MaxLength(
           json.get(COLUMN_FIELD).getAsString,
           getOptionalWhereParam(json))
 
-      case analyzerName =>
-        throw new IllegalArgumentException(s"Unable to deserialize analyzer $analyzerName.")
+      case analyzerId =>
+        throw new IllegalArgumentException(s"Unable to deserialize analyzer $analyzerId.")
     }
 
     analyzer

--- a/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
+++ b/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
@@ -208,9 +208,9 @@ private[deequ] object AnalyzerContextDeserializer extends JsonDeserializer[Analy
         val metric = context.deserialize(entry.getAsJsonObject.get(METRIC_FIELD),
           classOf[Metric[_]]).asInstanceOf[Metric[_]]
 
-        analyzer.asInstanceOf[Analyzer[State[_], Metric[_]]] -> metric
+        analyzer.id -> metric
       }
-      .asInstanceOf[Seq[(Analyzer[_, Metric[_]], Metric[_])]]
+      .asInstanceOf[Seq[(AnalyzerId, Metric[_])]]
       .toMap
 
     AnalyzerContext(metricMap)

--- a/src/main/scala/com/amazon/deequ/repository/MetricsRepositoryMultipleResultsLoader.scala
+++ b/src/main/scala/com/amazon/deequ/repository/MetricsRepositoryMultipleResultsLoader.scala
@@ -16,10 +16,10 @@
 
 package com.amazon.deequ.repository
 
-import com.amazon.deequ.analyzers.AnalyzerId
+import com.amazon.deequ.analyzers.AnalyzerName
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.{Column, DataFrame, SparkSession}
+import org.apache.spark.sql.{Column, DataFrame, Dataset, SparkSession}
 
 trait MetricsRepositoryMultipleResultsLoader {
 
@@ -35,7 +35,7 @@ trait MetricsRepositoryMultipleResultsLoader {
     *
     * @param analyzers A sequence of analyers who's resulting metrics you want to load
     */
-  def forAnalyzers(analyzers: Seq[AnalyzerId]): MetricsRepositoryMultipleResultsLoader
+  def forAnalyzers(analyzers: Seq[AnalyzerName]): MetricsRepositoryMultipleResultsLoader
 
   /**
     * Convenience method to only look at AnalysisResults with a history key with a greater value
@@ -61,6 +61,7 @@ trait MetricsRepositoryMultipleResultsLoader {
     */
   def getSuccessMetricsAsDataFrame(sparkSession: SparkSession, withTags: Seq[String] = Seq.empty)
   : DataFrame = {
+    import sparkSession.implicits.newProductEncoder
     val analysisResults = get()
 
     if (analysisResults.isEmpty) {
@@ -117,7 +118,7 @@ private[repository] object MetricsRepositoryMultipleResultsLoader {
     SimpleResultSerde.serialize(unioned)
   }
 
-  def dataFrameUnion(dataFrameOne: DataFrame, dataFrameTwo: DataFrame): DataFrame = {
+  def dataFrameUnion(dataFrameOne: Dataset[_], dataFrameTwo: Dataset[_]): DataFrame = {
 
     val columnsOne = dataFrameOne.columns.toSeq
     val columnsTwo = dataFrameTwo.columns.toSeq

--- a/src/main/scala/com/amazon/deequ/repository/MetricsRepositoryMultipleResultsLoader.scala
+++ b/src/main/scala/com/amazon/deequ/repository/MetricsRepositoryMultipleResultsLoader.scala
@@ -16,12 +16,10 @@
 
 package com.amazon.deequ.repository
 
-import com.amazon.deequ.analyzers.Analyzer
-import com.amazon.deequ.metrics.Metric
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import com.amazon.deequ.analyzers.AnalyzerId
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
 import org.apache.spark.sql.functions._
-import org.apache.spark.sql.Column
+import org.apache.spark.sql.{Column, DataFrame, SparkSession}
 
 trait MetricsRepositoryMultipleResultsLoader {
 
@@ -37,7 +35,7 @@ trait MetricsRepositoryMultipleResultsLoader {
     *
     * @param analyzers A sequence of analyers who's resulting metrics you want to load
     */
-  def forAnalyzers(analyzers: Seq[Analyzer[_, Metric[_]]]): MetricsRepositoryMultipleResultsLoader
+  def forAnalyzers(analyzers: Seq[AnalyzerId]): MetricsRepositoryMultipleResultsLoader
 
   /**
     * Convenience method to only look at AnalysisResults with a history key with a greater value

--- a/src/main/scala/com/amazon/deequ/repository/MetricsRepositoryMultipleResultsLoader.scala
+++ b/src/main/scala/com/amazon/deequ/repository/MetricsRepositoryMultipleResultsLoader.scala
@@ -16,7 +16,7 @@
 
 package com.amazon.deequ.repository
 
-import com.amazon.deequ.analyzers.AnalyzerName
+import com.amazon.deequ.analyzers.AnalyzerId
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
 import org.apache.spark.sql.functions._
 import org.apache.spark.sql.{Column, DataFrame, Dataset, SparkSession}
@@ -35,7 +35,7 @@ trait MetricsRepositoryMultipleResultsLoader {
     *
     * @param analyzers A sequence of analyers who's resulting metrics you want to load
     */
-  def forAnalyzers(analyzers: Seq[AnalyzerName]): MetricsRepositoryMultipleResultsLoader
+  def forAnalyzers(analyzers: Seq[AnalyzerId]): MetricsRepositoryMultipleResultsLoader
 
   /**
     * Convenience method to only look at AnalysisResults with a history key with a greater value
@@ -61,7 +61,6 @@ trait MetricsRepositoryMultipleResultsLoader {
     */
   def getSuccessMetricsAsDataFrame(sparkSession: SparkSession, withTags: Seq[String] = Seq.empty)
   : DataFrame = {
-    import sparkSession.implicits.newProductEncoder
     val analysisResults = get()
 
     if (analysisResults.isEmpty) {

--- a/src/main/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepository.scala
+++ b/src/main/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepository.scala
@@ -19,7 +19,7 @@ package com.amazon.deequ.repository.fs
 import java.io.{BufferedInputStream, BufferedOutputStream}
 import java.util.UUID.randomUUID
 
-import com.amazon.deequ.analyzers.AnalyzerName
+import com.amazon.deequ.analyzers.AnalyzerId
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
 import com.amazon.deequ.repository._
 import com.google.common.io.Closeables
@@ -77,7 +77,7 @@ class FileSystemMetricsRepositoryMultipleResultsLoader(
   session: SparkSession, path: String) extends MetricsRepositoryMultipleResultsLoader {
 
   private[this] var tagValues: Option[Map[String, String]] = None
-  private[this] var forAnalyzers: Option[Seq[AnalyzerName]] = None
+  private[this] var forAnalyzers: Option[Seq[AnalyzerId]] = None
   private[this] var before: Option[Long] = None
   private[this] var after: Option[Long] = None
 
@@ -96,7 +96,7 @@ class FileSystemMetricsRepositoryMultipleResultsLoader(
     *
     * @param analyzers A sequence of analyers who's resulting metrics you want to load
     */
-  def forAnalyzers(analyzers: Seq[AnalyzerName])
+  def forAnalyzers(analyzers: Seq[AnalyzerId])
     : MetricsRepositoryMultipleResultsLoader = {
 
     this.forAnalyzers = Option(analyzers)

--- a/src/main/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepository.scala
+++ b/src/main/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepository.scala
@@ -16,16 +16,16 @@
 
 package com.amazon.deequ.repository.fs
 
-import com.amazon.deequ.analyzers.Analyzer
+import java.io.{BufferedInputStream, BufferedOutputStream}
+import java.util.UUID.randomUUID
+
+import com.amazon.deequ.analyzers.AnalyzerName
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
-import com.amazon.deequ.metrics.Metric
-import com.amazon.deequ.repository.{AnalysisResult, AnalysisResultSerde, MetricsRepository, MetricsRepositoryMultipleResultsLoader, ResultKey}
+import com.amazon.deequ.repository._
+import com.google.common.io.Closeables
+import org.apache.commons.io.IOUtils
 import org.apache.hadoop.fs.{FileSystem, Path}
 import org.apache.spark.sql.SparkSession
-import java.util.UUID.randomUUID
-import com.google.common.io.Closeables
-import java.io.{BufferedInputStream, BufferedOutputStream}
-import org.apache.commons.io.IOUtils
 
 
 /** A Repository implementation using a file system */
@@ -77,7 +77,7 @@ class FileSystemMetricsRepositoryMultipleResultsLoader(
   session: SparkSession, path: String) extends MetricsRepositoryMultipleResultsLoader {
 
   private[this] var tagValues: Option[Map[String, String]] = None
-  private[this] var forAnalyzers: Option[Seq[Analyzer[_, Metric[_]]]] = None
+  private[this] var forAnalyzers: Option[Seq[AnalyzerName]] = None
   private[this] var before: Option[Long] = None
   private[this] var after: Option[Long] = None
 
@@ -96,7 +96,7 @@ class FileSystemMetricsRepositoryMultipleResultsLoader(
     *
     * @param analyzers A sequence of analyers who's resulting metrics you want to load
     */
-  def forAnalyzers(analyzers: Seq[Analyzer[_, Metric[_]]])
+  def forAnalyzers(analyzers: Seq[AnalyzerName])
     : MetricsRepositoryMultipleResultsLoader = {
 
     this.forAnalyzers = Option(analyzers)

--- a/src/main/scala/com/amazon/deequ/repository/memory/InMemoryMetricsRepository.scala
+++ b/src/main/scala/com/amazon/deequ/repository/memory/InMemoryMetricsRepository.scala
@@ -16,13 +16,13 @@
 
 package com.amazon.deequ.repository.memory
 
-import com.amazon.deequ.analyzers.Analyzer
-import com.amazon.deequ.metrics.Metric
-import com.amazon.deequ.repository._
+import java.util.concurrent.ConcurrentHashMap
+
+import com.amazon.deequ.analyzers.AnalyzerName
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
+import com.amazon.deequ.repository._
 
 import scala.collection.JavaConversions._
-import java.util.concurrent.ConcurrentHashMap
 
 /** A simple Repository implementation backed by a concurrent hash map */
 class InMemoryMetricsRepository() extends MetricsRepository {
@@ -69,7 +69,7 @@ class LimitedInMemoryMetricsRepositoryMultipleResultsLoader(
 
 
   private[this] var tagValues: Option[Map[String, String]] = None
-  private[this] var forAnalyzers: Option[Seq[Analyzer[_, Metric[_]]]] = None
+  private[this] var forAnalyzers: Option[Seq[AnalyzerName]] = None
   private[this] var before: Option[Long] = None
   private[this] var after: Option[Long] = None
 
@@ -88,7 +88,7 @@ class LimitedInMemoryMetricsRepositoryMultipleResultsLoader(
     *
     * @param analyzers A sequence of analyers who's resulting metrics you want to load
     */
-  def forAnalyzers(analyzers: Seq[Analyzer[_, Metric[_]]])
+  def forAnalyzers(analyzers: Seq[AnalyzerName])
     : MetricsRepositoryMultipleResultsLoader = {
 
     this.forAnalyzers = Option(analyzers)

--- a/src/main/scala/com/amazon/deequ/repository/memory/InMemoryMetricsRepository.scala
+++ b/src/main/scala/com/amazon/deequ/repository/memory/InMemoryMetricsRepository.scala
@@ -18,7 +18,7 @@ package com.amazon.deequ.repository.memory
 
 import java.util.concurrent.ConcurrentHashMap
 
-import com.amazon.deequ.analyzers.AnalyzerName
+import com.amazon.deequ.analyzers.AnalyzerId
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
 import com.amazon.deequ.repository._
 
@@ -69,7 +69,7 @@ class LimitedInMemoryMetricsRepositoryMultipleResultsLoader(
 
 
   private[this] var tagValues: Option[Map[String, String]] = None
-  private[this] var forAnalyzers: Option[Seq[AnalyzerName]] = None
+  private[this] var forAnalyzers: Option[Seq[AnalyzerId]] = None
   private[this] var before: Option[Long] = None
   private[this] var after: Option[Long] = None
 
@@ -88,7 +88,7 @@ class LimitedInMemoryMetricsRepositoryMultipleResultsLoader(
     *
     * @param analyzers A sequence of analyers who's resulting metrics you want to load
     */
-  def forAnalyzers(analyzers: Seq[AnalyzerName])
+  def forAnalyzers(analyzers: Seq[AnalyzerId])
     : MetricsRepositoryMultipleResultsLoader = {
 
     this.forAnalyzers = Option(analyzers)

--- a/src/test/scala/com/amazon/deequ/VerificationResultTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationResultTest.scala
@@ -21,7 +21,7 @@ import com.amazon.deequ.checks.{Check, CheckLevel}
 import com.amazon.deequ.metrics.Metric
 import com.amazon.deequ.repository.SimpleResultSerde
 import com.amazon.deequ.utils.FixtureSupport
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 import org.scalatest.{Matchers, WordSpec}
 
 class VerificationResultTest extends WordSpec with Matchers with SparkContextSpec
@@ -209,8 +209,8 @@ class VerificationResultTest extends WordSpec with Matchers with SparkContextSpe
     checkToSucceed :: checkToErrorOut :: checkToWarn :: Nil
   }
 
-  private[this] def assertSameRows(dataframeA: DataFrame, dataframeB: DataFrame): Unit = {
-    assert(dataframeA.collect().toSet == dataframeB.collect().toSet)
+  private[this] def assertSameRows(dataframeA: Dataset[_], dataframeB: Dataset[_]): Unit = {
+    assert(dataframeA.toDF.collect().toSet == dataframeB.toDF.collect().toSet)
   }
 
   private[this] def assertSameResultsJson(jsonA: String, jsonB: String): Unit = {

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -236,7 +236,7 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
             .addRequiredAnalyzers(analyzers).run()
         val expectedAnalyzerContextOnLoadByKey = AnalyzerContext(actualResult.metrics)
 
-        val resultWhichShouldBeOverwritten = AnalyzerContext(Map(AnalyzerName.Size(None) -> DoubleMetric(
+        val resultWhichShouldBeOverwritten = AnalyzerContext(Map(AnalyzerId.Size(None) -> DoubleMetric(
           Entity.Dataset, "", "", util.Try(100.0))))
 
         repository.save(resultKey, resultWhichShouldBeOverwritten)
@@ -371,8 +371,8 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
         .aggregateWith(stateLoaderStub)
         .run()
 
-      assert(results.metrics(AnalyzerName.Sum("att2", None)).value.get == 18.0 * 2)
-      assert(results.metrics(AnalyzerName.Completeness("att1", None)).value.get == 0.5)
+      assert(results.metrics(AnalyzerId.Sum("att2", None)).value.get == 18.0 * 2)
+      assert(results.metrics(AnalyzerId.Completeness("att1", None)).value.get == 0.5)
     }
 
     "keep order of check constraints and their results" in withSparkSession { sparkSession =>
@@ -413,14 +413,14 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
 
     (1 to 2).foreach { timeStamp =>
       val analyzerContext = new AnalyzerContext(Map(
-        AnalyzerName.Size(None) -> DoubleMetric(Entity.Column, "", "", util.Success(timeStamp))
+        AnalyzerId.Size(None) -> DoubleMetric(Entity.Column, "", "", util.Success(timeStamp))
       ))
       repository.save(ResultKey(timeStamp, Map("Region" -> "EU")), analyzerContext)
     }
 
     (3 to 4).foreach { timeStamp =>
       val analyzerContext = new AnalyzerContext(Map(
-        AnalyzerName.Size(None) -> DoubleMetric(Entity.Column, "", "", util.Success(timeStamp))
+        AnalyzerId.Size(None) -> DoubleMetric(Entity.Column, "", "", util.Success(timeStamp))
       ))
       repository.save(ResultKey(timeStamp, Map("Region" -> "NA")), analyzerContext)
     }

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalysisTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalysisTest.scala
@@ -108,7 +108,7 @@ class AnalysisTest extends WordSpec with Matchers with SparkContextSpec with Fix
 
       val analyzerContext = analysis.run(df)
 
-      assert(analyzerContext.metricMap(AnalyzerName.Mean("nonExistingColumnName", None)).value.compareFailureTypes(
+      assert(analyzerContext.metricMap(AnalyzerId.Mean("nonExistingColumnName", None)).value.compareFailureTypes(
         Failure(new NoSuchColumnException(""))))
     }
 
@@ -121,7 +121,7 @@ class AnalysisTest extends WordSpec with Matchers with SparkContextSpec with Fix
 
         val analyzerContext = analysis.run(df)
 
-        assert(analyzerContext.metricMap(AnalyzerName.Mean("att2", None)).value.compareFailureTypes(
+        assert(analyzerContext.metricMap(AnalyzerId.Mean("att2", None)).value.compareFailureTypes(
           Failure(new WrongColumnTypeException(""))))
       }
 
@@ -134,7 +134,7 @@ class AnalysisTest extends WordSpec with Matchers with SparkContextSpec with Fix
 
         val analyzerContext = analysis.run(df)
 
-        assert(analyzerContext.metricMap(AnalyzerName.Distinctness(Seq.empty, None)).value.compareFailureTypes(
+        assert(analyzerContext.metricMap(AnalyzerId.Distinctness(Seq.empty, None)).value.compareFailureTypes(
           Failure(new NoColumnsSpecifiedException(""))))
       }
 
@@ -147,7 +147,7 @@ class AnalysisTest extends WordSpec with Matchers with SparkContextSpec with Fix
 
         val analyzerContext = analysis.run(df)
 
-        assert(analyzerContext.metricMap(AnalyzerName.MutualInformation(Seq("att2"), None)).value.compareFailureTypes(
+        assert(analyzerContext.metricMap(AnalyzerId.MutualInformation(Seq("att2"), None)).value.compareFailureTypes(
           Failure(new NumberOfSpecifiedColumnsException(""))))
       }
 
@@ -160,7 +160,7 @@ class AnalysisTest extends WordSpec with Matchers with SparkContextSpec with Fix
 
         val analyzerContext = analysis.run(df)
 
-        assert(analyzerContext.metricMap(AnalyzerName.Histogram("att2", None, Integer.MAX_VALUE))
+        assert(analyzerContext.metricMap(AnalyzerId.Histogram("att2", None, Integer.MAX_VALUE))
           .value.compareFailureTypes(Failure(new IllegalAnalyzerParameterException(""))))
       }
 
@@ -173,7 +173,7 @@ class AnalysisTest extends WordSpec with Matchers with SparkContextSpec with Fix
 
         val analyzerContext = analysis.run(df)
 
-        assert(analyzerContext.metricMap(AnalyzerName.ApproxQuantile("att2", None, 1.1, 0.01))
+        assert(analyzerContext.metricMap(AnalyzerId.ApproxQuantile("att2", None, 1.1, 0.01))
           .value.compareFailureTypes(Failure(new IllegalAnalyzerParameterException(""))))
       }
 
@@ -186,7 +186,7 @@ class AnalysisTest extends WordSpec with Matchers with SparkContextSpec with Fix
 
         val analyzerContext = analysis.run(df)
 
-        assert(analyzerContext.metricMap(AnalyzerName.ApproxQuantile("att2", None, 0.5, -0.1))
+        assert(analyzerContext.metricMap(AnalyzerId.ApproxQuantile("att2", None, 0.5, -0.1))
           .value.compareFailureTypes(Failure(new IllegalAnalyzerParameterException(""))))
       }
 
@@ -205,7 +205,7 @@ class AnalysisTest extends WordSpec with Matchers with SparkContextSpec with Fix
 
         val analyzerContext = analysis.run(df)
 
-        assert(analyzerContext.metricMap(failingMean.name).value.compareOuterAndInnerFailureTypes(
+        assert(analyzerContext.metricMap(failingMean.id).value.compareOuterAndInnerFailureTypes(
           Failure(new MetricCalculationRuntimeException(meanException))))
       }
   }
@@ -230,13 +230,13 @@ class AnalysisTest extends WordSpec with Matchers with SparkContextSpec with Fix
 
         val analyzerContext = analysis.run(df)
 
-        assert(analyzerContext.metricMap(AnalyzerName.Mean("att1", None)).value.compareOuterAndInnerFailureTypes(
+        assert(analyzerContext.metricMap(AnalyzerId.Mean("att1", None)).value.compareOuterAndInnerFailureTypes(
           Failure(new MetricCalculationRuntimeException(meanException))))
 
-        analyzerContext.metricMap(AnalyzerName.Minimum("att1", None)).value should be
+        analyzerContext.metricMap(AnalyzerId.Minimum("att1", None)).value should be
           DoubleMetric(Entity.Column, "Minimum", "att1", Success(1.0))
 
-        analyzerContext.metricMap(AnalyzerName.Maximum("att1", None)).value should be
+        analyzerContext.metricMap(AnalyzerId.Maximum("att1", None)).value should be
           DoubleMetric(Entity.Column, "Maximum", "att1", Success(6.0))
     }
 
@@ -256,13 +256,13 @@ class AnalysisTest extends WordSpec with Matchers with SparkContextSpec with Fix
 
         val analyzerContext = analysis.run(df)
 
-        assert(analyzerContext.metricMap(aggFailingMean.name).value.compareOuterAndInnerFailureTypes(
+        assert(analyzerContext.metricMap(aggFailingMean.id).value.compareOuterAndInnerFailureTypes(
           Failure(new MetricCalculationRuntimeException(aggregationException))))
 
-        assert(analyzerContext.metricMap(AnalyzerName.Minimum("att1", None)).value.compareOuterAndInnerFailureTypes(
+        assert(analyzerContext.metricMap(AnalyzerId.Minimum("att1", None)).value.compareOuterAndInnerFailureTypes(
           Failure(new MetricCalculationRuntimeException(aggregationException))))
 
-        assert(analyzerContext.metricMap(AnalyzerName.Maximum("att1", None)).value.compareOuterAndInnerFailureTypes(
+        assert(analyzerContext.metricMap(AnalyzerId.Maximum("att1", None)).value.compareOuterAndInnerFailureTypes(
           Failure(new MetricCalculationRuntimeException(aggregationException))))
 
       }
@@ -288,14 +288,14 @@ class AnalysisTest extends WordSpec with Matchers with SparkContextSpec with Fix
 
         val analyzerContext = analysis.run(df)
 
-        assert(analyzerContext.metricMap(failingDistinctness.name).value
+        assert(analyzerContext.metricMap(failingDistinctness.id).value
           .compareOuterAndInnerFailureTypes(Failure(
             new MetricCalculationRuntimeException(distinctnessException))))
 
-        analyzerContext.metricMap(AnalyzerName.Entropy("att1", None)).value should be
+        analyzerContext.metricMap(AnalyzerId.Entropy("att1", None)).value should be
           DoubleMetric(Entity.Column, "Uniqueness", "att1", Success(1.0))
 
-        analyzerContext.metricMap(AnalyzerName.Uniqueness("att1", None)).value should be
+        analyzerContext.metricMap(AnalyzerId.Uniqueness("att1", None)).value should be
           DoubleMetric(Entity.Column, "Maximum", "att1", Success(6.0))
       }
 
@@ -315,14 +315,14 @@ class AnalysisTest extends WordSpec with Matchers with SparkContextSpec with Fix
 
         val analyzerContext = analysis.run(df)
 
-        assert(analyzerContext.metricMap(failingDistinctness.name).value
+        assert(analyzerContext.metricMap(failingDistinctness.id).value
           .compareOuterAndInnerFailureTypes(Failure(
             new MetricCalculationRuntimeException(aggregationException))))
 
-        assert(analyzerContext.metricMap(AnalyzerName.Entropy("att1", None)).value.compareOuterAndInnerFailureTypes(
+        assert(analyzerContext.metricMap(AnalyzerId.Entropy("att1", None)).value.compareOuterAndInnerFailureTypes(
           Failure(new MetricCalculationRuntimeException(aggregationException))))
 
-        assert(analyzerContext.metricMap(AnalyzerName.Uniqueness("att1", None)).value.compareOuterAndInnerFailureTypes(
+        assert(analyzerContext.metricMap(AnalyzerId.Uniqueness("att1", None)).value.compareOuterAndInnerFailureTypes(
           Failure(new MetricCalculationRuntimeException(aggregationException))))
       }
   }

--- a/src/test/scala/com/amazon/deequ/analyzers/IncrementalAnalysisTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/IncrementalAnalysisTest.scala
@@ -77,8 +77,8 @@ class IncrementalAnalysisTest extends WordSpec with Matchers with SparkContextSp
         analysis.run(initial, saveStatesWith = Some(initialStates))
         val results = analysis.run(delta, aggregateWith = Some(initialStates))
 
-        results.metricMap.foreach { case (analyzer, metric) =>
-          val nonIncrementalMetric = analyzer.calculate(everything)
+        results.metricMap.foreach { case (analyzerName, metric) =>
+          val nonIncrementalMetric = analyzers.find(_.name == analyzerName).get.calculate(everything)
           assert(nonIncrementalMetric == metric)
         }
       }
@@ -90,15 +90,16 @@ class IncrementalAnalysisTest extends WordSpec with Matchers with SparkContextSp
         val delta = deltaData(session)
         val everything = initial.union(delta)
 
-        val analysis = Analysis(Uniqueness("value") :: Entropy("value") :: Nil)
+        val analyzers = Uniqueness("value") :: Entropy("value") :: Nil
+        val analysis = Analysis(analyzers)
 
         val initialStates = InMemoryStateProvider()
 
         analysis.run(initial, saveStatesWith = Some(initialStates))
         val results = analysis.run(delta, aggregateWith = Some(initialStates))
 
-        results.metricMap.foreach { case (analyzer, metric) =>
-          val nonIncrementalMetric = analyzer.calculate(everything)
+        results.metricMap.foreach { case (analyzerName, metric) =>
+          val nonIncrementalMetric = analyzers.find(_.name == analyzerName).head.calculate(everything)
           assert(nonIncrementalMetric == metric)
         }
       }

--- a/src/test/scala/com/amazon/deequ/analyzers/IncrementalAnalysisTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/IncrementalAnalysisTest.scala
@@ -77,8 +77,8 @@ class IncrementalAnalysisTest extends WordSpec with Matchers with SparkContextSp
         analysis.run(initial, saveStatesWith = Some(initialStates))
         val results = analysis.run(delta, aggregateWith = Some(initialStates))
 
-        results.metricMap.foreach { case (analyzerName, metric) =>
-          val nonIncrementalMetric = analyzers.find(_.name == analyzerName).get.calculate(everything)
+        results.metricMap.foreach { case (analyzerId, metric) =>
+          val nonIncrementalMetric = analyzers.find(_.id == analyzerId).get.calculate(everything)
           assert(nonIncrementalMetric == metric)
         }
       }
@@ -98,8 +98,8 @@ class IncrementalAnalysisTest extends WordSpec with Matchers with SparkContextSp
         analysis.run(initial, saveStatesWith = Some(initialStates))
         val results = analysis.run(delta, aggregateWith = Some(initialStates))
 
-        results.metricMap.foreach { case (analyzerName, metric) =>
-          val nonIncrementalMetric = analyzers.find(_.name == analyzerName).head.calculate(everything)
+        results.metricMap.foreach { case (analyzerId, metric) =>
+          val nonIncrementalMetric = analyzers.find(_.id == analyzerId).head.calculate(everything)
           assert(nonIncrementalMetric == metric)
         }
       }

--- a/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
@@ -311,7 +311,7 @@ class AnalysisRunnerTests extends WordSpec with Matchers with SparkContextSpec w
       val expectedAnalyzerContextOnLoadByKey = AnalysisRunner.onData(df).useRepository(repository)
           .addAnalyzers(analyzers).run()
 
-      val resultWhichShouldBeOverwritten = AnalyzerContext(Map(AnalyzerName.Size(None) -> DoubleMetric(
+      val resultWhichShouldBeOverwritten = AnalyzerContext(Map(AnalyzerId.Size(None) -> DoubleMetric(
         Entity.Dataset, "", "", Try(100.0))))
       repository.save(resultKey, resultWhichShouldBeOverwritten)
 

--- a/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
@@ -311,7 +311,7 @@ class AnalysisRunnerTests extends WordSpec with Matchers with SparkContextSpec w
       val expectedAnalyzerContextOnLoadByKey = AnalysisRunner.onData(df).useRepository(repository)
           .addAnalyzers(analyzers).run()
 
-      val resultWhichShouldBeOverwritten = AnalyzerContext(Map(Size() -> DoubleMetric(
+      val resultWhichShouldBeOverwritten = AnalyzerContext(Map(AnalyzerName.Size(None) -> DoubleMetric(
         Entity.Dataset, "", "", Try(100.0))))
       repository.save(resultKey, resultWhichShouldBeOverwritten)
 

--- a/src/test/scala/com/amazon/deequ/analyzers/runners/AnalyzerContextTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/runners/AnalyzerContextTest.scala
@@ -21,7 +21,7 @@ import com.amazon.deequ.utils.FixtureSupport
 import org.scalatest.{Matchers, WordSpec}
 import com.amazon.deequ.analyzers._
 import com.amazon.deequ.repository.SimpleResultSerde
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 
 class AnalyzerContextTest extends WordSpec with Matchers with SparkContextSpec with FixtureSupport {
 
@@ -125,8 +125,8 @@ class AnalyzerContextTest extends WordSpec with Matchers with SparkContextSpec w
       .addAnalyzer(Uniqueness(Seq("att1", "att2")))
   }
 
-  private[this] def assertSameRows(dataframeA: DataFrame, dataframeB: DataFrame): Unit = {
-    assert(dataframeA.collect().toSet == dataframeB.collect().toSet)
+  private[this] def assertSameRows(dataframeA: Dataset[_], dataframeB: Dataset[_]): Unit = {
+    assert(dataframeA.toDF.collect().toSet == dataframeB.toDF.collect().toSet)
   }
 
   private[this] def assertSameJson(jsonA: String, jsonB: String): Unit = {

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -1043,8 +1043,8 @@ class CheckTest extends WordSpec with Matchers with SparkContextSpec with Fixtur
 
     (1 to 2).foreach { timeStamp =>
       val analyzerContext = new AnalyzerContext(Map(
-        Size() -> DoubleMetric(Entity.Column, "", "", Success(timeStamp)),
-        Distinctness(Seq("c0", "c1")) -> DoubleMetric(Entity.Column, "", "",
+        AnalyzerName.Size(None) -> DoubleMetric(Entity.Column, "", "", Success(timeStamp)),
+        AnalyzerName.Distinctness(Seq("c0", "c1"), None) -> DoubleMetric(Entity.Column, "", "",
           Success(timeStamp))
       ))
       repository.save(ResultKey(timeStamp, Map("Region" -> "EU")), analyzerContext)
@@ -1052,8 +1052,8 @@ class CheckTest extends WordSpec with Matchers with SparkContextSpec with Fixtur
 
     (3 to 4).foreach { timeStamp =>
       val analyzerContext = new AnalyzerContext(Map(
-        Size() -> DoubleMetric(Entity.Column, "", "", Success(timeStamp)),
-        Distinctness(Seq("c0", "c1")) -> DoubleMetric(Entity.Column, "", "",
+        AnalyzerName.Size(None) -> DoubleMetric(Entity.Column, "", "", Success(timeStamp)),
+        AnalyzerName.Distinctness(Seq("c0", "c1"), None) -> DoubleMetric(Entity.Column, "", "",
           Success(timeStamp))
       ))
       repository.save(ResultKey(timeStamp, Map("Region" -> "NA")), analyzerContext)

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -1043,8 +1043,8 @@ class CheckTest extends WordSpec with Matchers with SparkContextSpec with Fixtur
 
     (1 to 2).foreach { timeStamp =>
       val analyzerContext = new AnalyzerContext(Map(
-        AnalyzerName.Size(None) -> DoubleMetric(Entity.Column, "", "", Success(timeStamp)),
-        AnalyzerName.Distinctness(Seq("c0", "c1"), None) -> DoubleMetric(Entity.Column, "", "",
+        AnalyzerId.Size(None) -> DoubleMetric(Entity.Column, "", "", Success(timeStamp)),
+        AnalyzerId.Distinctness(Seq("c0", "c1"), None) -> DoubleMetric(Entity.Column, "", "",
           Success(timeStamp))
       ))
       repository.save(ResultKey(timeStamp, Map("Region" -> "EU")), analyzerContext)
@@ -1052,8 +1052,8 @@ class CheckTest extends WordSpec with Matchers with SparkContextSpec with Fixtur
 
     (3 to 4).foreach { timeStamp =>
       val analyzerContext = new AnalyzerContext(Map(
-        AnalyzerName.Size(None) -> DoubleMetric(Entity.Column, "", "", Success(timeStamp)),
-        AnalyzerName.Distinctness(Seq("c0", "c1"), None) -> DoubleMetric(Entity.Column, "", "",
+        AnalyzerId.Size(None) -> DoubleMetric(Entity.Column, "", "", Success(timeStamp)),
+        AnalyzerId.Distinctness(Seq("c0", "c1"), None) -> DoubleMetric(Entity.Column, "", "",
           Success(timeStamp))
       ))
       repository.save(ResultKey(timeStamp, Map("Region" -> "NA")), analyzerContext)

--- a/src/test/scala/com/amazon/deequ/constraints/AnalysisBasedConstraintTest.scala
+++ b/src/test/scala/com/amazon/deequ/constraints/AnalysisBasedConstraintTest.scala
@@ -44,7 +44,7 @@ class AnalysisBasedConstraintTest extends WordSpec with Matchers with SparkConte
     * Sample analyzer that returns a 1.0 value if the given column exists and fails otherwise.
     */
   case class SampleAnalyzer(column: String) extends Analyzer[NumMatches, DoubleMetric] {
-    override def name: AnalyzerName = AnalyzerName.CustomAnalyzerName("SampleAnalyzer", column)
+    override def id: AnalyzerId = AnalyzerId.CustomAnalyzerId("SampleAnalyzer", column)
 
     override def toFailureMetric(exception: Exception): DoubleMetric = {
       DoubleMetric(Entity.Column, "sample", column, Failure(MetricCalculationException
@@ -129,10 +129,10 @@ class AnalysisBasedConstraintTest extends WordSpec with Matchers with SparkConte
     "get the analysis from the context, if provided" in withSparkSession { sparkSession =>
       val df = getDfMissing(sparkSession)
 
-      val emptyResults = Map.empty[AnalyzerName, Metric[_]]
-      val validResults = Map[AnalyzerName, Metric[_]](
-        AnalyzerName.CustomAnalyzerName("SampleAnalyzer", "att1") -> SampleAnalyzer("att1").calculate(df),
-        AnalyzerName.CustomAnalyzerName("SampleAnalyzer", "someMissingColumn") -> SampleAnalyzer("someMissingColumn").calculate(df)
+      val emptyResults = Map.empty[AnalyzerId, Metric[_]]
+      val validResults = Map[AnalyzerId, Metric[_]](
+        AnalyzerId.CustomAnalyzerId("SampleAnalyzer", "att1") -> SampleAnalyzer("att1").calculate(df),
+        AnalyzerId.CustomAnalyzerId("SampleAnalyzer", "someMissingColumn") -> SampleAnalyzer("someMissingColumn").calculate(df)
       )
 
       // Analysis result should equal to 1.0 for an existing column
@@ -158,8 +158,8 @@ class AnalysisBasedConstraintTest extends WordSpec with Matchers with SparkConte
     "execute value picker on the analysis result value retrieved from context, if provided" in
       withSparkSession { sparkSession =>
         val df = getDfMissing(sparkSession)
-        val validResults = Map[AnalyzerName, Metric[_]](
-          AnalyzerName.CustomAnalyzerName("SampleAnalyzer", "att1") -> SampleAnalyzer("att1").calculate(df))
+        val validResults = Map[AnalyzerId, Metric[_]](
+          AnalyzerId.CustomAnalyzerId("SampleAnalyzer", "att1") -> SampleAnalyzer("att1").calculate(df))
 
         assert(AnalysisBasedConstraint[NumMatches, Double, Double](
             SampleAnalyzer("att1"), _ == 2.0, Some(valueDoubler))
@@ -174,9 +174,9 @@ class AnalysisBasedConstraintTest extends WordSpec with Matchers with SparkConte
 
       val df = getDfMissing(sparkSession)
 
-      val emptyResults = Map.empty[AnalyzerName, Metric[_]]
-      val validResults = Map[AnalyzerName, Metric[_]](
-        AnalyzerName.CustomAnalyzerName("SampleAnalyzer", "att1") -> SampleAnalyzer("att1").calculate(df))
+      val emptyResults = Map.empty[AnalyzerId, Metric[_]]
+      val validResults = Map[AnalyzerId, Metric[_]](
+        AnalyzerId.CustomAnalyzerId("SampleAnalyzer", "att1") -> SampleAnalyzer("att1").calculate(df))
 
       val constraint = AnalysisBasedConstraint[NumMatches, Double, Double](
           SampleAnalyzer("att1"), _ == 1.0, Some(problematicValuePicker))

--- a/src/test/scala/com/amazon/deequ/constraints/AnalysisBasedConstraintTest.scala
+++ b/src/test/scala/com/amazon/deequ/constraints/AnalysisBasedConstraintTest.scala
@@ -44,6 +44,8 @@ class AnalysisBasedConstraintTest extends WordSpec with Matchers with SparkConte
     * Sample analyzer that returns a 1.0 value if the given column exists and fails otherwise.
     */
   case class SampleAnalyzer(column: String) extends Analyzer[NumMatches, DoubleMetric] {
+    override def name: AnalyzerName = AnalyzerName.CustomAnalyzerName("SampleAnalyzer", column)
+
     override def toFailureMetric(exception: Exception): DoubleMetric = {
       DoubleMetric(Entity.Column, "sample", column, Failure(MetricCalculationException
         .wrapIfNecessary(exception)))
@@ -127,10 +129,10 @@ class AnalysisBasedConstraintTest extends WordSpec with Matchers with SparkConte
     "get the analysis from the context, if provided" in withSparkSession { sparkSession =>
       val df = getDfMissing(sparkSession)
 
-      val emptyResults = Map.empty[Analyzer[_, Metric[_]], Metric[_]]
-      val validResults = Map[Analyzer[_, Metric[_]], Metric[_]](
-        SampleAnalyzer("att1") -> SampleAnalyzer("att1").calculate(df),
-        SampleAnalyzer("someMissingColumn") -> SampleAnalyzer("someMissingColumn").calculate(df)
+      val emptyResults = Map.empty[AnalyzerName, Metric[_]]
+      val validResults = Map[AnalyzerName, Metric[_]](
+        AnalyzerName.CustomAnalyzerName("SampleAnalyzer", "att1") -> SampleAnalyzer("att1").calculate(df),
+        AnalyzerName.CustomAnalyzerName("SampleAnalyzer", "someMissingColumn") -> SampleAnalyzer("someMissingColumn").calculate(df)
       )
 
       // Analysis result should equal to 1.0 for an existing column
@@ -156,8 +158,8 @@ class AnalysisBasedConstraintTest extends WordSpec with Matchers with SparkConte
     "execute value picker on the analysis result value retrieved from context, if provided" in
       withSparkSession { sparkSession =>
         val df = getDfMissing(sparkSession)
-        val validResults = Map[Analyzer[_, Metric[_]], Metric[_]](
-          SampleAnalyzer("att1") -> SampleAnalyzer("att1").calculate(df))
+        val validResults = Map[AnalyzerName, Metric[_]](
+          AnalyzerName.CustomAnalyzerName("SampleAnalyzer", "att1") -> SampleAnalyzer("att1").calculate(df))
 
         assert(AnalysisBasedConstraint[NumMatches, Double, Double](
             SampleAnalyzer("att1"), _ == 2.0, Some(valueDoubler))
@@ -172,9 +174,9 @@ class AnalysisBasedConstraintTest extends WordSpec with Matchers with SparkConte
 
       val df = getDfMissing(sparkSession)
 
-      val emptyResults = Map.empty[Analyzer[_, Metric[_]], Metric[_]]
-      val validResults = Map[Analyzer[_, Metric[_]], Metric[_]](
-        SampleAnalyzer("att1") -> SampleAnalyzer("att1").calculate(df))
+      val emptyResults = Map.empty[AnalyzerName, Metric[_]]
+      val validResults = Map[AnalyzerName, Metric[_]](
+        AnalyzerName.CustomAnalyzerName("SampleAnalyzer", "att1") -> SampleAnalyzer("att1").calculate(df))
 
       val constraint = AnalysisBasedConstraint[NumMatches, Double, Double](
           SampleAnalyzer("att1"), _ == 1.0, Some(problematicValuePicker))

--- a/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerRunnerTest.scala
+++ b/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerRunnerTest.scala
@@ -128,7 +128,7 @@ class ColumnProfilerRunnerTest extends WordSpec with Matchers with SparkContextS
         .addAnalyzers(analyzers)
         .run()
 
-      val resultWhichShouldBeOverwritten = AnalyzerContext(Map(Size() -> DoubleMetric(
+      val resultWhichShouldBeOverwritten = AnalyzerContext(Map(AnalyzerName.Size(None) -> DoubleMetric(
         Entity.Dataset, "", "", Try(100.0))))
 
       repository.save(resultKey, resultWhichShouldBeOverwritten)

--- a/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerRunnerTest.scala
+++ b/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerRunnerTest.scala
@@ -128,7 +128,7 @@ class ColumnProfilerRunnerTest extends WordSpec with Matchers with SparkContextS
         .addAnalyzers(analyzers)
         .run()
 
-      val resultWhichShouldBeOverwritten = AnalyzerContext(Map(AnalyzerName.Size(None) -> DoubleMetric(
+      val resultWhichShouldBeOverwritten = AnalyzerContext(Map(AnalyzerId.Size(None) -> DoubleMetric(
         Entity.Dataset, "", "", Try(100.0))))
 
       repository.save(resultKey, resultWhichShouldBeOverwritten)

--- a/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
@@ -33,55 +33,55 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
   "analysis results serialization with successful Values" should "work" in {
 
     val analyzerContextWithAllSuccValues = new AnalyzerContext(Map(
-      AnalyzerName.Size(None) -> DoubleMetric(Entity.Column, "Size", "*", Success(5.0)),
-      AnalyzerName.Completeness("ColumnA", None) ->
+      AnalyzerId.Size(None) -> DoubleMetric(Entity.Column, "Size", "*", Success(5.0)),
+      AnalyzerId.Completeness("ColumnA", None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      AnalyzerName.Compliance("rule1", None, "att1 > 3") ->
+      AnalyzerId.Compliance("rule1", None, "att1 > 3") ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      AnalyzerName.ApproxCountDistinct("columnA", None) ->
+      AnalyzerId.ApproxCountDistinct("columnA", None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      AnalyzerName.CountDistinct(Seq("columnA", "columnB")) ->
+      AnalyzerId.CountDistinct(Seq("columnA", "columnB")) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      AnalyzerName.Distinctness(Seq("columnA", "columnB"), None) ->
+      AnalyzerId.Distinctness(Seq("columnA", "columnB"), None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      AnalyzerName.Correlation("firstColumn", "secondColumn", None) ->
+      AnalyzerId.Correlation("firstColumn", "secondColumn", None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      AnalyzerName.UniqueValueRatio(Seq("columnA", "columnB"), None) ->
+      AnalyzerId.UniqueValueRatio(Seq("columnA", "columnB"), None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      AnalyzerName.Correlation("firstColumn", "secondColumn", None) ->
+      AnalyzerId.Correlation("firstColumn", "secondColumn", None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      AnalyzerName.Uniqueness(Seq("ColumnA"), None) ->
+      AnalyzerId.Uniqueness(Seq("ColumnA"), None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      AnalyzerName.Uniqueness(Seq("ColumnA", "ColumnB"), None) ->
+      AnalyzerId.Uniqueness(Seq("ColumnA", "ColumnB"), None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      AnalyzerName.Histogram("ColumnA", None, Histogram.MaximumAllowedDetailBins) ->
+      AnalyzerId.Histogram("ColumnA", None, Histogram.MaximumAllowedDetailBins) ->
         HistogramMetric("ColumnA", Success(Distribution(
           Map("some" -> DistributionValue(10, 0.5)), 10))),
-      AnalyzerName.Histogram ("ColumnA", None, Histogram.MaximumAllowedDetailBins) ->
+      AnalyzerId.Histogram ("ColumnA", None, Histogram.MaximumAllowedDetailBins) ->
         HistogramMetric("ColumnA", Success(Distribution(
           Map("some" -> DistributionValue(10, 0.5), "other" -> DistributionValue(0, 0)), 10))),
-      AnalyzerName.Histogram("ColumnA", None, Histogram.MaximumAllowedDetailBins) ->
+      AnalyzerId.Histogram("ColumnA", None, Histogram.MaximumAllowedDetailBins) ->
         HistogramMetric("ColumnA", Success(Distribution(
           Map("some" -> DistributionValue(10, 0.5)), 10))),
-      AnalyzerName.Entropy("ColumnA", None) ->
+      AnalyzerId.Entropy("ColumnA", None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      AnalyzerName.MutualInformation(Seq("ColumnA", "ColumnB"), None) ->
+      AnalyzerId.MutualInformation(Seq("ColumnA", "ColumnB"), None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      AnalyzerName.Minimum("ColumnA", None) ->
+      AnalyzerId.Minimum("ColumnA", None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      AnalyzerName.Maximum("ColumnA", None) ->
+      AnalyzerId.Maximum("ColumnA", None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      AnalyzerName.Mean("ColumnA", None) ->
+      AnalyzerId.Mean("ColumnA", None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      AnalyzerName.Sum("ColumnA", None) ->
+      AnalyzerId.Sum("ColumnA", None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      AnalyzerName.StandardDeviation("ColumnA", None) ->
+      AnalyzerId.StandardDeviation("ColumnA", None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      AnalyzerName.DataType("ColumnA", None) ->
+      AnalyzerId.DataType("ColumnA", None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      AnalyzerName.MinLength("ColumnA", None) ->
+      AnalyzerId.MinLength("ColumnA", None) ->
         DoubleMetric(Entity.Column, "MinLength", "ColumnA", Success(5.0)),
-      AnalyzerName.MaxLength("ColumnA", None) ->
+      AnalyzerId.MaxLength("ColumnA", None) ->
         DoubleMetric(Entity.Column, "MaxLength", "ColumnA", Success(5.0))
     ))
 
@@ -106,13 +106,13 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
     val analyzer = PatternMatch("patternRule1", Patterns.EMAIL)
     val metric = DoubleMetric(Entity.Column, "PatternMatch", "ColumnA", Success(5.0))
 
-    val result = AnalysisResult(resultKeyOne, AnalyzerContext(Map(analyzer.name -> metric)))
+    val result = AnalysisResult(resultKeyOne, AnalyzerContext(Map(analyzer.id -> metric)))
 
     val clonedResult = deserialize(serialize(Seq(result))).head
 
     val (clonedAnalyzer, clonedMetric) = clonedResult.analyzerContext.metricMap
-      .collect { case (analyzerName: AnalyzerName.PatternMatch, metric: DoubleMetric) =>
-        analyzerName -> metric
+      .collect { case (patternMatchAnalyzerId: AnalyzerId.PatternMatch, metric: DoubleMetric) =>
+        patternMatchAnalyzerId -> metric
       }
       .head
 
@@ -128,8 +128,8 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
 
     val analyzerContextWithMixedValues = new AnalyzerContext(
       Map(
-        AnalyzerName.Size(None) -> DoubleMetric(Entity.Column, "Size", "*", Success(5.0)),
-        AnalyzerName.Completeness("ColumnA", None) ->
+        AnalyzerId.Size(None) -> DoubleMetric(Entity.Column, "Size", "*", Success(5.0)),
+        AnalyzerId.Completeness("ColumnA", None) ->
             DoubleMetric(Entity.Column, "Completeness", "ColumnA", Failure(sampleException))
       )
     )
@@ -151,7 +151,7 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
 
     val analyzer = ApproxQuantile("col", 0.5, relativeError = 0.2)
     val metric = DoubleMetric(Entity.Column, "ApproxQuantile", "col", Success(0.5))
-    val context = AnalyzerContext(Map(analyzer.name -> metric))
+    val context = AnalyzerContext(Map(analyzer.id -> metric))
     val result = new AnalysisResult(ResultKey(0), context)
 
     assertCorrectlyConvertsAnalysisResults(Seq(result))
@@ -166,7 +166,7 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
 
     val analyzer = ApproxQuantiles("col", Seq(0.25, 0.5, 0.75), relativeError = 0.2)
     val metric = KeyedDoubleMetric(Entity.Column, "ApproxQuantiles", "col", Success(quartiles))
-    val context = AnalyzerContext(Map(analyzer.name -> metric))
+    val context = AnalyzerContext(Map(analyzer.id -> metric))
     val result = new AnalysisResult(ResultKey(0), context)
 
     assertCorrectlyConvertsAnalysisResults(Seq(result))

--- a/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
@@ -33,55 +33,55 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
   "analysis results serialization with successful Values" should "work" in {
 
     val analyzerContextWithAllSuccValues = new AnalyzerContext(Map(
-      Size() -> DoubleMetric(Entity.Column, "Size", "*", Success(5.0)),
-      Completeness("ColumnA") ->
+      AnalyzerName.Size(None) -> DoubleMetric(Entity.Column, "Size", "*", Success(5.0)),
+      AnalyzerName.Completeness("ColumnA", None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      Compliance("rule1", "att1 > 3") ->
+      AnalyzerName.Compliance("rule1", None, "att1 > 3") ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      ApproxCountDistinct("columnA", Some("test")) ->
+      AnalyzerName.ApproxCountDistinct("columnA", None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      CountDistinct(Seq("columnA", "columnB")) ->
+      AnalyzerName.CountDistinct(Seq("columnA", "columnB")) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      Distinctness(Seq("columnA", "columnB")) ->
+      AnalyzerName.Distinctness(Seq("columnA", "columnB"), None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      Correlation("firstColumn", "secondColumn", Some("test")) ->
+      AnalyzerName.Correlation("firstColumn", "secondColumn", None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      UniqueValueRatio(Seq("columnA", "columnB")) ->
+      AnalyzerName.UniqueValueRatio(Seq("columnA", "columnB"), None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      Correlation("firstColumn", "secondColumn", Some("test")) ->
+      AnalyzerName.Correlation("firstColumn", "secondColumn", None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      Uniqueness("ColumnA") ->
+      AnalyzerName.Uniqueness(Seq("ColumnA"), None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      Uniqueness(Seq("ColumnA", "ColumnB")) ->
+      AnalyzerName.Uniqueness(Seq("ColumnA", "ColumnB"), None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      Histogram("ColumnA") ->
+      AnalyzerName.Histogram("ColumnA", None, Histogram.MaximumAllowedDetailBins) ->
         HistogramMetric("ColumnA", Success(Distribution(
           Map("some" -> DistributionValue(10, 0.5)), 10))),
-      Histogram ("ColumnA", None) ->
+      AnalyzerName.Histogram ("ColumnA", None, Histogram.MaximumAllowedDetailBins) ->
         HistogramMetric("ColumnA", Success(Distribution(
           Map("some" -> DistributionValue(10, 0.5), "other" -> DistributionValue(0, 0)), 10))),
-      Histogram("ColumnA", None, 5) ->
+      AnalyzerName.Histogram("ColumnA", None, Histogram.MaximumAllowedDetailBins) ->
         HistogramMetric("ColumnA", Success(Distribution(
           Map("some" -> DistributionValue(10, 0.5)), 10))),
-      Entropy("ColumnA") ->
+      AnalyzerName.Entropy("ColumnA", None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      MutualInformation(Seq("ColumnA", "ColumnB")) ->
+      AnalyzerName.MutualInformation(Seq("ColumnA", "ColumnB"), None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      Minimum("ColumnA") ->
+      AnalyzerName.Minimum("ColumnA", None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      Maximum("ColumnA") ->
+      AnalyzerName.Maximum("ColumnA", None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      Mean("ColumnA") ->
+      AnalyzerName.Mean("ColumnA", None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      Sum("ColumnA") ->
+      AnalyzerName.Sum("ColumnA", None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      StandardDeviation("ColumnA") ->
+      AnalyzerName.StandardDeviation("ColumnA", None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      DataType("ColumnA") ->
+      AnalyzerName.DataType("ColumnA", None) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      MinLength("ColumnA") ->
+      AnalyzerName.MinLength("ColumnA", None) ->
         DoubleMetric(Entity.Column, "MinLength", "ColumnA", Success(5.0)),
-      MaxLength("ColumnA") ->
+      AnalyzerName.MaxLength("ColumnA", None) ->
         DoubleMetric(Entity.Column, "MaxLength", "ColumnA", Success(5.0))
     ))
 
@@ -106,19 +106,19 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
     val analyzer = PatternMatch("patternRule1", Patterns.EMAIL)
     val metric = DoubleMetric(Entity.Column, "PatternMatch", "ColumnA", Success(5.0))
 
-    val result = AnalysisResult(resultKeyOne, AnalyzerContext(Map(analyzer -> metric)))
+    val result = AnalysisResult(resultKeyOne, AnalyzerContext(Map(analyzer.name -> metric)))
 
     val clonedResult = deserialize(serialize(Seq(result))).head
 
     val (clonedAnalyzer, clonedMetric) = clonedResult.analyzerContext.metricMap
-      .collect { case (analyzer: PatternMatch, metric: DoubleMetric) =>
-        analyzer -> metric
+      .collect { case (analyzerName: AnalyzerName.PatternMatch, metric: DoubleMetric) =>
+        analyzerName -> metric
       }
       .head
 
     assert(analyzer.column == clonedAnalyzer.column)
     assert(analyzer.pattern.toString() == clonedAnalyzer.pattern.toString())
-    assert(analyzer.where == clonedAnalyzer.where)
+    assert(analyzer.where == clonedAnalyzer.filterCondition)
 
     assert(metric == clonedMetric)
   }
@@ -128,8 +128,8 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
 
     val analyzerContextWithMixedValues = new AnalyzerContext(
       Map(
-        Size() -> DoubleMetric(Entity.Column, "Size", "*", Success(5.0)),
-        Completeness("ColumnA") ->
+        AnalyzerName.Size(None) -> DoubleMetric(Entity.Column, "Size", "*", Success(5.0)),
+        AnalyzerName.Completeness("ColumnA", None) ->
             DoubleMetric(Entity.Column, "Completeness", "ColumnA", Failure(sampleException))
       )
     )
@@ -151,7 +151,7 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
 
     val analyzer = ApproxQuantile("col", 0.5, relativeError = 0.2)
     val metric = DoubleMetric(Entity.Column, "ApproxQuantile", "col", Success(0.5))
-    val context = AnalyzerContext(Map(analyzer -> metric))
+    val context = AnalyzerContext(Map(analyzer.name -> metric))
     val result = new AnalysisResult(ResultKey(0), context)
 
     assertCorrectlyConvertsAnalysisResults(Seq(result))
@@ -166,7 +166,7 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
 
     val analyzer = ApproxQuantiles("col", Seq(0.25, 0.5, 0.75), relativeError = 0.2)
     val metric = KeyedDoubleMetric(Entity.Column, "ApproxQuantiles", "col", Success(quartiles))
-    val context = AnalyzerContext(Map(analyzer -> metric))
+    val context = AnalyzerContext(Map(analyzer.name -> metric))
     val result = new AnalysisResult(ResultKey(0), context)
 
     assertCorrectlyConvertsAnalysisResults(Seq(result))

--- a/src/test/scala/com/amazon/deequ/repository/AnalysisResultTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/AnalysisResultTest.scala
@@ -23,7 +23,7 @@ import com.amazon.deequ.utils.FixtureSupport
 import org.scalatest.{Matchers, WordSpec}
 import com.amazon.deequ.analyzers._
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 
 class AnalysisResultTest extends WordSpec with Matchers with SparkContextSpec with FixtureSupport {
 
@@ -335,8 +335,8 @@ class AnalysisResultTest extends WordSpec with Matchers with SparkContextSpec wi
     LocalDate.of(year, month, day).atTime(10, 10, 10).toEpochSecond(ZoneOffset.UTC)
   }
 
-  private[this] def assertSameRows(dataframeA: DataFrame, dataframeB: DataFrame): Unit = {
-    assert(dataframeA.collect().toSet == dataframeB.collect().toSet)
+  private[this] def assertSameRows(dataframeA: Dataset[_], dataframeB: Dataset[_]): Unit = {
+    assert(dataframeA.toDF.collect().toSet == dataframeB.toDF.collect().toSet)
   }
 
   private[this] def assertSameJson(jsonA: String, jsonB: String): Unit = {

--- a/src/test/scala/com/amazon/deequ/repository/MetricsRepositoryAnomalyDetectionIntegrationTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/MetricsRepositoryAnomalyDetectionIntegrationTest.scala
@@ -106,14 +106,14 @@ class MetricsRepositoryAnomalyDetectionIntegrationTest extends WordSpec with Mat
      (1 to 30).foreach { pastDay =>
 
       val pastResultsEU = Map(
-        Size() -> DoubleMetric(Entity.Dataset, "*", "Size", Success(math.floor(pastDay / 3))),
-        Mean("sales") -> DoubleMetric(Entity.Column, "sales", "Mean", Success(pastDay * 7))
-      ).asInstanceOf[Map[Analyzer[_, Metric[_]], Metric[_]]]
+        AnalyzerName.Size(None) -> DoubleMetric(Entity.Dataset, "*", "Size", Success(math.floor(pastDay / 3))),
+        AnalyzerName.Mean("sales", None) -> DoubleMetric(Entity.Column, "sales", "Mean", Success(pastDay * 7))
+      ).asInstanceOf[Map[AnalyzerName, Metric[_]]]
 
       val pastResultsNA = Map(
-        Size() -> DoubleMetric(Entity.Dataset, "*", "Size", Success(pastDay)),
-        Mean("sales") -> DoubleMetric(Entity.Column, "sales", "Mean", Success(pastDay * 9))
-      ).asInstanceOf[Map[Analyzer[_, Metric[_]], Metric[_]]]
+        AnalyzerName.Size(None) -> DoubleMetric(Entity.Dataset, "*", "Size", Success(pastDay)),
+        AnalyzerName.Mean("sales", None) -> DoubleMetric(Entity.Column, "sales", "Mean", Success(pastDay * 9))
+      ).asInstanceOf[Map[AnalyzerName, Metric[_]]]
 
       val analyzerContextEU = new AnalyzerContext(pastResultsEU)
       val analyzerContextNA = new AnalyzerContext(pastResultsNA)

--- a/src/test/scala/com/amazon/deequ/repository/MetricsRepositoryAnomalyDetectionIntegrationTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/MetricsRepositoryAnomalyDetectionIntegrationTest.scala
@@ -106,14 +106,14 @@ class MetricsRepositoryAnomalyDetectionIntegrationTest extends WordSpec with Mat
      (1 to 30).foreach { pastDay =>
 
       val pastResultsEU = Map(
-        AnalyzerName.Size(None) -> DoubleMetric(Entity.Dataset, "*", "Size", Success(math.floor(pastDay / 3))),
-        AnalyzerName.Mean("sales", None) -> DoubleMetric(Entity.Column, "sales", "Mean", Success(pastDay * 7))
-      ).asInstanceOf[Map[AnalyzerName, Metric[_]]]
+        AnalyzerId.Size(None) -> DoubleMetric(Entity.Dataset, "*", "Size", Success(math.floor(pastDay / 3))),
+        AnalyzerId.Mean("sales", None) -> DoubleMetric(Entity.Column, "sales", "Mean", Success(pastDay * 7))
+      ).asInstanceOf[Map[AnalyzerId, Metric[_]]]
 
       val pastResultsNA = Map(
-        AnalyzerName.Size(None) -> DoubleMetric(Entity.Dataset, "*", "Size", Success(pastDay)),
-        AnalyzerName.Mean("sales", None) -> DoubleMetric(Entity.Column, "sales", "Mean", Success(pastDay * 9))
-      ).asInstanceOf[Map[AnalyzerName, Metric[_]]]
+        AnalyzerId.Size(None) -> DoubleMetric(Entity.Dataset, "*", "Size", Success(pastDay)),
+        AnalyzerId.Mean("sales", None) -> DoubleMetric(Entity.Column, "sales", "Mean", Success(pastDay * 9))
+      ).asInstanceOf[Map[AnalyzerId, Metric[_]]]
 
       val analyzerContextEU = new AnalyzerContext(pastResultsEU)
       val analyzerContextNA = new AnalyzerContext(pastResultsNA)

--- a/src/test/scala/com/amazon/deequ/repository/MetricsRepositoryMultipleResultsLoaderTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/MetricsRepositoryMultipleResultsLoaderTest.scala
@@ -24,7 +24,7 @@ import org.scalatest.{Matchers, WordSpec}
 import com.amazon.deequ.analyzers._
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
 import com.amazon.deequ.repository.memory.InMemoryMetricsRepository
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 
 class MetricsRepositoryMultipleResultsLoaderTest extends WordSpec with Matchers
   with SparkContextSpec with FixtureSupport {
@@ -258,8 +258,8 @@ class MetricsRepositoryMultipleResultsLoaderTest extends WordSpec with Matchers
     LocalDate.of(year, month, day).atTime(10, 10, 10).toEpochSecond(ZoneOffset.UTC)
   }
 
-  private[this] def assertSameRows(dataframeA: DataFrame, dataframeB: DataFrame): Unit = {
-    assert(dataframeA.collect().toSet == dataframeB.collect().toSet)
+  private[this] def assertSameRows(dataframeA: Dataset[_], dataframeB: Dataset[_]): Unit = {
+    assert(dataframeA.toDF.collect().toSet == dataframeB.toDF.collect().toSet)
   }
 
   private[this] def assertSameJson(jsonA: String, jsonB: String): Unit = {

--- a/src/test/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepositoryTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepositoryTest.scala
@@ -59,9 +59,9 @@ class FileSystemMetricsRepositoryTest extends WordSpec with SparkContextSpec wit
 
     "save should ignore failed result metrics when saving" in withSparkSession { session =>
 
-      val metrics: Map[AnalyzerName, Metric[_]] = Map(
-        AnalyzerName.Size(None) -> DoubleMetric(Entity.Column, "Size", "*", Success(5.0)),
-        AnalyzerName.Completeness("ColumnA", None) ->
+      val metrics: Map[AnalyzerId, Metric[_]] = Map(
+        AnalyzerId.Size(None) -> DoubleMetric(Entity.Column, "Size", "*", Success(5.0)),
+        AnalyzerId.Completeness("ColumnA", None) ->
           DoubleMetric(Entity.Column, "Completeness", "ColumnA",
             Failure(new RuntimeException("error"))))
 
@@ -185,7 +185,7 @@ class FileSystemMetricsRepositoryTest extends WordSpec with SparkContextSpec wit
 
           val analysisResultsAsDataFrame = repository.load()
             .after(DATE_ONE)
-            .forAnalyzers(Seq(AnalyzerName.Completeness("att1", None), AnalyzerName.Uniqueness(Seq("att1", "att2"), None)))
+            .forAnalyzers(Seq(AnalyzerId.Completeness("att1", None), AnalyzerId.Uniqueness(Seq("att1", "att2"), None)))
             .getSuccessMetricsAsDataFrame(sparkSession)
 
           import sparkSession.implicits._

--- a/src/test/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepositoryTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepositoryTest.scala
@@ -23,7 +23,7 @@ import com.amazon.deequ.analyzers.runners.AnalyzerContext
 import com.amazon.deequ.metrics.{DoubleMetric, Entity, Metric}
 import com.amazon.deequ.repository.{MetricsRepository, ResultKey}
 import com.amazon.deequ.utils.{FixtureSupport, TempFileUtils}
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.{DataFrame, Dataset, SparkSession}
 import org.scalatest.WordSpec
 import AnalyzerContext._
 import com.amazon.deequ.SparkContextSpec
@@ -59,9 +59,9 @@ class FileSystemMetricsRepositoryTest extends WordSpec with SparkContextSpec wit
 
     "save should ignore failed result metrics when saving" in withSparkSession { session =>
 
-      val metrics: Map[Analyzer[_, Metric[_]], Metric[_]] = Map(
-        Size() -> DoubleMetric(Entity.Column, "Size", "*", Success(5.0)),
-        Completeness("ColumnA") ->
+      val metrics: Map[AnalyzerName, Metric[_]] = Map(
+        AnalyzerName.Size(None) -> DoubleMetric(Entity.Column, "Size", "*", Success(5.0)),
+        AnalyzerName.Completeness("ColumnA", None) ->
           DoubleMetric(Entity.Column, "Completeness", "ColumnA",
             Failure(new RuntimeException("error"))))
 
@@ -185,7 +185,7 @@ class FileSystemMetricsRepositoryTest extends WordSpec with SparkContextSpec wit
 
           val analysisResultsAsDataFrame = repository.load()
             .after(DATE_ONE)
-            .forAnalyzers(Seq(Completeness("att1"), Uniqueness(Seq("att1", "att2"))))
+            .forAnalyzers(Seq(AnalyzerName.Completeness("att1", None), AnalyzerName.Uniqueness(Seq("att1", "att2"), None)))
             .getSuccessMetricsAsDataFrame(sparkSession)
 
           import sparkSession.implicits._
@@ -266,7 +266,7 @@ class FileSystemMetricsRepositoryTest extends WordSpec with SparkContextSpec wit
     new FileSystemMetricsRepository(sparkSession, tempDir)
   }
 
-  private[this] def assertSameRows(dataFrameA: DataFrame, dataFrameB: DataFrame): Unit = {
-    assert(dataFrameA.collect().toSet == dataFrameB.collect().toSet)
+  private[this] def assertSameRows(dataFrameA: Dataset[_], dataFrameB: Dataset[_]): Unit = {
+    assert(dataFrameA.toDF.collect().toSet == dataFrameB.toDF.collect().toSet)
   }
 }

--- a/src/test/scala/com/amazon/deequ/repository/memory/InMemoryMetricsRepositoryTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/memory/InMemoryMetricsRepositoryTest.scala
@@ -59,9 +59,9 @@ class InMemoryMetricsRepositoryTest extends WordSpec with SparkContextSpec with 
 
     "save should ignore failed result metrics when saving" in withSparkSession { session =>
 
-      val metrics: Map[AnalyzerName, Metric[_]] = Map(
-        AnalyzerName.Size(None) -> DoubleMetric(Entity.Column, "Size", "*", Success(5.0)),
-        AnalyzerName.Completeness("ColumnA", None) ->
+      val metrics: Map[AnalyzerId, Metric[_]] = Map(
+        AnalyzerId.Size(None) -> DoubleMetric(Entity.Column, "Size", "*", Success(5.0)),
+        AnalyzerId.Completeness("ColumnA", None) ->
           DoubleMetric(Entity.Column, "Completeness", "ColumnA",
             Failure(new RuntimeException("error"))))
 
@@ -174,7 +174,7 @@ class InMemoryMetricsRepositoryTest extends WordSpec with SparkContextSpec with 
 
           val analysisResultsAsDataFrame = repository.load()
             .after(DATE_ONE)
-            .forAnalyzers(Seq(AnalyzerName.Completeness("att1", None), AnalyzerName.Uniqueness(Seq("att1", "att2"), None)))
+            .forAnalyzers(Seq(AnalyzerId.Completeness("att1", None), AnalyzerId.Uniqueness(Seq("att1", "att2"), None)))
             .getSuccessMetricsAsDataFrame(sparkSession)
 
           import sparkSession.implicits._

--- a/src/test/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunnerTest.scala
+++ b/src/test/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunnerTest.scala
@@ -151,7 +151,7 @@ class ConstraintSuggestionRunnerTest extends WordSpec with Matchers with SparkCo
         .addAnalyzers(analyzers)
         .run()
 
-      val resultWhichShouldBeOverwritten = AnalyzerContext(Map(AnalyzerName.Size(None) -> DoubleMetric(
+      val resultWhichShouldBeOverwritten = AnalyzerContext(Map(AnalyzerId.Size(None) -> DoubleMetric(
         Entity.Dataset, "", "", Try(100.0))))
 
       repository.save(resultKey, resultWhichShouldBeOverwritten)

--- a/src/test/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunnerTest.scala
+++ b/src/test/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunnerTest.scala
@@ -151,7 +151,7 @@ class ConstraintSuggestionRunnerTest extends WordSpec with Matchers with SparkCo
         .addAnalyzers(analyzers)
         .run()
 
-      val resultWhichShouldBeOverwritten = AnalyzerContext(Map(Size() -> DoubleMetric(
+      val resultWhichShouldBeOverwritten = AnalyzerContext(Map(AnalyzerName.Size(None) -> DoubleMetric(
         Entity.Dataset, "", "", Try(100.0))))
 
       repository.save(resultKey, resultWhichShouldBeOverwritten)


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/deequ/issues/232

*Description of changes:*
Updating repositories to store a map of analyzerId to metric, rather than the whole analyzer. Idea is that it makes extending repository more straight forward if you want to store metrics somewhere else, as you have some simpler thing to store, rather than storing Analyzer object itself. Should make it simpler to switch file system repository to store data in some more structured format rather than storing as serialized objects (which for example would be hard to do trend analysis with some external tool).

NOTE: This change will break backwards compatibility for people storing metrics with existing method.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
