### PR TITLE
Cast column types with select() instead of withColumn()

### DIFF
--- a/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
+++ b/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
@@ -448,15 +448,22 @@ object ColumnProfiler {
     : DataFrame = {
 
     var castedData = originalData
+    var columnsSet = columns.toSet
 
-    columns.foreach { name =>
-
-      castedData = genericStatistics.typeOf(name) match {
-        case Integral => castColumn(castedData, name, LongType)
-        case Fractional => castColumn(castedData, name, DoubleType)
-        case _ => castedData
-      }
-    }
+    castedData = castedData.select(
+      castedData.columns.map { name =>
+        if (!columnsSet.contains(name)) {
+          castedData(name)
+        }
+        else {
+          genericStatistics.typeOf(name) match {
+            case Integral => castedData(name).cast(LongType)
+            case Fractional => castedData(name).cast(DoubleType)
+            case _ => castedData(name)
+          }
+        }
+      }: _*
+    )
 
     castedData
   }


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*
We're facing slowness while running the ColumnProfiler on large datasets. According to the PySpark's [doc](https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.DataFrame.withColumn.html), using withColumn for multiple times, like in a for-loop, can cause performance issues. select() is suggested here to replace the multiple withColumn() call.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
