### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ __Maven__
 ```
 __sbt__
 ```
-libraryDependencies += "com.amazon.deequ" % "deequ" % "1.1.0-spark-3.0-scala-2.12"
+libraryDependencies += "com.amazon.deequ" % "deequ" % "1.1.0_spark-3.0-scala-2.12"
 ```
 
 ## Example


### PR DESCRIPTION
Typo in sbt section of installation instructions. It requires an underscore after the version number, not a dash: https://mvnrepository.com/artifact/com.amazon.deequ/deequ/1.1.0_spark-3.0-scala-2.12

*Issue #, if available:*

*Description of changes:*
Update typo in readme.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
