### PR TITLE
Preparing for scala 2.12 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,8 +58,8 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <encoding>UTF-8</encoding>
-        <scala.major.version>2.11</scala.major.version>
-        <scala.version>${scala.major.version}.5</scala.version>
+        <scala.major.version>2.12</scala.major.version>
+        <scala.version>${scala.major.version}.6</scala.version>
         <scala-maven-plugin.version>3.4.4</scala-maven-plugin.version>
     </properties>
 
@@ -73,13 +73,13 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.major.version}</artifactId>
-            <version>2.2.2</version>
+            <version>3.0.0</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.major.version}</artifactId>
-            <version>2.2.2</version>
+            <version>3.0.0</version>
         </dependency>
 
         <dependency>
@@ -89,16 +89,22 @@
         </dependency>
 
         <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scalap</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.major.version}</artifactId>
-            <version>2.2.6</version>
+            <version>3.2.2</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
             <groupId>org.scalamock</groupId>
             <artifactId>scalamock-scalatest-support_${scala.major.version}</artifactId>
-            <version>3.2.2</version>
+            <version>3.4.1</version>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <encoding>UTF-8</encoding>
         <scala.major.version>2.11</scala.major.version>
-        <scala.version>${scala.major.version}.5</scala.version>
+        <scala.version>${scala.major.version}.6</scala.version>
         <scala-maven-plugin.version>3.4.4</scala-maven-plugin.version>
         <spark.version>2.2.2</spark.version>
     </properties>
@@ -149,13 +149,6 @@
             <artifactId>scala-reflect</artifactId>
             <version>${scala.version}</version>
         </dependency>
-
-        <dependency>
-            <groupId>org.scala-lang</groupId>
-            <artifactId>scala-actors</artifactId>
-            <version>${scala.version}</version>
-        </dependency>
-
 
     </dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -58,9 +58,10 @@
         <maven.compiler.source>1.8</maven.compiler.source>
         <maven.compiler.target>1.8</maven.compiler.target>
         <encoding>UTF-8</encoding>
-        <scala.major.version>2.12</scala.major.version>
-        <scala.version>${scala.major.version}.6</scala.version>
+        <scala.major.version>2.11</scala.major.version>
+        <scala.version>${scala.major.version}.5</scala.version>
         <scala-maven-plugin.version>3.4.4</scala-maven-plugin.version>
+        <spark.version>2.2.2</spark.version>
     </properties>
 
     <dependencies>
@@ -73,13 +74,13 @@
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-core_${scala.major.version}</artifactId>
-            <version>3.0.0</version>
+            <version>${spark.version}</version>
         </dependency>
 
         <dependency>
             <groupId>org.apache.spark</groupId>
             <artifactId>spark-sql_${scala.major.version}</artifactId>
-            <version>3.0.0</version>
+            <version>${spark.version}</version>
         </dependency>
 
         <dependency>
@@ -97,7 +98,7 @@
         <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.major.version}</artifactId>
-            <version>3.2.2</version>
+            <version>3.1.0</version>
             <scope>test</scope>
         </dependency>
 
@@ -141,6 +142,18 @@
             <artifactId>datasketches-java</artifactId>
             <version>1.1.0-incubating</version>
             <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-reflect</artifactId>
+            <version>${scala.version}</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.scala-lang</groupId>
+            <artifactId>scala-actors</artifactId>
+            <version>${scala.version}</version>
         </dependency>
 
 

--- a/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
+++ b/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
@@ -19,9 +19,10 @@ package com.amazon.deequ.KLL
 import com.amazon.deequ.SparkContextSpec
 import com.amazon.deequ.analyzers.{Distance, QuantileNonSample}
 import com.amazon.deequ.utils.FixtureSupport
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
+class KLLDistanceTest extends AnyWordSpec with Matchers with SparkContextSpec
   with FixtureSupport{
 
   "KLL distance calculator should compute correct linf_simple" in {

--- a/src/test/scala/com/amazon/deequ/KLL/KLLProbTest.scala
+++ b/src/test/scala/com/amazon/deequ/KLL/KLLProbTest.scala
@@ -16,14 +16,14 @@
 
 package com.amazon.deequ.KLL
 
-import org.scalatest.FlatSpec
-import org.scalatest.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 import org.scalatest._
 
 import scala.util.Random
 import com.amazon.deequ.analyzers.QuantileNonSample
 
-class KLLProbTest extends FlatSpec with Matchers {
+class KLLProbTest extends AnyFlatSpec with Matchers {
 
   "sketch" should "not crash or have a huge error for simple stream" in {
 

--- a/src/test/scala/com/amazon/deequ/KLL/KLLProfileTest.scala
+++ b/src/test/scala/com/amazon/deequ/KLL/KLLProfileTest.scala
@@ -23,9 +23,10 @@ import com.amazon.deequ.profiles.{ColumnProfiler, NumericColumnProfile}
 import com.amazon.deequ.utils.FixtureSupport
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class KLLProfileTest extends WordSpec with Matchers with SparkContextSpec
+class KLLProfileTest extends AnyWordSpec with Matchers with SparkContextSpec
   with FixtureSupport {
 
   def assertProfilesEqual(expected: NumericColumnProfile, actual: NumericColumnProfile): Unit = {

--- a/src/test/scala/com/amazon/deequ/SparkBasicTest.scala
+++ b/src/test/scala/com/amazon/deequ/SparkBasicTest.scala
@@ -16,9 +16,10 @@
 
 package com.amazon.deequ
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class SparkBasicTest extends WordSpec with Matchers with SparkContextSpec {
+class SparkBasicTest extends AnyWordSpec with Matchers with SparkContextSpec {
   "check that initializing a spark context and a basic example works" in
     withSparkSession { sparkSession =>
       val sc = sparkSession.sparkContext

--- a/src/test/scala/com/amazon/deequ/VerificationResultTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationResultTest.scala
@@ -22,9 +22,10 @@ import com.amazon.deequ.metrics.Metric
 import com.amazon.deequ.repository.SimpleResultSerde
 import com.amazon.deequ.utils.FixtureSupport
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class VerificationResultTest extends WordSpec with Matchers with SparkContextSpec
+class VerificationResultTest extends AnyWordSpec with Matchers with SparkContextSpec
   with FixtureSupport {
 
   "VerificationResult getSuccessMetrics" should {

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -29,11 +29,12 @@ import com.amazon.deequ.utils.CollectionUtils.SeqExtensions
 import com.amazon.deequ.utils.{FixtureSupport, TempFileUtils}
 import org.apache.spark.sql.DataFrame
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
 
 
-class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
+class VerificationSuiteTest extends AnyWordSpec with Matchers with SparkContextSpec
   with FixtureSupport with MockFactory {
 
   "Verification Suite" should {

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalysisTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalysisTest.scala
@@ -22,11 +22,12 @@ import com.amazon.deequ.metrics.{DoubleMetric, Entity}
 import com.amazon.deequ.utils.FixtureSupport
 import com.amazon.deequ.utils.AssertionUtils.TryUtils
 import org.apache.spark.sql.{DataFrame, Row}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.util.{Failure, Success}
 
-class AnalysisTest extends WordSpec with Matchers with SparkContextSpec with FixtureSupport {
+class AnalysisTest extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport {
 
   "Analysis" should {
     "return results for configured analyzers" in withSparkSession { sparkSession =>

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
@@ -24,11 +24,12 @@ import com.amazon.deequ.utils.FixtureSupport
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions.{col, udf}
 import org.apache.spark.sql.types._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.util.{Failure, Success}
 
-class AnalyzerTests extends WordSpec with Matchers with SparkContextSpec with FixtureSupport {
+class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport {
 
   "Size analyzer" should {
     "compute correct metrics" in withSparkSession { sparkSession =>

--- a/src/test/scala/com/amazon/deequ/analyzers/IncrementalAnalysisTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/IncrementalAnalysisTest.scala
@@ -19,10 +19,11 @@ package com.amazon.deequ.analyzers
 import com.amazon.deequ.SparkContextSpec
 import com.amazon.deequ.utils.FixtureSupport
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 import org.apache.spark.sql.functions.col
 
-class IncrementalAnalysisTest extends WordSpec with Matchers with SparkContextSpec
+class IncrementalAnalysisTest extends AnyWordSpec with Matchers with SparkContextSpec
   with FixtureSupport {
 
   "An IncrementalAnalysisRunner" should {

--- a/src/test/scala/com/amazon/deequ/analyzers/IncrementalAnalyzerTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/IncrementalAnalyzerTest.scala
@@ -19,12 +19,13 @@ package com.amazon.deequ.analyzers
 import com.amazon.deequ.SparkContextSpec
 import com.amazon.deequ.utils.FixtureSupport
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.util.Success
 
 
-class IncrementalAnalyzerTest extends WordSpec with Matchers with SparkContextSpec
+class IncrementalAnalyzerTest extends AnyWordSpec with Matchers with SparkContextSpec
   with FixtureSupport {
 
   "Size analyzer" should {

--- a/src/test/scala/com/amazon/deequ/analyzers/NullHandlingTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/NullHandlingTests.scala
@@ -22,11 +22,12 @@ import com.amazon.deequ.metrics.DoubleMetric
 import com.amazon.deequ.utils.FixtureSupport
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.types.{DoubleType, StringType, StructField, StructType}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.util.Success
 
-class NullHandlingTests extends WordSpec with Matchers with SparkContextSpec with FixtureSupport {
+class NullHandlingTests extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport {
 
   private[this] def dataWithNullColumns(session: SparkSession): DataFrame = {
 

--- a/src/test/scala/com/amazon/deequ/analyzers/PartitionedTableIntegrationTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/PartitionedTableIntegrationTest.scala
@@ -22,12 +22,12 @@ import com.amazon.deequ.repository.fs.FileSystemMetricsRepository
 import com.amazon.deequ.utils.TempFileUtils
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 import TempFileUtils._
 import com.amazon.deequ.{SparkContextSpec, VerificationResult, VerificationSuite}
 import com.amazon.deequ.constraints.ConstraintStatus
 
-class PartitionedTableIntegrationTest extends WordSpec with SparkContextSpec {
+class PartitionedTableIntegrationTest extends AnyWordSpec with SparkContextSpec {
 
   private val SCHEMA = StructType(
     StructField("item", StringType, nullable = false) ::

--- a/src/test/scala/com/amazon/deequ/analyzers/StateAggregationIntegrationTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/StateAggregationIntegrationTest.scala
@@ -23,10 +23,11 @@ import com.amazon.deequ.examples.{ExampleUtils, Item}
 import com.amazon.deequ.utils.FixtureSupport
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 import org.apache.spark.sql.functions.expr
 
-class StateAggregationIntegrationTest extends WordSpec with Matchers with SparkContextSpec
+class StateAggregationIntegrationTest extends AnyWordSpec with Matchers with SparkContextSpec
   with FixtureSupport {
 
   "State aggregation" should {

--- a/src/test/scala/com/amazon/deequ/analyzers/StateAggregationTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/StateAggregationTests.scala
@@ -20,10 +20,11 @@ import com.amazon.deequ.SparkContextSpec
 import com.amazon.deequ.metrics.Metric
 import com.amazon.deequ.utils.FixtureSupport
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 import org.apache.spark.sql.functions.{expr, rand}
 
-class StateAggregationTests extends WordSpec with Matchers with SparkContextSpec
+class StateAggregationTests extends AnyWordSpec with Matchers with SparkContextSpec
   with FixtureSupport {
 
   "State aggregation outside" should {

--- a/src/test/scala/com/amazon/deequ/analyzers/StateProviderTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/StateProviderTest.scala
@@ -20,9 +20,10 @@ import com.amazon.deequ.SparkContextSpec
 import com.amazon.deequ.analyzers.runners.AnalysisRunner
 import com.amazon.deequ.utils.{FixtureSupport, TempFileUtils}
 import org.apache.spark.sql.{DataFrame, SparkSession, AnalysisException}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class StateProviderTest extends WordSpec with Matchers with SparkContextSpec with FixtureSupport {
+class StateProviderTest extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport {
 
   "Analyzers" should {
 

--- a/src/test/scala/com/amazon/deequ/analyzers/StatesTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/StatesTest.scala
@@ -18,9 +18,10 @@ package com.amazon.deequ.analyzers
 
 import com.amazon.deequ.SparkContextSpec
 import com.amazon.deequ.utils.FixtureSupport
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class StatesTest extends WordSpec with Matchers with SparkContextSpec with FixtureSupport {
+class StatesTest extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport {
 
   "FrequenciesAndNumRows" should {
     "merge correctly" in withSparkSession { session =>

--- a/src/test/scala/com/amazon/deequ/analyzers/UniquenessTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/UniquenessTest.scala
@@ -21,9 +21,10 @@ import com.amazon.deequ.analyzers.runners.AnalysisRunner
 import com.amazon.deequ.metrics.DoubleMetric
 import com.amazon.deequ.utils.FixtureSupport
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class UniquenessTest extends WordSpec with Matchers with SparkContextSpec with FixtureSupport {
+class UniquenessTest extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport {
 
   def uniquenessSampleData(sparkSession: SparkSession): DataFrame = {
     import sparkSession.implicits._

--- a/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
@@ -23,11 +23,13 @@ import com.amazon.deequ.metrics.{DoubleMetric, Entity}
 import com.amazon.deequ.repository.ResultKey
 import com.amazon.deequ.repository.memory.InMemoryMetricsRepository
 import com.amazon.deequ.utils.{FixtureSupport, TempFileUtils}
-import org.scalatest.{Matchers, PrivateMethodTester, WordSpec}
+import org.scalatest.PrivateMethodTester
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 import org.apache.spark.sql.functions.udf
 import scala.util.Try
 
-class AnalysisRunnerTests extends WordSpec with Matchers with SparkContextSpec with FixtureSupport
+class AnalysisRunnerTests extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport
   with PrivateMethodTester {
 
   "AnalysisRunner" should {

--- a/src/test/scala/com/amazon/deequ/analyzers/runners/AnalyzerContextTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/runners/AnalyzerContextTest.scala
@@ -18,12 +18,13 @@ package com.amazon.deequ.analyzers.runners
 
 import com.amazon.deequ.SparkContextSpec
 import com.amazon.deequ.utils.FixtureSupport
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 import com.amazon.deequ.analyzers._
 import com.amazon.deequ.repository.SimpleResultSerde
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
-class AnalyzerContextTest extends WordSpec with Matchers with SparkContextSpec with FixtureSupport {
+class AnalyzerContextTest extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport {
 
   "AnalyzerContext" should {
     "correctly return a DataFrame that is formatted as expected" in withSparkSession { session =>

--- a/src/test/scala/com/amazon/deequ/anomalydetection/AbsoluteChangeStrategyTest.scala
+++ b/src/test/scala/com/amazon/deequ/anomalydetection/AbsoluteChangeStrategyTest.scala
@@ -17,9 +17,10 @@
 package com.amazon.deequ.anomalydetection
 
 import breeze.linalg.DenseVector
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class AbsoluteChangeStrategyTest extends WordSpec with Matchers {
+class AbsoluteChangeStrategyTest extends AnyWordSpec with Matchers {
 
   "Absolute Change Strategy" should {
 

--- a/src/test/scala/com/amazon/deequ/anomalydetection/AnomalyDetectionTestUtilsTest.scala
+++ b/src/test/scala/com/amazon/deequ/anomalydetection/AnomalyDetectionTestUtilsTest.scala
@@ -16,9 +16,10 @@
 
 package com.amazon.deequ.anomalydetection
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class AnomalyDetectionTestUtilsTest extends WordSpec with Matchers {
+class AnomalyDetectionTestUtilsTest extends AnyWordSpec with Matchers {
 
   "AnomalyDetectionTestUtilsTest" should {
 

--- a/src/test/scala/com/amazon/deequ/anomalydetection/AnomalyDetectorTest.scala
+++ b/src/test/scala/com/amazon/deequ/anomalydetection/AnomalyDetectorTest.scala
@@ -17,10 +17,11 @@
 package com.amazon.deequ.anomalydetection
 
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.{Matchers, PrivateMethodTester, WordSpec}
+import org.scalatest.PrivateMethodTester
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-
-class AnomalyDetectorTest extends WordSpec with Matchers with MockFactory with PrivateMethodTester {
+class AnomalyDetectorTest extends AnyWordSpec with Matchers with MockFactory with PrivateMethodTester {
   private val fakeAnomalyDetector = stub[AnomalyDetectionStrategy]
 
   val aD = AnomalyDetector(fakeAnomalyDetector)

--- a/src/test/scala/com/amazon/deequ/anomalydetection/BatchNormalStrategyTest.scala
+++ b/src/test/scala/com/amazon/deequ/anomalydetection/BatchNormalStrategyTest.scala
@@ -16,11 +16,12 @@
 
 package com.amazon.deequ.anomalydetection
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.util.Random
 
-class BatchNormalStrategyTest extends WordSpec with Matchers {
+class BatchNormalStrategyTest extends AnyWordSpec with Matchers {
 
   "Batch Normal Strategy" should {
 

--- a/src/test/scala/com/amazon/deequ/anomalydetection/HistoryUtilsTest.scala
+++ b/src/test/scala/com/amazon/deequ/anomalydetection/HistoryUtilsTest.scala
@@ -17,11 +17,12 @@
 package com.amazon.deequ.anomalydetection
 
 import com.amazon.deequ.metrics.{DoubleMetric, Entity}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.util.{Failure, Success}
 
-class HistoryUtilsTest extends WordSpec with Matchers {
+class HistoryUtilsTest extends AnyWordSpec with Matchers {
 
   "History Utils" should {
     val sampleException = new IllegalArgumentException()

--- a/src/test/scala/com/amazon/deequ/anomalydetection/OnlineNormalStrategyTest.scala
+++ b/src/test/scala/com/amazon/deequ/anomalydetection/OnlineNormalStrategyTest.scala
@@ -16,13 +16,14 @@
 
 package com.amazon.deequ.anomalydetection
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 import breeze.stats.meanAndVariance
 import scala.util.Random
 
 import scala.math.abs
 
-class OnlineNormalStrategyTest extends WordSpec with Matchers {
+class OnlineNormalStrategyTest extends AnyWordSpec with Matchers {
 
   "Online Normal Strategy" should {
 

--- a/src/test/scala/com/amazon/deequ/anomalydetection/RateOfChangeStrategyTest.scala
+++ b/src/test/scala/com/amazon/deequ/anomalydetection/RateOfChangeStrategyTest.scala
@@ -16,13 +16,14 @@
 
 package com.amazon.deequ.anomalydetection
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
 /**
  * The tested class RateOfChangeStrategy is deprecated.
  * This test is to ensure backwards compatibility for deequ checks that still rely on this strategy.
  */
-class RateOfChangeStrategyTest extends WordSpec with Matchers {
+class RateOfChangeStrategyTest extends AnyWordSpec with Matchers {
 
   "RateOfChange Strategy" should {
 

--- a/src/test/scala/com/amazon/deequ/anomalydetection/RelativeRateOfChangeStrategyTest.scala
+++ b/src/test/scala/com/amazon/deequ/anomalydetection/RelativeRateOfChangeStrategyTest.scala
@@ -17,9 +17,10 @@
 package com.amazon.deequ.anomalydetection
 
 import breeze.linalg.DenseVector
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class RelativeRateOfChangeStrategyTest extends WordSpec with Matchers {
+class RelativeRateOfChangeStrategyTest extends AnyWordSpec with Matchers {
 
   "Relative Rate of Change Strategy" should {
 

--- a/src/test/scala/com/amazon/deequ/anomalydetection/SimpleThresholdStrategyTest.scala
+++ b/src/test/scala/com/amazon/deequ/anomalydetection/SimpleThresholdStrategyTest.scala
@@ -16,9 +16,10 @@
 
 package com.amazon.deequ.anomalydetection
 
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class SimpleThresholdStrategyTest extends WordSpec with Matchers {
+class SimpleThresholdStrategyTest extends AnyWordSpec with Matchers {
 
   "Simple Threshold Strategy" should {
 

--- a/src/test/scala/com/amazon/deequ/anomalydetection/seasonal/HoltWintersTest.scala
+++ b/src/test/scala/com/amazon/deequ/anomalydetection/seasonal/HoltWintersTest.scala
@@ -17,9 +17,12 @@
 package com.amazon.deequ.anomalydetection.seasonal
 
 import com.amazon.deequ.anomalydetection.Anomaly
-import org.scalatest.{Matchers, ShouldMatchers, WordSpec}
+//import org.scalatest.{Matchers, ShouldMatchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class HoltWintersTest extends WordSpec with ShouldMatchers with Matchers {
+
+class HoltWintersTest extends AnyWordSpec with Matchers {
 
   import HoltWintersTest._
 

--- a/src/test/scala/com/amazon/deequ/checks/ApplicabilityTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/ApplicabilityTest.scala
@@ -20,9 +20,9 @@ package checks
 import com.amazon.deequ.analyzers.applicability.Applicability
 import com.amazon.deequ.analyzers.{Completeness, Compliance, Maximum, Minimum}
 import org.apache.spark.sql.types._
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class ApplicabilityTest extends WordSpec with SparkContextSpec {
+class ApplicabilityTest extends AnyWordSpec with SparkContextSpec {
 
   private[this] val schema = StructType(Array(
       StructField("stringCol", StringType, nullable = true),

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -28,11 +28,12 @@ import com.amazon.deequ.utils.FixtureSupport
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.util.{Success, Try}
 
-class CheckTest extends WordSpec with Matchers with SparkContextSpec with FixtureSupport
+class CheckTest extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport
   with MockFactory {
 
   import CheckTest._
@@ -1067,7 +1068,7 @@ class CheckTest extends WordSpec with Matchers with SparkContextSpec with Fixtur
   }
 }
 
-object CheckTest extends WordSpec with Matchers {
+object CheckTest extends AnyWordSpec with Matchers {
 
   def assertSuccess(check: Check, context: AnalyzerContext): Unit = {
     check.evaluate(context).status shouldBe CheckStatus.Success

--- a/src/test/scala/com/amazon/deequ/checks/ColumnConditionTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/ColumnConditionTest.scala
@@ -16,9 +16,9 @@
 
 package com.amazon.deequ.checks
 
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class ColumnConditionTest extends WordSpec {
+class ColumnConditionTest extends AnyWordSpec {
 
   "ColumnCondition" should {
 

--- a/src/test/scala/com/amazon/deequ/checks/FilterableCheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/FilterableCheckTest.scala
@@ -19,9 +19,10 @@ package checks
 
 import com.amazon.deequ.analyzers.{Completeness, Compliance}
 import com.amazon.deequ.utils.FixtureSupport
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class FilterableCheckTest extends WordSpec with Matchers with SparkContextSpec with FixtureSupport {
+class FilterableCheckTest extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport {
 
   "Filterable checks" should {
     "build correctly" in {

--- a/src/test/scala/com/amazon/deequ/constraints/AnalysisBasedConstraintTest.scala
+++ b/src/test/scala/com/amazon/deequ/constraints/AnalysisBasedConstraintTest.scala
@@ -24,11 +24,13 @@ import com.amazon.deequ.metrics.{DoubleMetric, Entity, Metric}
 import com.amazon.deequ.utils.FixtureSupport
 import org.apache.spark.sql.DataFrame
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.{Matchers, PrivateMethodTester, WordSpec}
+import org.scalatest.PrivateMethodTester
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.util.{Failure, Try}
 
-class AnalysisBasedConstraintTest extends WordSpec with Matchers with SparkContextSpec
+class AnalysisBasedConstraintTest extends AnyWordSpec with Matchers with SparkContextSpec
   with FixtureSupport with MockFactory with PrivateMethodTester {
 
   /**

--- a/src/test/scala/com/amazon/deequ/constraints/ConstraintsTest.scala
+++ b/src/test/scala/com/amazon/deequ/constraints/ConstraintsTest.scala
@@ -18,7 +18,8 @@ package com.amazon.deequ
 package constraints
 
 import com.amazon.deequ.utils.FixtureSupport
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 import ConstraintUtils.calculate
 import com.amazon.deequ.analyzers.{Completeness, NumMatchesAndCount}
 import org.apache.spark.sql.Row
@@ -26,7 +27,7 @@ import org.apache.spark.sql.types.{DoubleType, StringType}
 import Constraint._
 import com.amazon.deequ.SparkContextSpec
 
-class ConstraintsTest extends WordSpec with Matchers with SparkContextSpec with FixtureSupport {
+class ConstraintsTest extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport {
 
   "Completeness constraint" should {
     "assert on wrong completeness" in withSparkSession { sparkSession =>

--- a/src/test/scala/com/amazon/deequ/examples/ExamplesTest.scala
+++ b/src/test/scala/com/amazon/deequ/examples/ExamplesTest.scala
@@ -16,9 +16,9 @@
 
 package com.amazon.deequ.examples
 
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class ExamplesTest extends WordSpec {
+class ExamplesTest extends AnyWordSpec {
 
   "all examples" should {
     "run without errors" in {

--- a/src/test/scala/com/amazon/deequ/metrics/MetricsTests.scala
+++ b/src/test/scala/com/amazon/deequ/metrics/MetricsTests.scala
@@ -17,12 +17,13 @@
 package com.amazon.deequ.metrics
 
 import com.amazon.deequ.analyzers.DataTypeInstances
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.util.{Failure, Success}
 
 
-class MetricsTests extends WordSpec with Matchers {
+class MetricsTests extends AnyWordSpec with Matchers {
   val sampleException = new IllegalArgumentException()
   "Double metric" should {
     "flatten and return itself" in {

--- a/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerRunnerTest.scala
+++ b/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerRunnerTest.scala
@@ -24,10 +24,11 @@ import com.amazon.deequ.metrics.{DoubleMetric, Entity}
 import com.amazon.deequ.repository.ResultKey
 import com.amazon.deequ.repository.memory.InMemoryMetricsRepository
 import com.amazon.deequ.utils.{FixtureSupport, TempFileUtils}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 import scala.util.Try
 
-class ColumnProfilerRunnerTest extends WordSpec with Matchers with SparkContextSpec
+class ColumnProfilerRunnerTest extends AnyWordSpec with Matchers with SparkContextSpec
   with FixtureSupport {
 
   "Column Profiler runner" should {

--- a/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerTest.scala
+++ b/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerTest.scala
@@ -23,9 +23,10 @@ import com.amazon.deequ.metrics.{BucketDistribution, BucketValue, Distribution, 
 import com.amazon.deequ.utils.FixtureSupport
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types._
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class ColumnProfilerTest extends WordSpec with Matchers with SparkContextSpec
+class ColumnProfilerTest extends AnyWordSpec with Matchers with SparkContextSpec
   with FixtureSupport {
 
   def assertProfilesEqual(expected: NumericColumnProfile, actual: NumericColumnProfile): Unit = {

--- a/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
@@ -25,10 +25,13 @@ import com.amazon.deequ.utils.FixtureSupport
 import org.scalatest._
 import AnalysisResultSerde._
 import com.amazon.deequ.SparkContextSpec
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
 
 import scala.util.{Failure, Success}
 
-class AnalysisResultSerdeTest extends FlatSpec with Matchers {
+class AnalysisResultSerdeTest extends AnyFlatSpec with Matchers {
 
   "analysis results serialization with successful Values" should "work" in {
 
@@ -190,7 +193,7 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
   }
 }
 
-class SimpleResultSerdeTest extends WordSpec with Matchers with SparkContextSpec
+class SimpleResultSerdeTest extends AnyWordSpec with Matchers with SparkContextSpec
   with FixtureSupport{
 
   "serialize and deserialize success metric results with tags" in

--- a/src/test/scala/com/amazon/deequ/repository/AnalysisResultTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/AnalysisResultTest.scala
@@ -20,12 +20,13 @@ import java.time.{LocalDate, ZoneOffset}
 
 import com.amazon.deequ.SparkContextSpec
 import com.amazon.deequ.utils.FixtureSupport
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 import com.amazon.deequ.analyzers._
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
-class AnalysisResultTest extends WordSpec with Matchers with SparkContextSpec with FixtureSupport {
+class AnalysisResultTest extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport {
 
   private[this] val DATE_ONE = createDate(2017, 10, 14)
 

--- a/src/test/scala/com/amazon/deequ/repository/MetricsRepositoryAnomalyDetectionIntegrationTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/MetricsRepositoryAnomalyDetectionIntegrationTest.scala
@@ -30,11 +30,12 @@ import java.time.{LocalDate, ZoneOffset}
 
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.sql.types.{IntegerType, StringType, StructField, StructType}
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.util.Success
 
-class MetricsRepositoryAnomalyDetectionIntegrationTest extends WordSpec with Matchers
+class MetricsRepositoryAnomalyDetectionIntegrationTest extends AnyWordSpec with Matchers
   with SparkContextSpec with FixtureSupport {
 
   "Anomaly Detection" should {

--- a/src/test/scala/com/amazon/deequ/repository/MetricsRepositoryMultipleResultsLoaderTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/MetricsRepositoryMultipleResultsLoaderTest.scala
@@ -20,13 +20,14 @@ import java.time.{LocalDate, ZoneOffset}
 
 import com.amazon.deequ.SparkContextSpec
 import com.amazon.deequ.utils.FixtureSupport
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 import com.amazon.deequ.analyzers._
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
 import com.amazon.deequ.repository.memory.InMemoryMetricsRepository
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
-class MetricsRepositoryMultipleResultsLoaderTest extends WordSpec with Matchers
+class MetricsRepositoryMultipleResultsLoaderTest extends AnyWordSpec with Matchers
   with SparkContextSpec with FixtureSupport {
 
   private[this] val DATE_ONE = createDate(2017, 10, 14)

--- a/src/test/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepositoryTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepositoryTest.scala
@@ -24,13 +24,13 @@ import com.amazon.deequ.metrics.{DoubleMetric, Entity, Metric}
 import com.amazon.deequ.repository.{MetricsRepository, ResultKey}
 import com.amazon.deequ.utils.{FixtureSupport, TempFileUtils}
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 import AnalyzerContext._
 import com.amazon.deequ.SparkContextSpec
 
 import scala.util.{Failure, Success}
 
-class FileSystemMetricsRepositoryTest extends WordSpec with SparkContextSpec with FixtureSupport {
+class FileSystemMetricsRepositoryTest extends AnyWordSpec with SparkContextSpec with FixtureSupport {
 
   private[this] val DATE_ONE = createDate(2017, 10, 14)
   private[this] val DATE_TWO = createDate(2017, 10, 15)

--- a/src/test/scala/com/amazon/deequ/repository/memory/InMemoryMetricsRepositoryTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/memory/InMemoryMetricsRepositoryTest.scala
@@ -24,13 +24,13 @@ import com.amazon.deequ.metrics.{DoubleMetric, Entity, Metric}
 import com.amazon.deequ.repository.{MetricsRepository, ResultKey}
 import com.amazon.deequ.utils.FixtureSupport
 import org.apache.spark.sql.{DataFrame, SparkSession}
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 import AnalyzerContext._
 import com.amazon.deequ.SparkContextSpec
 
 import scala.util.{Failure, Success}
 
-class InMemoryMetricsRepositoryTest extends WordSpec with SparkContextSpec with FixtureSupport {
+class InMemoryMetricsRepositoryTest extends AnyWordSpec with SparkContextSpec with FixtureSupport {
 
   private[this] val DATE_ONE = createDate(2017, 10, 14)
   private[this] val DATE_TWO = createDate(2017, 10, 15)

--- a/src/test/scala/com/amazon/deequ/schema/RowLevelSchemaValidatorTest.scala
+++ b/src/test/scala/com/amazon/deequ/schema/RowLevelSchemaValidatorTest.scala
@@ -18,9 +18,9 @@ package com.amazon.deequ.schema
 
 import com.amazon.deequ.SparkContextSpec
 import org.apache.spark.sql.types.{IntegerType, StringType, TimestampType}
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class RowLevelSchemaValidatorTest extends WordSpec with SparkContextSpec {
+class RowLevelSchemaValidatorTest extends AnyWordSpec with SparkContextSpec {
 
   "row level schema validation" should {
 

--- a/src/test/scala/com/amazon/deequ/suggestions/ConstraintSuggestionResultTest.scala
+++ b/src/test/scala/com/amazon/deequ/suggestions/ConstraintSuggestionResultTest.scala
@@ -21,9 +21,10 @@ import com.amazon.deequ.suggestions.rules.UniqueIfApproximatelyUniqueRule
 import com.amazon.deequ.utils.FixtureSupport
 import com.google.gson.JsonParser
 import org.apache.spark.sql.SparkSession
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
-class ConstraintSuggestionResultTest extends WordSpec with Matchers with SparkContextSpec
+class ConstraintSuggestionResultTest extends AnyWordSpec with Matchers with SparkContextSpec
   with FixtureSupport {
 
   "ConstraintSuggestionResult" should {

--- a/src/test/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunnerTest.scala
+++ b/src/test/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunnerTest.scala
@@ -27,13 +27,14 @@ import com.amazon.deequ.repository.memory.InMemoryMetricsRepository
 import com.amazon.deequ.suggestions.rules.UniqueIfApproximatelyUniqueRule
 import com.amazon.deequ.utils.{FixtureSupport, TempFileUtils}
 import org.apache.spark.sql.DataFrame
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.wordspec.AnyWordSpec
+import org.scalatest.matchers.should.Matchers
 
 import scala.util.Try
 import tools.reflect.ToolBox
 import scala.reflect.runtime.currentMirror
 
-class ConstraintSuggestionRunnerTest extends WordSpec with Matchers with SparkContextSpec
+class ConstraintSuggestionRunnerTest extends AnyWordSpec with Matchers with SparkContextSpec
   with FixtureSupport {
 
   "Constraint Suggestion Suite" should {

--- a/src/test/scala/com/amazon/deequ/suggestions/ConstraintSuggestionsIntegrationTest.scala
+++ b/src/test/scala/com/amazon/deequ/suggestions/ConstraintSuggestionsIntegrationTest.scala
@@ -23,7 +23,7 @@ import com.amazon.deequ.metrics.Metric
 import com.amazon.deequ.suggestions.rules.{NonNegativeNumbersRule, UniqueIfApproximatelyUniqueRule}
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.types.IntegerType
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
 import scala.util.Random
 
@@ -38,7 +38,7 @@ case class Record(
     allNullColumn2: java.lang.Double
 )
 
-class ConstraintSuggestionsIntegrationTest extends WordSpec with SparkContextSpec {
+class ConstraintSuggestionsIntegrationTest extends AnyWordSpec with SparkContextSpec {
 
   "Suggestions" should {
 

--- a/src/test/scala/com/amazon/deequ/suggestions/rules/ConstraintRulesTest.scala
+++ b/src/test/scala/com/amazon/deequ/suggestions/rules/ConstraintRulesTest.scala
@@ -25,9 +25,9 @@ import com.amazon.deequ.profiles._
 import com.amazon.deequ.utils.FixtureSupport
 import com.amazon.deequ.{SparkContextSpec, VerificationSuite}
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.WordSpec
+import org.scalatest.wordspec.AnyWordSpec
 
-class ConstraintRulesTest extends WordSpec with FixtureSupport with SparkContextSpec
+class ConstraintRulesTest extends AnyWordSpec with FixtureSupport with SparkContextSpec
   with MockFactory{
 
 


### PR DESCRIPTION


Preparing unit tests to be compatible with Scala 2.12 in preparation for compatibility with spark 3.0.0 Next step will be to create profiles in pom to do builds for spark 2 and spark 3


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
