### PR TITLE
fixed issue #271: Histogram analyzer filter missing

### DIFF
--- a/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
+++ b/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
@@ -301,6 +301,7 @@ private[deequ] object AnalyzerSerializer
         result.addProperty(ANALYZER_NAME_FIELD, "Histogram")
         result.addProperty(COLUMN_FIELD, histogram.column)
         result.addProperty("maxDetailBins", histogram.maxDetailBins)
+        result.addProperty(WHERE_FIELD, histogram.where.orNull)
 
       case _ : Histogram =>
         throw new IllegalArgumentException("Unable to serialize Histogram with binningUdf!")
@@ -434,7 +435,8 @@ private[deequ] object AnalyzerDeserializer
         Histogram(
           json.get(COLUMN_FIELD).getAsString,
           None,
-          json.get("maxDetailBins").getAsInt)
+          json.get("maxDetailBins").getAsInt,
+          getOptionalWhereParam(json))
 
       case "DataType" =>
         DataType(


### PR DESCRIPTION
*Issue #, if available: #271

*Description of changes:*
Added the missing filter to Histogram analyzer in AnalysisResultSerde.scala, so that Histogram metrics with filter can be stored in the repository.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.

P.S. The issue was opened last year and unfortunately I haven't got a chance to submit a PR. Recently, I checked the latest build that this bug still exists, so I submit it this time. I was also thinking about if a test case is needed. In AnalysisResultSerdeTest.scala, it seems nowhere to fit in such a use case. Please let me know if any suggestion. Thanks.