### PR TITLE
Enable using same analyzers for anomaly and CHECK constraints

### DIFF
--- a/src/main/scala/com/amazon/deequ/VerificationSuite.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationSuite.scala
@@ -120,7 +120,7 @@ class VerificationSuite {
 
     val analysisResults = AnalysisRunner.doAnalysisRun(
       data,
-      analyzers,
+      analyzers.distinct,
       aggregateWith,
       saveStatesWith,
       metricsRepositoryOptions = AnalysisRunnerRepositoryOptions(

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -302,7 +302,8 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
       }
     }
 
-    "addAnomalyCheck with duplicate analyzer in check should work" in withSparkSession { sparkSession =>
+    "addAnomalyCheck with duplicate check analyzer should work" in
+      withSparkSession { sparkSession =>
       evaluateWithRepositoryWithHistory { repository =>
 
         val df = getDfWithNRows(sparkSession, 11)
@@ -312,7 +313,7 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
 
         val verificationResultOne = VerificationSuite()
           .onData(df)
-          .addCheck( Check(CheckLevel.Error, "group-1").hasSize(_ == 11))
+          .addCheck(Check(CheckLevel.Error, "group-1").hasSize(_ == 11))
           .useRepository(repository)
           .addRequiredAnalyzers(analyzers)
           .saveOrAppendResult(saveResultsWithKey)

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -336,24 +336,11 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
           )
           .run()
 
-        val verificationResultThree = VerificationSuite()
-          .onData(df)
-          .useRepository(repository)
-          .addRequiredAnalyzers(analyzers)
-          .saveOrAppendResult(saveResultsWithKey)
-          .addAnomalyCheck(
-            AbsoluteChangeStrategy(Some(-7.0), Some(7.0)),
-            Size()
-          )
-          .run()
-
         val checkResultsOne = verificationResultOne.checkResults.values.toSeq(1).status
         val checkResultsTwo = verificationResultTwo.checkResults.head._2.status
-        val checkResultsThree = verificationResultThree.checkResults.head._2.status
 
         assert(checkResultsOne == CheckStatus.Warning)
         assert(checkResultsTwo == CheckStatus.Success)
-        assert(checkResultsThree == CheckStatus.Success)
       }
     }
 


### PR DESCRIPTION
… checks #316

*Issue #316*

*use distinct analyzers to enable using same analyzers for anomaly and checks:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
