### PR TITLE
Entity Enums name correction

### DIFF
--- a/src/main/scala/com/amazon/deequ/metrics/Metric.scala
+++ b/src/main/scala/com/amazon/deequ/metrics/Metric.scala
@@ -19,7 +19,7 @@ package com.amazon.deequ.metrics
 import scala.util.{Failure, Success, Try}
 
 object Entity extends Enumeration {
-  val Dataset, Column, Mutlicolumn = Value
+  val Dataset, Column, MultiColumn = Value
 }
 
 /** Common trait for all data quality metrics */


### PR DESCRIPTION
*Issue #, if available:*
-
*Description of changes:*
Entity enumerations under 'metrics.scala' has value 'Mutlicolumn' which is spelled wrong. corrected to  'Multicolumn'

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
