### PR TITLE
Fix PatternMatch hashCode bug

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
@@ -81,6 +81,7 @@ case class PatternMatch(column: String, pattern: Regex, where: Option[String] = 
 }
 
 object Patterns {
+
   // scalastyle:off
   // http://emailregex.com
   val EMAIL: Regex = """(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])""".r

--- a/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
@@ -60,10 +60,27 @@ case class PatternMatch(column: String, pattern: Regex, where: Option[String] = 
   override protected def additionalPreconditions(): Seq[StructType => Unit] = {
     hasColumn(column) :: isString(column) :: Nil
   }
+
+  // PatternMatch hasCode is different with the same-parameter objects because Regex compares by address
+  // fix this by tuple with pattern string
+  private val internalObj = (column, pattern.toString(), where)
+
+  override def hashCode(): Int = {
+    internalObj.hashCode()
+  }
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case o: PatternMatch => {
+        internalObj.equals(o.asInstanceOf[PatternMatch].internalObj)
+      }
+      case _ => false
+    }
+  }
+
 }
 
 object Patterns {
-
   // scalastyle:off
   // http://emailregex.com
   val EMAIL: Regex = """(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])""".r

--- a/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
@@ -61,7 +61,8 @@ case class PatternMatch(column: String, pattern: Regex, where: Option[String] = 
     hasColumn(column) :: isString(column) :: Nil
   }
 
-  // PatternMatch hasCode is different with the same-parameter objects because Regex compares by address
+  // PatternMatch hasCode is different with the same-parameter objects
+  // because Regex compares by address
   // fix this by tuple with pattern string
   private val internalObj = (column, pattern.toString(), where)
 
@@ -71,9 +72,7 @@ case class PatternMatch(column: String, pattern: Regex, where: Option[String] = 
 
   override def equals(obj: Any): Boolean = {
     obj match {
-      case o: PatternMatch => {
-        internalObj.equals(o.asInstanceOf[PatternMatch].internalObj)
-      }
+      case o: PatternMatch => internalObj.equals(o.asInstanceOf[PatternMatch].internalObj)
       case _ => false
     }
   }

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
@@ -679,6 +679,13 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
   "Pattern compliance analyzer" should {
     val someColumnName = "some"
 
+    "PatternMatch hashCode should equal for the same pattern" in {
+      val p1 = PatternMatch("col1", "[a-z]".r)
+      val p2 = PatternMatch("col1", "[a-z]".r)
+      p1.hashCode() should equal(p2.hashCode())
+      p1 should equal(p2)
+    }
+
     "not match doubles in nullable column" in withSparkSession { sparkSession =>
 
        val df = dataFrameWithColumn(someColumnName, DoubleType, sparkSession, Row(1.1),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The PatternMatch hashCode differs for the same class parameters because Regex parameter compares by reference other than the pattern value.
A possible problem this causing is getting PatternMatch metrics from AnalyzerContext map will return nothing if the PatternMatch object does not reference equal.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
