### PR TITLE
correctly handle scientific notations in `isNonNegative`/`isPositive` checks as well

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/catalyst/StatefulDataType.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/catalyst/StatefulDataType.scala
@@ -33,7 +33,7 @@ private[sql] class StatefulDataType extends UserDefinedAggregateFunction {
   val BOOLEAN_POS = 3
   val STRING_POS = 4
 
-  val FRACTIONAL: Regex = """^(-|\+)? ?\d+(\.\d+|(?:\.\d+)?[Ee][-+]?\d+)$""".r
+  val FRACTIONAL: Regex = """^(-|\+)? ?\d+((\.\d+)|((?:\.\d+)?[Ee][-+]?\d+))$""".r
   val INTEGRAL: Regex = """^(-|\+)? ?\d+$""".r
   val BOOLEAN: Regex = """^(true|false)$""".r
 

--- a/src/main/scala/com/amazon/deequ/analyzers/catalyst/StatefulDataType.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/catalyst/StatefulDataType.scala
@@ -33,7 +33,7 @@ private[sql] class StatefulDataType extends UserDefinedAggregateFunction {
   val BOOLEAN_POS = 3
   val STRING_POS = 4
 
-  val FRACTIONAL: Regex = """^(-|\+)? ?\d*\.\d+$""".r
+  val FRACTIONAL: Regex = """^(-|\+)? ?\d+(\.\d+|(?:\.\d+)?[Ee][-+]?\d+)$""".r
   val INTEGRAL: Regex = """^(-|\+)? ?\d+$""".r
   val BOOLEAN: Regex = """^(true|false)$""".r
 
@@ -60,10 +60,10 @@ private[sql] class StatefulDataType extends UserDefinedAggregateFunction {
       buffer(NULL_POS) = buffer.getLong(NULL_POS) + 1L
     } else {
       input.getString(0) match {
-        case FRACTIONAL(_) => buffer(FRACTIONAL_POS) = buffer.getLong(FRACTIONAL_POS) + 1L
-        case INTEGRAL(_) => buffer(INTEGRAL_POS) = buffer.getLong(INTEGRAL_POS) + 1L
-        case BOOLEAN(_) => buffer(BOOLEAN_POS) = buffer.getLong(BOOLEAN_POS) + 1L
-        case _ => buffer(STRING_POS) = buffer.getLong(STRING_POS) + 1L
+        case FRACTIONAL(_*) => buffer(FRACTIONAL_POS) = buffer.getLong(FRACTIONAL_POS) + 1L
+        case INTEGRAL(_*)   => buffer(INTEGRAL_POS) = buffer.getLong(INTEGRAL_POS) + 1L
+        case BOOLEAN(_*)    => buffer(BOOLEAN_POS) = buffer.getLong(BOOLEAN_POS) + 1L
+        case _              => buffer(STRING_POS) = buffer.getLong(STRING_POS) + 1L
       }
     }
   }

--- a/src/main/scala/com/amazon/deequ/analyzers/catalyst/StatefulDataType.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/catalyst/StatefulDataType.scala
@@ -61,9 +61,9 @@ private[sql] class StatefulDataType extends UserDefinedAggregateFunction {
     } else {
       input.getString(0) match {
         case FRACTIONAL(_*) => buffer(FRACTIONAL_POS) = buffer.getLong(FRACTIONAL_POS) + 1L
-        case INTEGRAL(_*)   => buffer(INTEGRAL_POS) = buffer.getLong(INTEGRAL_POS) + 1L
-        case BOOLEAN(_*)    => buffer(BOOLEAN_POS) = buffer.getLong(BOOLEAN_POS) + 1L
-        case _              => buffer(STRING_POS) = buffer.getLong(STRING_POS) + 1L
+        case INTEGRAL(_*) => buffer(INTEGRAL_POS) = buffer.getLong(INTEGRAL_POS) + 1L
+        case BOOLEAN(_*) => buffer(BOOLEAN_POS) = buffer.getLong(BOOLEAN_POS) + 1L
+        case _ => buffer(STRING_POS) = buffer.getLong(STRING_POS) + 1L
       }
     }
   }

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -804,8 +804,14 @@ case class Check(
       hint: Option[String] = None)
     : CheckWithLastConstraintFilterable = {
 
-    // coalescing column to not count NULL values as non-compliant
-    satisfies(s"COALESCE($column, 0.0) >= 0", s"$column is non-negative", assertion, hint = hint)
+    satisfies(
+      // coalescing column to not count NULL values as non-compliant
+      // NOTE: cast to DECIMAL(20, 10) is needed to handle scientific notations
+      s"COALESCE(CAST($column as DECIMAL(20,10)), 0.0) >= 0",
+      s"$column is non-negative",
+      assertion,
+      hint = hint
+    )
   }
 
   /**
@@ -822,7 +828,13 @@ case class Check(
       hint: Option[String] = None)
     : CheckWithLastConstraintFilterable = {
     // coalescing column to not count NULL values as non-compliant
-    satisfies(s"COALESCE($column, 1.0) > 0", s"$column is positive", assertion, hint)
+    // NOTE: cast to DECIMAL(20, 10) is needed to handle scientific notations
+    satisfies(
+      s"COALESCE(CAST($column as DECIMAL(20,10)), 1.0) > 0",
+      s"$column is positive",
+      assertion,
+      hint
+    )
   }
 
   /**

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -830,7 +830,7 @@ case class Check(
     // coalescing column to not count NULL values as non-compliant
     // NOTE: cast to DECIMAL(20, 10) is needed to handle scientific notations
     satisfies(
-      s"COALESCE(CAST($column as DECIMAL(20,10)), 1.0) > 0",
+      s"COALESCE(CAST($column AS DECIMAL(20,10)), 1.0) > 0",
       s"$column is positive",
       assertion,
       hint

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -807,7 +807,7 @@ case class Check(
     satisfies(
       // coalescing column to not count NULL values as non-compliant
       // NOTE: cast to DECIMAL(20, 10) is needed to handle scientific notations
-      s"COALESCE(CAST($column as DECIMAL(20,10)), 0.0) >= 0",
+      s"COALESCE(CAST($column AS DECIMAL(20,10)), 0.0) >= 0",
       s"$column is non-negative",
       assertion,
       hint = hint

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -764,7 +764,7 @@ class CheckTest extends AnyWordSpec with Matchers with SparkContextSpec with Fix
       assertEvaluatesTo(checkWithFilter, context, CheckStatus.Success)
     }
 
-    "correctly handle fractional values represented in scientific notations" in withSparkSession { sparkSession =>
+    "handle fractional values in scientific notations" in withSparkSession { sparkSession =>
       import sparkSession.implicits._
 
       val df = Seq(

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -776,12 +776,15 @@ class CheckTest extends AnyWordSpec with Matchers with SparkContextSpec with Fix
         ("1E-3")
       ).toDF("val")
 
-      val check = Check(CheckLevel.Error, "they're all fractional")
+      val datatypeCheck = Check(CheckLevel.Error, "they're all fractional")
         .hasDataType("val", ConstrainableDataTypes.Fractional, _ == 1.0)
+      val datatypeContext = runChecks(df, datatypeCheck)
+      assertEvaluatesTo(datatypeCheck, datatypeContext, CheckStatus.Success)
 
-      val context = runChecks(df, check)
-
-      assertEvaluatesTo(check, context, CheckStatus.Success)
+      val nonNegativeCheck = Check(CheckLevel.Error, "they're positive")
+        .isNonNegative("val")
+      val nonNegativeContext = runChecks(df, nonNegativeCheck)
+      assertEvaluatesTo(nonNegativeCheck, nonNegativeContext, CheckStatus.Success)
     }
 
     "find credit card numbers embedded in text" in withSparkSession { sparkSession =>


### PR DESCRIPTION
really fixes #276 

- it turns out we need to handle scientific notations in `isNonNegative` and `isPositive` checks as well; this time we need to use `cast(col as decimal(n, n)` to eliminate scientific notations before doing checks
- built on top of #311 (you can see the actual diff from #311 in https://github.com/awslabs/deequ/pull/312/commits/7539fd21213bb8fcffd01a6948bfbc84500766e8)

I'm okay with either of 1.) merge #311 first, and then merge this branch into `master` after rebasing or such, 2.) merge this as is and close #311

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
