### PR TITLE
Tammruka/2.0.0 spark 3.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@ Python users may also be interested in PyDeequ, a Python interface for Deequ. Yo
 
 ## Requirements and Installation
 
-__Deequ__ depends on Java 8. We provide releases compatible with Apache Spark versions 2.2.x to 3.1.x. The Spark 2.2.x and 2.3.x releases depend on Scala 2.11 and the Spark 2.4.x, 3.0.x, and 3.1.x releases depend on Scala 2.12. Note: Deequ version 2.x only runs with Spark 3.1, and vice versa. If you rely on a previous Spark version, please use a Deequ 1.x version (legacy version is maintained in legacy-spark-3.0 branch). 
+__Deequ__ depends on Java 8. Deequ version 2.x only runs with Spark 3.1, and vice versa. If you rely on a previous Spark version, please use a Deequ 1.x version (legacy version is maintained in legacy-spark-3.0 branch). We provide legacy releases compatible with Apache Spark versions 2.2.x to 3.0.x. The Spark 2.2.x and 2.3.x releases depend on Scala 2.11 and the Spark 2.4.x, 3.0.x, and 3.1.x releases depend on Scala 2.12. 
 
 Available via [maven central](http://mvnrepository.com/artifact/com.amazon.deequ/deequ). 
 
 Choose the latest release that matches your Spark version from the [available versions](https://repo1.maven.org/maven2/com/amazon/deequ/deequ/). Add the release as a dependency to your project. For example, for Spark 3.1.x:
+
 __Maven__
 ```
 <dependency>

--- a/README.md
+++ b/README.md
@@ -10,22 +10,22 @@ Python users may also be interested in PyDeequ, a Python interface for Deequ. Yo
 
 ## Requirements and Installation
 
-__Deequ__ depends on Java 8. We provide releases compatible with Apache Spark versions 2.2.x to 3.0.x. The Spark 2.2.x and 2.3.x releases depend on Scala 2.11 and the Spark 2.4.x and 3.0.x releases depend on Scala 2.12.
+__Deequ__ depends on Java 8. We provide releases compatible with Apache Spark versions 2.2.x to 3.1.x. The Spark 2.2.x and 2.3.x releases depend on Scala 2.11 and the Spark 2.4.x, 3.0.x, and 3.1.x releases depend on Scala 2.12. Note: Deequ version 2.x only runs with Spark 3.1, and vice versa. If you rely on a previous Spark version, please use a Deequ 1.x version (legacy version is maintained in legacy-spark-3.0 branch). 
 
 Available via [maven central](http://mvnrepository.com/artifact/com.amazon.deequ/deequ). 
 
-Choose the latest release that matches your Spark version from the [available versions](https://repo1.maven.org/maven2/com/amazon/deequ/deequ/). Add the release as a dependency to your project. For example for spark 3.0.x:
+Choose the latest release that matches your Spark version from the [available versions](https://repo1.maven.org/maven2/com/amazon/deequ/deequ/). Add the release as a dependency to your project. For example, for Spark 3.1.x:
 __Maven__
 ```
 <dependency>
   <groupId>com.amazon.deequ</groupId>
   <artifactId>deequ</artifactId>
-  <version>1.2.2-spark-3.0</version>
+  <version>2.0.0-spark-3.1</version>
 </dependency>
 ```
 __sbt__
 ```
-libraryDependencies += "com.amazon.deequ" % "deequ" % "1.2.2-spark-3.0"
+libraryDependencies += "com.amazon.deequ" % "deequ" % "2.0.0-spark-3.1"
 ```
 
 ## Example

--- a/pom.xml
+++ b/pom.xml
@@ -13,12 +13,12 @@
         <maven.compiler.target>1.8</maven.compiler.target>
         <encoding>UTF-8</encoding>
 
-        <scala.major.version>2.12</scala.major.version>
-        <scala.version>${scala.major.version}.10</scala.version>
+        <scala.major.version>2.13</scala.major.version>
+        <scala.version>${scala.major.version}.0</scala.version>
         <artifact.scala.version>${scala.major.version}</artifact.scala.version>
-        <scala-maven-plugin.version>4.4.0</scala-maven-plugin.version>
+        <scala-maven-plugin.version>4.5.6</scala-maven-plugin.version>
 
-        <spark.version>3.1.1</spark.version>
+        <spark.version>3.2.0</spark.version>
     </properties>
 
     <name>deequ</name>
@@ -89,7 +89,7 @@
         <dependency>
             <groupId>org.scalanlp</groupId>
             <artifactId>breeze_${scala.major.version}</artifactId>
-            <version>0.13.2</version>
+            <version>2.0.1-RC1</version>
         </dependency>
 
         <dependency>
@@ -235,9 +235,9 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.2.0</version>
-								<configuration>
-										<finalName>${project.artifactId}_${scala.major.version}-${project.version}</finalName>
-								</configuration>
+                <configuration>
+                    <finalName>${project.artifactId}_${scala.major.version}-${project.version}</finalName>
+                </configuration>
                 <executions>
                     <execution>
                         <goals>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,6 @@
         <scala.version>${scala.major.version}.0</scala.version>
         <artifact.scala.version>${scala.major.version}</artifact.scala.version>
         <scala-maven-plugin.version>4.5.6</scala-maven-plugin.version>
-
         <spark.version>3.2.0</spark.version>
     </properties>
 

--- a/pom.xml
+++ b/pom.xml
@@ -146,6 +146,7 @@
 
     <build>
         <sourceDirectory>src/main/scala</sourceDirectory>
+        <testSourceDirectory>src/test/scala</testSourceDirectory>
 
         <plugins>
             <plugin>

--- a/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
@@ -81,6 +81,7 @@ case class PatternMatch(column: String, pattern: Regex, where: Option[String] = 
 }
 
 object Patterns {
+
   // scalastyle:off
   // http://emailregex.com
   val EMAIL: Regex = """(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])""".r

--- a/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
@@ -60,10 +60,27 @@ case class PatternMatch(column: String, pattern: Regex, where: Option[String] = 
   override protected def additionalPreconditions(): Seq[StructType => Unit] = {
     hasColumn(column) :: isString(column) :: Nil
   }
+
+  // PatternMatch hasCode is different with the same-parameter objects because Regex compares by address
+  // fix this by tuple with pattern string
+  private val internalObj = (column, pattern.toString(), where)
+
+  override def hashCode(): Int = {
+    internalObj.hashCode()
+  }
+
+  override def equals(obj: Any): Boolean = {
+    obj match {
+      case o: PatternMatch => {
+        internalObj.equals(o.asInstanceOf[PatternMatch].internalObj)
+      }
+      case _ => false
+    }
+  }
+
 }
 
 object Patterns {
-
   // scalastyle:off
   // http://emailregex.com
   val EMAIL: Regex = """(?:[a-z0-9!#$%&'*+/=?^_`{|}~-]+(?:\.[a-z0-9!#$%&'*+/=?^_`{|}~-]+)*|"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*")@(?:(?:[a-z0-9](?:[a-z0-9-]*[a-z0-9])?\.)+[a-z0-9](?:[a-z0-9-]*[a-z0-9])?|\[(?:(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)\.){3}(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?|[a-z0-9-]*[a-z0-9]:(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21-\x5a\x53-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])+)\])""".r

--- a/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
@@ -61,7 +61,8 @@ case class PatternMatch(column: String, pattern: Regex, where: Option[String] = 
     hasColumn(column) :: isString(column) :: Nil
   }
 
-  // PatternMatch hasCode is different with the same-parameter objects because Regex compares by address
+  // PatternMatch hasCode is different with the same-parameter objects
+  // because Regex compares by address
   // fix this by tuple with pattern string
   private val internalObj = (column, pattern.toString(), where)
 
@@ -71,9 +72,7 @@ case class PatternMatch(column: String, pattern: Regex, where: Option[String] = 
 
   override def equals(obj: Any): Boolean = {
     obj match {
-      case o: PatternMatch => {
-        internalObj.equals(o.asInstanceOf[PatternMatch].internalObj)
-      }
+      case o: PatternMatch => internalObj.equals(o.asInstanceOf[PatternMatch].internalObj)
       case _ => false
     }
   }

--- a/src/main/scala/com/amazon/deequ/analyzers/QuantileNonSample.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/QuantileNonSample.scala
@@ -52,7 +52,7 @@ class QuantileNonSample[T](
     this.shrinkingFactor = shrinkingFactor
     compactors = ArrayBuffer.fill(data.length)(new NonSampleCompactor[T])
     for (i <- data.indices) {
-      compactors(i).buffer = data(i).to[ArrayBuffer]
+      compactors(i).buffer = data(i).to[ArrayBuffer[T]]
     }
     curNumOfCompactors = data.length
     compactorActualSize = getCompactorItemsCount

--- a/src/main/scala/com/amazon/deequ/analyzers/QuantileNonSample.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/QuantileNonSample.scala
@@ -51,7 +51,7 @@ class QuantileNonSample[T](
     this.shrinkingFactor = shrinkingFactor
     compactors = ArrayBuffer.fill(data.length)(new NonSampleCompactor[T])
     for (i <- data.indices) {
-      compactors(i).buffer = data(i).to[ArrayBuffer[T]]
+      compactors(i).buffer = data(i).to(ArrayBuffer[T])
     }
     curNumOfCompactors = data.length
     compactorActualSize = getCompactorItemsCount

--- a/src/main/scala/com/amazon/deequ/analyzers/QuantileNonSample.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/QuantileNonSample.scala
@@ -21,7 +21,6 @@ import scala.collection.mutable.ArrayBuffer
 import scala.reflect.ClassTag
 import scala.util.control.Breaks._
 
-
 class QuantileNonSample[T](
     var sketchSize: Int,
     var shrinkingFactor: Double = 0.64)

--- a/src/main/scala/com/amazon/deequ/analyzers/StateProvider.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/StateProvider.scala
@@ -24,7 +24,7 @@ import org.apache.spark.sql.SparkSession
 import org.apache.spark.sql.catalyst.expressions.aggregate.{ApproximatePercentile, DeequHyperLogLogPlusPlusUtils}
 import org.apache.spark.sql.SaveMode
 
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 import scala.util.hashing.MurmurHash3
 
 private object StateInformation {
@@ -58,7 +58,7 @@ case class InMemoryStateProvider() extends StateLoader with StatePersister {
 
   override def toString: String = {
     val buffer = new StringBuilder()
-    statesByAnalyzer.foreach { case (analyzer, state) =>
+    statesByAnalyzer.asScala.foreach { case (analyzer, state) =>
       buffer.append(analyzer.toString)
       buffer.append(" => ")
       buffer.append(state.toString)

--- a/src/main/scala/com/amazon/deequ/anomalydetection/OnlineNormalStrategy.scala
+++ b/src/main/scala/com/amazon/deequ/anomalydetection/OnlineNormalStrategy.scala
@@ -116,7 +116,7 @@ case class OnlineNormalStrategy(
         ret += OnlineCalculationResult(currentMean, stdDev, isAnomaly = true)
       }
     }
-    ret
+    ret.toSeq
   }
 
 

--- a/src/main/scala/com/amazon/deequ/anomalydetection/seasonal/HoltWinters.scala
+++ b/src/main/scala/com/amazon/deequ/anomalydetection/seasonal/HoltWinters.scala
@@ -132,7 +132,7 @@ class HoltWinters(
       }
     val forecasted = Y.drop(series.size)
 
-    ModelResults(forecasted, level, trend, seasonality, residuals)
+    ModelResults(forecasted.toSeq, level.toSeq, trend.toSeq, seasonality.toSeq, residuals.toSeq)
   }
 
   private def modelSelectionFor(

--- a/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
+++ b/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
@@ -317,7 +317,7 @@ object ColumnProfiler {
                   Histogram(histogram.column).equals(histogram)
               case _ => false
             }
-          analyzerContextExistingValues = AnalyzerContext(relevantEntries)
+          analyzerContextExistingValues = AnalyzerContext(relevantEntries.toMap)
         }
       }
     }

--- a/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
+++ b/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
@@ -19,7 +19,6 @@ package com.amazon.deequ.repository
 import java.lang.reflect.Type
 
 import com.amazon.deequ.analyzers.{State, _}
-import org.apache.spark.sql.functions._
 import com.amazon.deequ.metrics.{Distribution, Metric, _}
 
 import util.{Failure, Success, Try}
@@ -28,12 +27,10 @@ import com.google.gson._
 import com.google.gson.reflect.TypeToken
 
 import scala.collection._
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap, List => JList, Map => JMap}
 
 import JsonSerializationConstants._
-
-import scala.collection.JavaConversions._
 
 private[repository] object JsonSerializationConstants {
 
@@ -413,22 +410,22 @@ private[deequ] object AnalyzerDeserializer
           getOptionalWhereParam(json))
 
       case "CountDistinct" =>
-        CountDistinct(getColumnsAsSeq(context, json))
+        CountDistinct(getColumnsAsSeq(context, json).toSeq)
 
       case "Distinctness" =>
-        Distinctness(getColumnsAsSeq(context, json))
+        Distinctness(getColumnsAsSeq(context, json).toSeq)
 
       case "Entropy" =>
         Entropy(json.get(COLUMN_FIELD).getAsString)
 
       case "MutualInformation" =>
-        MutualInformation(getColumnsAsSeq(context, json))
+        MutualInformation(getColumnsAsSeq(context, json).toSeq)
 
       case "UniqueValueRatio" =>
-        UniqueValueRatio(getColumnsAsSeq(context, json))
+        UniqueValueRatio(getColumnsAsSeq(context, json).toSeq)
 
       case "Uniqueness" =>
-        Uniqueness(getColumnsAsSeq(context, json))
+        Uniqueness(getColumnsAsSeq(context, json).toSeq)
 
       case "Histogram" =>
         Histogram(
@@ -571,7 +568,7 @@ private[deequ] object MetricDeserializer extends JsonDeserializer[Metric[_]] {
         val instance = jsonObject.get("instance").getAsString
         if (jsonObject.has("value")) {
           val entries = jsonObject.get("value").getAsJsonObject
-          val values = entries.entrySet().map { entry =>
+          val values = entries.entrySet().asScala.map { entry =>
             entry.getKey -> entry.getValue.getAsDouble
           }
           .toMap

--- a/src/main/scala/com/amazon/deequ/repository/MetricsRepositoryMultipleResultsLoader.scala
+++ b/src/main/scala/com/amazon/deequ/repository/MetricsRepositoryMultipleResultsLoader.scala
@@ -99,8 +99,8 @@ private[repository] object MetricsRepositoryMultipleResultsLoader {
 
   def jsonUnion(jsonOne: String, jsonTwo: String): String = {
 
-    val objectOne: Seq[Map[String, Any]] = SimpleResultSerde.deserialize(jsonOne)
-    val objectTwo: Seq[Map[String, Any]] = SimpleResultSerde.deserialize(jsonTwo)
+    val objectOne: Seq[Map[String, Any]] = SimpleResultSerde.deserialize(jsonOne).toSeq
+    val objectTwo: Seq[Map[String, Any]] = SimpleResultSerde.deserialize(jsonTwo).toSeq
 
     val columnsTotal = objectOne.headOption.getOrElse(Map.empty).keySet ++
       objectTwo.headOption.getOrElse(Map.empty).keySet

--- a/src/main/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepository.scala
+++ b/src/main/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepository.scala
@@ -147,10 +147,10 @@ class FileSystemMetricsRepositoryMultipleResultsLoader(
           .metricMap
           .filterKeys(analyzer => forAnalyzers.isEmpty || forAnalyzers.get.contains(analyzer))
 
-        val requestedAnalyzerContext = AnalyzerContext(requestedMetrics)
+        val requestedAnalyzerContext = AnalyzerContext(requestedMetrics.toMap)
 
         AnalysisResult(analysisResult.resultKey, requestedAnalyzerContext)
-      }
+      }.toSeq
   }
 }
 

--- a/src/main/scala/com/amazon/deequ/repository/memory/InMemoryMetricsRepository.scala
+++ b/src/main/scala/com/amazon/deequ/repository/memory/InMemoryMetricsRepository.scala
@@ -21,7 +21,7 @@ import com.amazon.deequ.metrics.Metric
 import com.amazon.deequ.repository._
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
 
-import scala.collection.JavaConversions._
+import scala.jdk.CollectionConverters._
 import java.util.concurrent.ConcurrentHashMap
 
 /** A simple Repository implementation backed by a concurrent hash map */
@@ -117,7 +117,7 @@ class LimitedInMemoryMetricsRepositoryMultipleResultsLoader(
 
   /** Get the AnalysisResult */
   def get(): Seq[AnalysisResult] = {
-    resultsRepository
+    resultsRepository.asScala
       .filterKeys(key => after.isEmpty || after.get <= key.dataSetDate)
       .filterKeys(key => before.isEmpty || key.dataSetDate <= before.get)
       .filterKeys(key => tagValues.isEmpty || tagValues.get.toSet.subsetOf(key.tags.toSet))
@@ -129,7 +129,7 @@ class LimitedInMemoryMetricsRepositoryMultipleResultsLoader(
           .metricMap
           .filterKeys(analyzer => forAnalyzers.isEmpty || forAnalyzers.get.contains(analyzer))
 
-        AnalysisResult(analysisResult.resultKey, AnalyzerContext(requestedMetrics))
+        AnalysisResult(analysisResult.resultKey, AnalyzerContext(requestedMetrics.toMap))
       }
       .toSeq
   }

--- a/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunner.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunner.scala
@@ -132,7 +132,7 @@ class ConstraintSuggestionRunner {
         groupedSuggestionsWithColumnNames.map { case (_, suggestion) => suggestion } }
 
     ConstraintSuggestionResult(columnProfiles.profiles, columnProfiles.numRecords,
-      columnsWithSuggestions, verificationResult)
+      columnsWithSuggestions.toMap, verificationResult)
   }
 
   private[this] def splitTrainTestSets(

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
@@ -679,6 +679,13 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
   "Pattern compliance analyzer" should {
     val someColumnName = "some"
 
+    "PatternMatch hashCode should equal for the same pattern" in {
+      val p1 = PatternMatch("col1", "[a-z]".r)
+      val p2 = PatternMatch("col1", "[a-z]".r)
+      p1.hashCode() should equal(p2.hashCode())
+      p1 should equal(p2)
+    }
+
     "not match doubles in nullable column" in withSparkSession { sparkSession =>
 
        val df = dataFrameWithColumn(someColumnName, DoubleType, sparkSession, Row(1.1),


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/deequ/issues/380

*Description of changes:*
Support for Scala 2.13 and Spark 3.2

It is not fully done as I face two issues before I could even successfully compile. Here is the result of the output:

```
joesan@joesan-S-14-v5:~/Projects/Private/scala-projects/deequ$ mvn clean install
[INFO] Scanning for projects...
[INFO] 
[INFO] -----------------------< com.amazon.deequ:deequ >-----------------------
[INFO] Building deequ 2.0.0-spark-3.2
[INFO] --------------------------------[ jar ]---------------------------------
[INFO] 
[INFO] --- maven-clean-plugin:2.5:clean (default-clean) @ deequ ---
[INFO] Deleting /home/joesan/Projects/Private/scala-projects/deequ/target
[INFO] 
[INFO] --- maven-resources-plugin:2.7:resources (default-resources) @ deequ ---
[INFO] Using 'UTF-8' encoding to copy filtered resources.
[INFO] skip non existing resourceDirectory /home/joesan/Projects/Private/scala-projects/deequ/src/main/resources
[INFO] 
[INFO] --- scala-maven-plugin:4.5.6:add-source (scala-compile-first) @ deequ ---
[INFO] 
[INFO] --- scala-maven-plugin:4.5.6:compile (scala-compile-first) @ deequ ---
[INFO] Using incremental compilation using Mixed compile order
[INFO] Compiler bridge file: /home/joesan/.sbt/1.0/zinc/org.scala-sbt/org.scala-sbt-compiler-bridge_2.13-1.5.8-bin_2.13.0__52.0-1.5.8_20211211T222914.jar
[INFO] compiling 106 Scala sources and 1 Java source to /home/joesan/Projects/Private/scala-projects/deequ/target/classes ...
[ERROR] /home/joesan/Projects/Private/scala-projects/deequ/src/main/scala/com/amazon/deequ/analyzers/QuantileNonSample.scala:54: missing argument list for method apply in trait IterableFactory
Unapplied methods are only converted to functions when a function type is expected.
You can make this conversion explicit by writing `apply _` or `apply(_)` instead of `apply`.
[ERROR] one error found
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  11.392 s
[INFO] Finished at: 2021-12-20T07:12:16+01:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal net.alchim31.maven:scala-maven-plugin:4.5.6:compile (scala-compile-first) on project deequ: Execution scala-compile-first of goal net.alchim31.maven:scala-maven-plugin:4.5.6:compile failed: Compilation failed: InterfaceCompileFailed -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
