### PR TITLE
Update release process and point README to a working release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,2 @@
-# mvn profiles for the different supported 
-# Spark and Scala versions. Uncomment
-# the one that you want to use. You can also 
-# override the profile on the command line:
-# `make MVN_PROFILE=spark-2.4-scala-2.11 build`
-MVN_PROFILE := spark-3.0-scala-2.12
-# MVN_PROFILE := spark-2.4-scala-2.11
-# MVN_PROFILE := spark-2.3-scala-2.11
-# MVN_PROFILE := spark-2.2-scala-2.11
-
-# Build the project for specific Spark and 
-# Scala versions. You can change the profile 
-# variable to use a different Scala or Spark 
-# version (see list above).
-# If you need more log ouput remove the -q flag.
 build:
-	mvn clean install -q -P $(MVN_PROFILE)
+	mvn clean install

--- a/README.md
+++ b/README.md
@@ -10,22 +10,22 @@ Python users may also be interested in PyDeequ, a Python interface for Deequ. Yo
 
 ## Requirements and Installation
 
-__Deequ__ depends on Java 8. We provide releases compatible with Apache Spark versions 2.2.x to 2.4.x and 3.0.x.
+__Deequ__ depends on Java 8. We provide releases compatible with Apache Spark versions 2.2.x to 3.0.x. The Spark 2.2.x and 2.3.x releases depend on Scala 2.11 and the Spark 2.4.x and 3.0.x releases depend on Scala 2.12.
 
 Available via [maven central](http://mvnrepository.com/artifact/com.amazon.deequ/deequ). 
 
-Choose the latest release that matches your Scala and Spark versions from the [available versions](https://repo1.maven.org/maven2/com/amazon/deequ/deequ/). Add the release as a dependency to your project. For example:
+Choose the latest release that matches your Spark version from the [available versions](https://repo1.maven.org/maven2/com/amazon/deequ/deequ/). Add the release as a dependency to your project. For example for spark 3.0.x:
 __Maven__
 ```
 <dependency>
   <groupId>com.amazon.deequ</groupId>
   <artifactId>deequ</artifactId>
-  <version>1.1.0_spark-3.0-scala-2.12</version>
+  <version>1.2.2-spark-3.0</version>
 </dependency>
 ```
 __sbt__
 ```
-libraryDependencies += "com.amazon.deequ" % "deequ" % "1.1.0_spark-3.0-scala-2.12"
+libraryDependencies += "com.amazon.deequ" % "deequ" % "1.2.2-spark-3.0"
 ```
 
 ## Example

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.amazon.deequ</groupId>
     <artifactId>deequ</artifactId>
-    <version>1.2.2-spark-2.2</version>
+    <version>1.2.2-SNAPSHOT</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -14,13 +14,13 @@
         <encoding>UTF-8</encoding>
 
         <!-- Scala (select 2.11 or 2.12) -->
-        <scala.major.version>2.11</scala.major.version>
+        <scala.major.version>2.12</scala.major.version>
         <scala.version>${scala.major.version}.10</scala.version>
         <artifact.scala.version>${scala.major.version}</artifact.scala.version>
         <scala-maven-plugin.version>4.4.0</scala-maven-plugin.version>
 
         <!-- Spark (select 2.2.3, 2.3.4, 2.4.7, or 3.0.1) -->
-        <spark.version>2.2.3</spark.version>
+        <spark.version>2.4.7</spark.version>
     </properties>
 
     <name>deequ</name>

--- a/pom.xml
+++ b/pom.xml
@@ -5,8 +5,23 @@
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>com.amazon.deequ</groupId>
-    <artifactId>deequ${artifact.scala.version}${artifact.spark.version}</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <artifactId>deequ</artifactId>
+    <version>1.2.2-spark-2.2</version>
+
+    <properties>
+        <maven.compiler.source>1.8</maven.compiler.source>
+        <maven.compiler.target>1.8</maven.compiler.target>
+        <encoding>UTF-8</encoding>
+
+        <!-- Scala (select 2.11 or 2.12) -->
+        <scala.major.version>2.11</scala.major.version>
+        <scala.version>${scala.major.version}.10</scala.version>
+        <artifact.scala.version>${scala.major.version}</artifact.scala.version>
+        <scala-maven-plugin.version>4.4.0</scala-maven-plugin.version>
+
+        <!-- Spark (select 2.2.3, 2.3.4, 2.4.7, or 3.0.1) -->
+        <spark.version>2.2.3</spark.version>
+    </properties>
 
     <name>deequ</name>
     <description>Deequ is a library built on top of Apache Spark for defining "unit tests for data",
@@ -53,28 +68,6 @@
     <scm>
         <url>https://github.com/awslabs/deequ</url>
     </scm>
-
-    <properties>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
-        <encoding>UTF-8</encoding>
-
-        <!-- Scala -->
-        <scala.major.version>${scala-211.major.version}</scala.major.version>
-        <scala.version>${scala.major.version}.10</scala.version>
-        <scala-211.major.version>2.11</scala-211.major.version>
-        <scala-212.major.version>2.12</scala-212.major.version>
-        <artifact.scala.version></artifact.scala.version>
-        <scala-maven-plugin.version>4.4.0</scala-maven-plugin.version>
-
-        <!-- Spark -->
-        <spark.version>${spark-24.version}</spark.version>
-        <spark-22.version>2.2.2</spark-22.version>
-        <spark-23.version>2.3.2</spark-23.version>
-        <spark-24.version>2.4.2</spark-24.version>
-        <spark-30.version>3.0.0</spark-30.version>
-        <artifact.spark.version></artifact.spark.version>
-    </properties>
 
     <dependencies>
         <dependency>
@@ -244,6 +237,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.2.0</version>
+								<configuration>
+										<finalName>${project.artifactId}_${scala.major.version}-${project.version}</finalName>
+								</configuration>
                 <executions>
                     <execution>
                         <goals>
@@ -402,46 +398,6 @@
                     </plugin>
                 </plugins>
             </build>
-        </profile>
-        <profile>
-            <id>spark-2.2-scala-2.11</id>
-            <properties>
-                <spark.version>${spark-22.version}</spark.version>
-                <scala.major.version>${scala-211.major.version}</scala.major.version>
-                <scala.version>${scala.major.version}.10</scala.version>
-                <artifact.scala.version>_scala-${scala.major.version}</artifact.scala.version>
-                <artifact.spark.version>_spark-${spark.version}</artifact.spark.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>spark-2.3-scala-2.11</id>
-            <properties>
-                <spark.version>${spark-23.version}</spark.version>
-                <scala.major.version>${scala-211.major.version}</scala.major.version>
-                <scala.version>${scala.major.version}.10</scala.version>
-                <artifact.scala.version>_scala-${scala.major.version}</artifact.scala.version>
-                <artifact.spark.version>_spark-${spark.version}</artifact.spark.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>spark-2.4-scala-2.11</id>
-            <properties>
-                <spark.version>${spark-24.version}</spark.version>
-                <scala.major.version>${scala-211.major.version}</scala.major.version>
-                <scala.version>${scala.major.version}.10</scala.version>
-                <artifact.scala.version>_scala-${scala.major.version}</artifact.scala.version>
-                <artifact.spark.version>_spark-${spark.version}</artifact.spark.version>
-            </properties>
-        </profile>
-        <profile>
-            <id>spark-3.0-scala-2.12</id>
-            <properties>
-                <spark.version>${spark-30.version}</spark.version>
-                <scala.major.version>${scala-212.major.version}</scala.major.version>
-                <scala.version>${scala.major.version}.10</scala.version>
-                <artifact.scala.version>_scala-${scala.major.version}</artifact.scala.version>
-                <artifact.spark.version>_spark-${spark.version}</artifact.spark.version>
-            </properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
*Issue #, if available: https://github.com/awslabs/deequ/issues/353, https://github.com/awslabs/deequ/issues/349*

### Description of changes

This PR
- drastically simplifies the pom.xml by removing most profiles. Releases now require more manual work to set the right scala and spark versions, but this change should make the releases usable again. The Makefile is also updated to remove the logic related to the (now removed) pom.xml build profiles.
- updates the readme to point to a working release. 

I performed releases for Spark 2.2.x to 3.0.x that include the changes from this PR. The releases are called `1.2.2-spark-..` and they should become available on maven over the next days ([Link to maven repository](https://mvnrepository.com/artifact/com.amazon.deequ/deequ)).

### Remaining TODOs

A couple of work items should be completed before this PR is merged:
- Wait for the 1.2.2-.. releases to become available on maven ([Link to maven repository](https://mvnrepository.com/artifact/com.amazon.deequ/deequ)) and make sure that they are importable.
- Create GitHub release tags for the 1.2.2-.. release branches


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
