### PR TITLE
Update anomaly_detection_example.md

### DIFF
--- a/src/main/scala/com/amazon/deequ/examples/anomaly_detection_example.md
+++ b/src/main/scala/com/amazon/deequ/examples/anomaly_detection_example.md
@@ -18,7 +18,7 @@ val yesterdaysDataset = itemsAsDataframe(session,
 
 We test for anomalies in the size of the data, and want to enforce that it should not increase by more than 2x. We define a check for this by using the [RateOfChangeStrategy](https://github.com/awslabs/deequ/blob/master/src/main/scala/com/amazon/deequ/anomalydetection/RateOfChangeStrategy.scala) for detecting anomalies. Note that we store the resulting metrics in our repository via `useRepository` and `saveOrAppendResult` under a result key `yesterdaysKey` with yesterdays timestamp.
 ```scala
-val yesterdaysKey = ResultKey(System.currentTimeMillis() - 24 * 60 * 1000)
+val yesterdaysKey = ResultKey(System.currentTimeMillis() - 24 * 60 * 60 * 1000)
 
 VerificationSuite()
   .onData(yesterdaysDataset)


### PR DESCRIPTION
There is a 60 multiplication missing in the example:
1000 ms = 1 s
60 s = 1 min
60 min = 1 h
24 h = 1 d

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
