### PR TITLE
update example documentation to actual example script:

### DIFF
--- a/src/main/scala/com/amazon/deequ/examples/constraint_suggestion_example.md
+++ b/src/main/scala/com/amazon/deequ/examples/constraint_suggestion_example.md
@@ -7,9 +7,9 @@ Our constraint suggestion first [profiles the data](https://github.com/awslabs/d
 Let's first generate some example data:
 ```scala
 case class RawData(
-  productName: String, 
-  count: String, 
-  status: String, 
+  productName: String,
+  totalNumber: String,
+  status: String,
   valuable: String
 )
 
@@ -62,16 +62,16 @@ Constraint suggestion for 'valuable': 'valuable' has less than 62% missing value
 The corresponding scala code is .hasCompleteness("valuable", _ >= 0.38, Some("It should be above 0.38!"))
 ```
 
-Next we look at the `count` column. **Deequ** identified that this column is actually a numeric column 'disguised' as string column and therefore suggests a constraint on a fractional datatype (such as float or double). Furthermore, it saw that this column contains some missing values and suggests a constraint that checks that the ratio of missing values should not increase in the future. Additionally, it suggests that values in this column should always be positive (as it did not see any negative values in the example data), which probably makes a lot of sense for count-like data.
+Next we look at the `totalNumber` column. **Deequ** identified that this column is actually a numeric column 'disguised' as string column and therefore suggests a constraint on a fractional datatype (such as float or double). Furthermore, it saw that this column contains some missing values and suggests a constraint that checks that the ratio of missing values should not increase in the future. Additionally, it suggests that values in this column should always be positive (as it did not see any negative values in the example data), which probably makes a lot of sense for this count-like data.
 ```
-Constraint suggestion for 'count': 'count' has type Fractional
-The corresponding scala code is .hasDataType("count", ConstrainableDataTypes.Fractional)
+Constraint suggestion for 'totalNumber': 'totalNumber' has type Fractional
+The corresponding scala code is .hasDataType("totalNumber", ConstrainableDataTypes.Fractional)
 
-Constraint suggestion for 'count': 'count' has less than 47% missing values
-The corresponding scala code is .hasCompleteness("count", _ >= 0.53, Some("It should be above 0.53!"))
+Constraint suggestion for 'totalNumber': 'totalNumber' has less than 47% missing values
+The corresponding scala code is .hasCompleteness("totalNumber", _ >= 0.53, Some("It should be above 0.53!"))
 
-Constraint suggestion for 'count': 'count' has only values that are equal to or greater than 0
-The corresponding scala code is .isNonNegative("count")
+Constraint suggestion for 'totalNumber': 'totalNumber' has no negative values
+The corresponding scala code is .isNonNegative("totalNumber")
 ```
 
 Finally, we look at the suggestions for the `productName` and `status` columns. Both of them did not have a single missing value in the example data, so an `isComplete` constraint is suggested for them. Furthermore, both of them only have a small set of possible values, therefore an `isContainedIn` constraint is suggested, which would check that future values are also contained in the range of observed values.
@@ -92,5 +92,3 @@ The corresponding scala code is .isContainedIn("status", Array("DELAYED", "UNKNO
 Currently, we leave it up to the user to decide whether they want to apply the suggested constraints or not, and provide the corresponding Scala code for convenience. For larger datasets, it makes sense to evaluate the suggested constraints on some held-out portion of the data to see whether they hold or not. You can test this by adding an invocation of `.useTrainTestSplitWithTestsetRatio(0.1)` to the `ConstraintSuggestionRunner`. With this configuration, it would compute constraint suggestions on 90% of the data and evaluate the suggested constraints on the remaining 10%.
 
 Finally, we would also like to note that the constraint suggestion code provides access to the underlying [column profiles](https://github.com/awslabs/deequ/blob/master/src/main/scala/com/amazon/deequ/examples/data_profiling_example.md) that it computed via `suggestionResult.columnProfiles`.
-
-

--- a/src/main/scala/com/amazon/deequ/examples/data_profiling_example.md
+++ b/src/main/scala/com/amazon/deequ/examples/data_profiling_example.md
@@ -6,9 +6,9 @@ Very often we are faced with large, raw datasets and struggle to make sense of t
 Assume we have raw data that is string typed (such as the data you would get from a CSV file). For the sake of simplicity, we use the following toy data in this example:
 
 ```scala
-case class RawData(productName: String, count: String, status: String, valuable: String)
+case class RawData(productName: String, totalNumber: String, status: String, valuable: String)
 
-val rows = spark.parallelize(Seq(
+val rows = session.sparkContext.parallelize(Seq(
   RawData("thingA", "13.0", "IN_TRANSIT", "true"),
   RawData("thingA", "5", "DELAYED", "false"),
   RawData("thingB", null,  "DELAYED", null),
@@ -20,7 +20,7 @@ val rows = spark.parallelize(Seq(
 ))
 
 val rawData = session.createDataFrame(rows)
-``` 
+```
 
 It only takes a single method invocation to make **deequ** profile this data. Note that it will execute the three passes over the data and avoid any shuffles in order to easily scale to large data.
 ```scala
@@ -41,7 +41,7 @@ result.profiles.foreach { case (colName, profile) =>
 }
 ```
 
-In case of our toy data, we would get the following profiling results. Note that **deequ** detected that `count` is a fractional column (and could be casted to float or double type) and that `valuable` is a boolean column. 
+In case of our toy data, we would get the following profiling results. Note that **deequ** detected that `totalNumber` is a fractional column (and could be casted to float or double type) and that `valuable` is a boolean column.
 
 ```
 Column 'productName':
@@ -49,7 +49,7 @@ Column 'productName':
 	approximate number of distinct values: 5
 	datatype: String
 
-Column 'count':
+Column 'totalNumber':
  	completeness: 0.75
 	approximate number of distinct values: 5
 	datatype: Fractional
@@ -67,18 +67,18 @@ Column 'valuable':
 
 For numeric columns, we get an extended profile which also contains descriptive statistics:
 ```scala
-val countProfile = result.profiles("count").asInstanceOf[NumericColumnProfile]
+val totalNumberProfile = result.profiles("totalNumber").asInstanceOf[NumericColumnProfile]
 
-println(s"Statistics of 'count':\n" +
-  s"\tminimum: ${countProfile.minimum.get}\n" +
-  s"\tmaximum: ${countProfile.maximum.get}\n" +
-  s"\tmean: ${countProfile.mean.get}\n" +
-  s"\tstandard deviation: ${countProfile.stdDev.get}\n")
+println(s"Statistics of 'totalNumber':\n" +
+  s"\tminimum: ${totalNumberProfile.minimum.get}\n" +
+  s"\tmaximum: ${totalNumberProfile.maximum.get}\n" +
+  s"\tmean: ${totalNumberProfile.mean.get}\n" +
+  s"\tstandard deviation: ${totalNumberProfile.stdDev.get}\n")
 ```
 
-For the `count` column we can inspect its minimum, maximum, mean and standard deviation:
+For the `totalNumber` column we can inspect its minimum, maximum, mean and standard deviation:
 ```
-Statistics of 'count':
+Statistics of 'totalNumber':
 	minimum: 1.0
 	maximum: 20.0
 	mean: 8.25


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

This PR updates the timed example documentation to actual example scripts.

update documents:
- `data_profiling_example.md` (sync to [`DataProfilingExample.scala`](https://github.com/awslabs/deequ/blob/d9640b5b56c7104cbf6954abc4a85f142428e94f/src/main/scala/com/amazon/deequ/examples/DataProfilingExample.scala))
- `constraint_suggestion_example.md` (sync to [`ConstraintSuggestionExample.scala`](https://github.com/awslabs/deequ/blob/d9640b5b56c7104cbf6954abc4a85f142428e94f/src/main/scala/com/amazon/deequ/examples/ConstraintSuggestionExample.scala#L1))

The main changes are two below:
- `count` -> `totalNumber`
- fix ambiguous `spark` variable

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
