### PR TITLE
Fixes #301: Datatype REGEX fix for column profiler;

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/catalyst/StatefulDataType.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/catalyst/StatefulDataType.scala
@@ -33,8 +33,8 @@ private[sql] class StatefulDataType extends UserDefinedAggregateFunction {
   val BOOLEAN_POS = 3
   val STRING_POS = 4
 
-  val FRACTIONAL: Regex = """^(-|\+)? ?\d*\.\d*$""".r
-  val INTEGRAL: Regex = """^(-|\+)? ?\d*$""".r
+  val FRACTIONAL: Regex = """^(-|\+)? ?\d*\.\d+$""".r
+  val INTEGRAL: Regex = """^(-|\+)? ?\d+$""".r
   val BOOLEAN: Regex = """^(true|false)$""".r
 
   override def inputSchema: StructType = StructType(StructField("value", StringType) :: Nil)

--- a/src/test/scala/com/amazon/deequ/DatatypeSuggestionTest.scala
+++ b/src/test/scala/com/amazon/deequ/DatatypeSuggestionTest.scala
@@ -1,0 +1,27 @@
+package com.amazon.deequ
+
+import com.amazon.deequ.profiles.{ColumnProfiler, ColumnProfiles, StandardColumnProfile}
+import com.amazon.deequ.utils.FixtureSupport
+import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.scalamock.scalatest.MockFactory
+import org.scalatest.{Matchers, WordSpec}
+
+class DatatypeSuggestionTest extends WordSpec with Matchers with SparkContextSpec
+  with FixtureSupport with MockFactory{
+
+  "Column Profiler" should {
+    "return the correct datatype(String) in case of profiling empty string columns" in
+      withSparkSession { sparkSession =>
+
+        val df = getEmptyColumnDataDf(sparkSession = sparkSession)
+
+        val profile = ColumnProfiler
+                        .profile(df, Option(Seq("att1")))
+                        .profiles("att1")
+
+        assert(profile.isInstanceOf[StandardColumnProfile])
+        assert(profile.isDataTypeInferred && profile.dataType.toString.equalsIgnoreCase("String"))
+      }
+  }
+
+}

--- a/src/test/scala/com/amazon/deequ/DatatypeSuggestionTest.scala
+++ b/src/test/scala/com/amazon/deequ/DatatypeSuggestionTest.scala
@@ -1,3 +1,19 @@
+/**
+  * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+  *
+  * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+  * use this file except in compliance with the License. A copy of the License
+  * is located at
+  *
+  *     http://aws.amazon.com/apache2.0/
+  *
+  * or in the "license" file accompanying this file. This file is distributed on
+  * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+  * express or implied. See the License for the specific language governing
+  * permissions and limitations under the License.
+  *
+  */
+
 package com.amazon.deequ
 
 import com.amazon.deequ.profiles.{ColumnProfiler, ColumnProfiles, StandardColumnProfile}

--- a/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
+++ b/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
@@ -24,6 +24,19 @@ import scala.util.Random
 
 trait FixtureSupport {
 
+  def getEmptyColumnDataDf(sparkSession: SparkSession): DataFrame = {
+    import sparkSession.implicits._
+
+    Seq(
+      ("", "a", "f"),
+      ("", "b", "d"),
+      ("", "a", null),
+      ("", "a", "f"),
+      ("", "b", null),
+      ("", "a", "f")
+    ).toDF("att1", "att2", "att3")
+  }
+
   def getDfEmpty(sparkSession: SparkSession): DataFrame = {
     import sparkSession.implicits._
     val column1 = $"column1".string


### PR DESCRIPTION
Fixes #301 

Changed the REGEX for Integral and Fractional datatype.
This is because if a column has all values as empty string ("") then it is suggested as a integral column with a numeric column profile while it should not be.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
