### PR TITLE
travis-ci.org to travis-ci.com link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Deequ - Unit Tests for Data
 [![GitHub license](https://img.shields.io/github/license/awslabs/deequ.svg)](https://github.com/awslabs/deequ/blob/master/LICENSE)
 [![GitHub issues](https://img.shields.io/github/issues/awslabs/deequ.svg)](https://github.com/awslabs/deequ/issues)
-[![Build Status](https://travis-ci.org/awslabs/deequ.svg?branch=master)](https://travis-ci.org/awslabs/deequ)
+[![Build Status](https://travis-ci.com/awslabs/deequ.svg?branch=master)](https://travis-ci.com/awslabs/deequ)
 [![Maven Central](https://maven-badges.herokuapp.com/maven-central/com.amazon.deequ/deequ/badge.svg)](https://maven-badges.herokuapp.com/maven-central/com.amazon.deequ/deequ)
 
 Deequ is a library built on top of Apache Spark for defining "unit tests for data", which measure data quality in large datasets. We are happy to receive feedback and [contributions](CONTRIBUTING.md).


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Travis-CI is moving domains from .org to .com.  When you go to the older .org domain it recommends redirecting and updating links.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
