### PR TITLE
RowLevelSchemaValidator: Integer constraints for fractional data

### DIFF
--- a/src/test/scala/com/amazon/deequ/schema/RowLevelSchemaValidatorTest.scala
+++ b/src/test/scala/com/amazon/deequ/schema/RowLevelSchemaValidatorTest.scala
@@ -121,6 +121,7 @@ class RowLevelSchemaValidatorTest extends WordSpec with SparkContextSpec {
       import sparkSession.implicits._
 
       val data = Seq(
+        "11.00",
         "1.23",
         "123",
         "N/A",
@@ -136,9 +137,10 @@ class RowLevelSchemaValidatorTest extends WordSpec with SparkContextSpec {
 
       val result = RowLevelSchemaValidator.validate(data, schema)
 
-      assert(result.numValidRows == 3)
+      assert(result.numValidRows == 4)
       val validIds = result.validRows.select("id").collect.map { _.getInt(0) }.toSet
       assert(validIds.size == result.numValidRows)
+      assert(validIds.contains(11))
       assert(validIds.contains(123))
       assert(validIds.contains(456))
       assert(validIds.contains(-9))

--- a/src/test/scala/com/amazon/deequ/schema/RowLevelSchemaValidatorTest.scala
+++ b/src/test/scala/com/amazon/deequ/schema/RowLevelSchemaValidatorTest.scala
@@ -121,6 +121,7 @@ class RowLevelSchemaValidatorTest extends WordSpec with SparkContextSpec {
       import sparkSession.implicits._
 
       val data = Seq(
+        "1.23",
         "123",
         "N/A",
         "456",
@@ -142,7 +143,7 @@ class RowLevelSchemaValidatorTest extends WordSpec with SparkContextSpec {
       assert(validIds.contains(456))
       assert(validIds.contains(-9))
 
-      assert(result.numInvalidRows == 4)
+      assert(result.numInvalidRows == 5)
       assert(result.invalidRows.count() == result.numInvalidRows)
     }
 


### PR DESCRIPTION
*Issue #, if available:*

#262 

*Description of changes:*

In Spark, when casting a string like "1.23" to int the fractional part will simply be ignored (thanks to `UTF8String` in spark-unsafe). This results in a false schema match for these cases. Casting to Decimal avoids this by doing a precision/scale-aware cast.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
