### PR TITLE
Adding chi-square distance method for categorical variables

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -95,6 +95,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-mllib_${scala.major.version}</artifactId>
+            <version>${spark.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.scalanlp</groupId>
             <artifactId>breeze_${scala.major.version}</artifactId>
             <version>0.13.2</version>

--- a/src/main/scala/com/amazon/deequ/analyzers/Distance.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Distance.scala
@@ -28,10 +28,15 @@ import org.apache.spark.mllib.stat.test.ChiSqTestResult
 
 object Distance {
 
-    // chi-square constants
+    // Chi-square constants
+    // at least two distinct categories are required to run the chi-square test for a categorical variable
     private val chisquareMinDimension: Int = 2
+
+    //for tables larger than 2 x 2: "No more than 20% of the expected counts are less than 5 and all individual expected counts are 1 or greater" (Yates, Moore & McCabe, 1999, The Practice of Statistics, p. 734)
     private val defaultAbsThresholdYates: Integer = 5
     private val defaultPercThresholdYates: Double = 0.2
+
+    // for 2x2 tables: all expected counts should be 10 or greater (Cochran, William G. "The χ2 test of goodness of fit." The Annals of mathematical statistics (1952): 315-345.)
     private val defaultAbsThresholdCochran: Integer = 10
 
     trait CategoricalDistanceMethod

--- a/src/main/scala/com/amazon/deequ/analyzers/Distance.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Distance.scala
@@ -15,6 +15,18 @@
  */
 
 package com.amazon.deequ.analyzers
+import com.amazon.deequ.analyzers.CategoricalDistanceMethod.{CategoricalDistanceMethod, Chisquare, LInfinity}
+import org.apache.spark.SparkContext
+import org.apache.spark.mllib.linalg._
+import org.apache.spark.mllib.regression.LabeledPoint
+import org.apache.spark.mllib.stat.Statistics
+import org.apache.spark.mllib.stat.Statistics._
+import org.apache.spark.mllib.stat.test.ChiSqTestResult
+
+object CategoricalDistanceMethod extends Enumeration {
+  type CategoricalDistanceMethod = Value
+  val LInfinity, Chisquare = Value
+}
 
 object Distance {
 
@@ -40,32 +52,198 @@ object Distance {
       selectMetrics(linfSimple, n, m, correctForLowNumberOfSamples)
     }
 
-    /** Calculate distance of categorical profiles based on L-Infinity Distance */
-    def categoricalDistance(
-      sample1: scala.collection.mutable.Map[String, Long],
-      sample2: scala.collection.mutable.Map[String, Long],
-      correctForLowNumberOfSamples: Boolean = false)
+  /** Calculate distance of categorical profiles based on different distance methods
+   *
+   * Thresholds for chi-square method:
+   *    - for 2x2 tables: all expected counts should be 10 or greater (Cochran 1952, 1954)
+   *    - for tables larger than 2 x 2: "No more than 20% of the expected counts are less than 5 and all individual expected counts are 1 or greater" (Yates, Moore & McCabe, 1999, p. 734)
+   *
+   * @param sample1                      the mapping between categories(keys) and counts(values) of the observed sample
+   * @param sample2                      the mapping between categories(keys) and counts(values) of the expected baseline
+   * @param correctForLowNumberOfSamples if true returns chi-square statistics otherwise p-value
+   * @param method                       Method to use: LInfinity or Chisquare
+   * @param absThresholdYates            Yates absolute threshold for tables larger than 2x2
+   * @param percThresholdYates           Yates percentage of categories that can be below threshold for tables larger than 2x2
+   * @param absThresholdCochran          Cochran absolute threshold for 2x2 tables
+   * @return distance                    can be an absolute distance or a p-value based on the correctForLowNumberOfSamples argument
+   */
+  def categoricalDistance(
+    sample1: scala.collection.mutable.Map[String, Long],
+    sample2: scala.collection.mutable.Map[String, Long],
+    correctForLowNumberOfSamples: Boolean = false,
+    method: CategoricalDistanceMethod = LInfinity,
+    absThresholdYates: Integer = 5,
+    percThresholdYates: Double = 0.2,
+    absThresholdCochran: Integer = 10)
     : Double = {
-
-      var n = 0.0
-      var m = 0.0
-      sample1.keySet.foreach { key =>
-        n += sample1(key)
-      }
-      sample2.keySet.foreach { key =>
-        m += sample2(key)
-      }
-      val combinedKeys = sample1.keySet.union(sample2.keySet)
-      var linfSimple = 0.0
-
-      combinedKeys.foreach { key =>
-        val cdf1 = sample1.getOrElse(key, 0L) / n
-        val cdf2 = sample2.getOrElse(key, 0L) / m
-        val cdfDiff = Math.abs(cdf1 - cdf2)
-        linfSimple = Math.max(linfSimple, cdfDiff)
-      }
-      selectMetrics(linfSimple, n, m, correctForLowNumberOfSamples)
+    method match {
+      case LInfinity => categoricalLInfinityDistance(sample1, sample2, correctForLowNumberOfSamples)
+      case Chisquare => categoricalChiSquareTest(sample1, sample2, correctForLowNumberOfSamples, absThresholdYates , percThresholdYates,absThresholdCochran )
     }
+  }
+
+  /** Calculate distance of categorical profiles based on Chisquare test or stats
+   *
+   *  for 2x2 tables: all expected counts should be 10 or greater (Cochran 1952, 1954)
+   *  for tables larger than 2 x 2: "No more than 20% of the expected counts are less than 5 and all individual expected counts are 1 or greater" (Yates, Moore & McCabe, 1999, p. 734)
+   *
+   *  @param sample                       the mapping between categories(keys) and counts(values) of the observed sample
+   *  @param expected                     the mapping between categories(keys) and counts(values) of the expected baseline
+   *  @param correctForLowNumberOfSamples if true returns chi-square statistics otherwise p-value
+   *  @param absThresholdYates            Yates absolute threshold for tables larger than 2x2
+   *  @param percThresholdYates           Yates percentage of categories that can be below threshold for tables larger than 2x2
+   *  @param absThresholdCochran          Cochran absolute threshold for 2x2 tables
+   *  @return distance                    can be an absolute distance or a p-value based on the correctForLowNumberOfSamples argument
+   *
+   */
+  private[this] def categoricalChiSquareTest(
+    sample: scala.collection.mutable.Map[String, Long],
+    expected: scala.collection.mutable.Map[String, Long],
+    correctForLowNumberOfSamples: Boolean = false,
+    absThresholdYates : Integer = 5 ,
+    percThresholdYates : Double = 0.2,
+    absThresholdCochran : Integer = 10)
+  : Double = {
+
+    val sample_sum: Double = sample.filter(e => expected.contains(e._1)).map((e => e._2)).sum
+    val expected_sum: Double = expected.map(e => e._2).sum
+
+    // Normalize the expected input
+    val expectedNorm: scala.collection.mutable.Map[String, Double] = expected.map(e => (e._1, (e._2 / expected_sum * sample_sum)))
+
+    // Call the function that regroups categories if necessary depending on thresholds
+    val (regrouped_sample, regrouped_expected) = regroupCategories(sample.map(e => (e._1, e._2.toDouble)), expectedNorm, absThresholdYates, percThresholdYates, absThresholdCochran)
+
+    // If less than 2 categories remain we cannot conduct the test
+    if (regrouped_sample.keySet.size < 2) {
+      Double.NaN
+    } else {
+      // run chi-square test and return statistics or p-value
+      val result = chiSquareTest(regrouped_sample, regrouped_expected)
+      if (correctForLowNumberOfSamples) {
+        result.statistic
+      } else {
+        result.pValue
+      }
+    }
+  }
+
+  /** Regroup categories with elements below threshold, required for chi-square test
+   *
+   * for 2x2 tables: all expected counts should be 10 or greater (Cochran 1952, 1954)
+   * for tables larger than 2 x 2: "No more than 20% of the expected counts are less than 5 and all individual expected counts are 1 or greater" (Yates, Moore & McCabe, 1999, p. 734)
+   *
+   * @param sample                       the mapping between categories(keys) and counts(values) of the observed sample
+   * @param expected                     the mapping between categories(keys) and counts(values) of the expected baseline
+   * @param absThresholdYates            Yates absolute threshold for tables larger than 2x2
+   * @param percThresholdYates           Yates percentage of categories that can be below threshold for tables larger than 2x2
+   * @param absThresholdCochran          Cochran absolute threshold for 2x2 tables
+   * @return (sample, expected)          returns the two regrouped mappings
+   *
+   */
+  private[this] def regroupCategories(
+    sample: scala.collection.mutable.Map[String, Double],
+    expected: scala.collection.mutable.Map[String, Double],
+    absThresholdYates: Integer = 5,
+    percThresholdYates: Double = 0.2,
+    absThresholdCochran: Integer = 10)
+    : (scala.collection.mutable.Map[String, Double], scala.collection.mutable.Map[String, Double]) = {
+
+    // If number of categories is below return original mappings
+    if (expected.keySet.size < 2) {
+      (sample, expected)
+    } else {
+      // Determine thresholds depending on dimensions of mapping (2x2 tables use Cohan, all other tables Yates thresholds)
+      var absThresholdPerColumn : Integer = absThresholdCochran
+      var maxNbColumnsBelowThreshold: Integer = 0
+      if (expected.keySet.size > 2) {
+        absThresholdPerColumn = absThresholdYates
+        maxNbColumnsBelowThreshold = (percThresholdYates * expected.keySet.size).toInt
+      }
+      // Count number of categories below threshold
+      val nbExpectedColumnsBelowThreshold = expected.filter(e => e._2 < absThresholdPerColumn).keySet.size
+
+      // If the number of categories below threshold exceeds the authorized maximum, small categories are regrouped until valid
+      if (nbExpectedColumnsBelowThreshold > maxNbColumnsBelowThreshold){
+
+        // Identified key that holds minimum value
+        val expectedMin: (String, Double) = expected.minBy(e => e._2)
+        val sampleMinValue : Double = sample.getOrElse(expectedMin._1, 0)
+
+        // Remove smallest category
+        expected.remove(expectedMin._1)
+        sample.remove(expectedMin._1)
+
+        // Add value of smallest category to second smallest category
+        val expectedSecondMin = expected.minBy(e => e._2)
+        val sampleSecondMinValue : Double = sample.getOrElse(expectedSecondMin._1, 0)
+
+        expected.update(expectedSecondMin._1, expectedSecondMin._2 + expectedMin._2 )
+        sample.update(expectedSecondMin._1, sampleMinValue + sampleSecondMinValue )
+
+        // Recursively call function until mappings are valid
+        regroupCategories(sample, expected, absThresholdYates, percThresholdYates, absThresholdCochran)
+      } else {
+        // In case the mappings are valid the original mappings are returned
+        (sample, expected)
+      }
+    }
+  }
+
+
+  /** Runs chi-square test on two mappings
+   *
+   * @param sample              the mapping between categories(keys) and counts(values) of the observed sample
+   * @param expected            the mapping between categories(keys) and counts(values) of the expected baseline
+   * @return ChiSqTestResult    returns the chi-square test result object (contains both statistics and p-value)
+   *
+   */
+  private[this] def chiSquareTest(
+                                   sample: scala.collection.mutable.Map[String, Double],
+                                   expected: scala.collection.mutable.Map[String, Double])
+  : ChiSqTestResult = {
+
+    var sample_array = Array[Double]()
+    var expected_array = Array[Double]()
+
+    expected.keySet.foreach { key =>
+      val cdf1: Double = sample.getOrElse(key, 0.0)
+      val cdf2: Double = expected(key)
+      sample_array = sample_array :+ cdf1
+      expected_array = expected_array :+ cdf2
+    }
+
+    val vec_sample: Vector = Vectors.dense(sample_array)
+    val vec_expected: Vector = Vectors.dense(expected_array)
+
+    Statistics.chiSqTest(vec_sample, vec_expected)
+  }
+
+  /** Calculate distance of categorical profiles based on L-Infinity Distance */
+  private[this] def categoricalLInfinityDistance(
+    sample1: scala.collection.mutable.Map[String, Long],
+    sample2: scala.collection.mutable.Map[String, Long],
+    correctForLowNumberOfSamples: Boolean = false)
+  : Double = {
+    var n = 0.0
+    var m = 0.0
+    sample1.keySet.foreach { key =>
+      n += sample1(key)
+    }
+    sample2.keySet.foreach { key =>
+      m += sample2(key)
+    }
+    val combinedKeys = sample1.keySet.union(sample2.keySet)
+    var linfSimple = 0.0
+
+    combinedKeys.foreach { key =>
+      val cdf1 = sample1.getOrElse(key, 0L) / n
+      val cdf2 = sample2.getOrElse(key, 0L) / m
+      val cdfDiff = Math.abs(cdf1 - cdf2)
+      linfSimple = Math.max(linfSimple, cdfDiff)
+    }
+    selectMetrics(linfSimple, n, m, correctForLowNumberOfSamples)
+  }
 
   /** Select which metrics to compute (linf_simple or linf_robust)
    *  based on whether samples are enough */

--- a/src/main/scala/com/amazon/deequ/analyzers/Distance.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Distance.scala
@@ -55,8 +55,8 @@ object Distance {
   /** Calculate distance of categorical profiles based on different distance methods
    *
    * Thresholds for chi-square method:
-   *    - for 2x2 tables: all expected counts should be 10 or greater (Cochran 1952, 1954)
-   *    - for tables larger than 2 x 2: "No more than 20% of the expected counts are less than 5 and all individual expected counts are 1 or greater" (Yates, Moore & McCabe, 1999, p. 734)
+   *    - for 2x2 tables: all expected counts should be 10 or greater (Cochran, William G. "The χ2 test of goodness of fit." The Annals of mathematical statistics (1952): 315-345.)
+   *    - for tables larger than 2 x 2: "No more than 20% of the expected counts are less than 5 and all individual expected counts are 1 or greater" (Yates, Moore & McCabe, 1999, The Practice of Statistics, p. 734)
    *
    * @param sample1                      the mapping between categories(keys) and counts(values) of the observed sample
    * @param sample2                      the mapping between categories(keys) and counts(values) of the expected baseline
@@ -84,8 +84,8 @@ object Distance {
 
   /** Calculate distance of categorical profiles based on Chisquare test or stats
    *
-   *  for 2x2 tables: all expected counts should be 10 or greater (Cochran 1952, 1954)
-   *  for tables larger than 2 x 2: "No more than 20% of the expected counts are less than 5 and all individual expected counts are 1 or greater" (Yates, Moore & McCabe, 1999, p. 734)
+   *  for 2x2 tables: all expected counts should be 10 or greater (Cochran, William G. "The χ2 test of goodness of fit." The Annals of mathematical statistics (1952): 315-345.)
+   *  for tables larger than 2 x 2: "No more than 20% of the expected counts are less than 5 and all individual expected counts are 1 or greater" (Yates, Moore & McCabe, 1999, The Practice of Statistics, p. 734)
    *
    *  @param sample                       the mapping between categories(keys) and counts(values) of the observed sample
    *  @param expected                     the mapping between categories(keys) and counts(values) of the expected baseline
@@ -130,8 +130,8 @@ object Distance {
 
   /** Regroup categories with elements below threshold, required for chi-square test
    *
-   * for 2x2 tables: all expected counts should be 10 or greater (Cochran 1952, 1954)
-   * for tables larger than 2 x 2: "No more than 20% of the expected counts are less than 5 and all individual expected counts are 1 or greater" (Yates, Moore & McCabe, 1999, p. 734)
+   * for 2x2 tables: all expected counts should be 10 or greater (Cochran, William G. "The χ2 test of goodness of fit." The Annals of mathematical statistics (1952): 315-345.)
+   * for tables larger than 2 x 2: "No more than 20% of the expected counts are less than 5 and all individual expected counts are 1 or greater" (Yates, Moore & McCabe, 1999, The Practice of Statistics, p. 734)
    *
    * @param sample                       the mapping between categories(keys) and counts(values) of the observed sample
    * @param expected                     the mapping between categories(keys) and counts(values) of the expected baseline
@@ -153,7 +153,7 @@ object Distance {
     if (expected.keySet.size < 2) {
       (sample, expected)
     } else {
-      // Determine thresholds depending on dimensions of mapping (2x2 tables use Cohan, all other tables Yates thresholds)
+      // Determine thresholds depending on dimensions of mapping (2x2 tables use Cochran, all other tables Yates thresholds)
       var absThresholdPerColumn : Integer = absThresholdCochran
       var maxNbColumnsBelowThreshold: Integer = 0
       if (expected.keySet.size > 2) {

--- a/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
+++ b/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
@@ -17,6 +17,7 @@
 package com.amazon.deequ.KLL
 
 import com.amazon.deequ.SparkContextSpec
+import com.amazon.deequ.analyzers.CategoricalDistanceMethod.Chisquare
 import com.amazon.deequ.analyzers.{Distance, QuantileNonSample}
 import com.amazon.deequ.utils.FixtureSupport
 import org.scalatest.{Matchers, WordSpec}
@@ -73,4 +74,76 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
       "f" -> 11L, "a" -> 20L, "c" -> 25L, "d" -> 10L, "e" -> 10L)
     assert(Distance.categoricalDistance(sample1, sample2) == 0.0)
   }
+
+
+  // Tests using chi-square method for categorical variables
+
+  "Categorial distance should compute correct chisquare stats with missing bin values" in {
+    val sample1 = scala.collection.mutable.Map(
+      "a" -> 207L, "b" -> 20L, "c" -> 25L, "d" -> 14L, "e" -> 25L, "g" -> 13L)
+    val sample2 = scala.collection.mutable.Map(
+      "a" -> 223L, "b" -> 20L, "c" -> 25L, "d" -> 12L, "e" -> 13L, "f" -> 15L)
+
+    assert(Distance.categoricalDistance(sample1, sample2, correctForLowNumberOfSamples = true, method = Chisquare) == 28.175042782458068)
+  }
+
+
+
+  "Categorial distance should compute correct chisquare test with missing bin values" in {
+    val sample1 = scala.collection.mutable.Map(
+      "a" -> 207L, "b" -> 20L, "c" -> 25L, "d" -> 14L, "e" -> 25L, "g" -> 13L)
+    val sample2 = scala.collection.mutable.Map(
+      "a" -> 223L, "b" -> 20L, "c" -> 25L, "d" -> 12L, "e" -> 13L, "f" -> 15L)
+    assert(Distance.categoricalDistance(sample1, sample2, method = Chisquare) ==  3.3640191298478506E-5)
+  }
+
+
+  "Categorial distance should compute correct chisquare test" in {
+    val sample1 = scala.collection.mutable.Map(
+      "a" -> 207L, "b" -> 20L, "c" -> 25L, "d" -> 14L, "e" -> 25L)
+    val sample2 = scala.collection.mutable.Map(
+      "a" -> 223L, "b" -> 20L, "c" -> 25L, "d" -> 12L, "e" -> 13L)
+    assert(Distance.categoricalDistance(sample1, sample2, method = Chisquare) == 0.013227994814265176)
+  }
+
+  "Categorial distance should compute correct chisquare distance with regrouping 2 categories (yates) after normalizing" in {
+    val sample1 = scala.collection.mutable.Map(
+      "a" -> 100L, "b" -> 20L, "c" -> 25L, "d" -> 10L, "e" -> 5L, "f" -> 2L)
+    val sample2 = scala.collection.mutable.Map(
+      "a" -> 100L, "b" -> 22L, "c" -> 25L, "d" -> 5L, "e" -> 13L, "f" -> 2L)
+    assert(Distance.categoricalDistance(sample1, sample2, correctForLowNumberOfSamples = true, method = Chisquare) == 8.789790456457125)
+  }
+
+  "Categorial distance should compute correct chisquare distance with regrouping (yates)" in {
+    val baseline = scala.collection.mutable.Map(
+      "a" -> 100L, "b" -> 40L, "c" -> 30L,"e" -> 4L)
+    val sample = scala.collection.mutable.Map(
+      "a" -> 100L, "b" -> 40L, "c" -> 30L,"d" -> 10L)
+    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = Chisquare) == 0.38754325259515626)
+  }
+
+  "Categorial distance should compute correct chisquare distance with regrouping 2 categories (yates)" in {
+    val baseline = scala.collection.mutable.Map(
+      "a" -> 100L, "b" -> 4L, "c" -> 3L, "d" -> 34L)
+    val sample = scala.collection.mutable.Map(
+      "a" -> 100L, "b" -> 4L, "c" -> 3L, "d" -> 27L)
+    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = Chisquare) == 1.1507901668129925)
+  }
+
+  "Categorial distance should compute correct chisquare distance with regrouping ( sum of 2 grouped categories is below threshold, but small categories represent less than 20%)  (yates)" in {
+    val baseline = scala.collection.mutable.Map(
+      "a" -> 100L, "b" -> 2L, "c" -> 1L, "d" -> 34L,"e" -> 20L,"f" -> 20L,"g" -> 20L,"h" -> 20L)
+    val sample = scala.collection.mutable.Map(
+      "a" -> 100L, "b" -> 4L, "c" -> 3L, "d" -> 27L,"e" -> 20L,"f" -> 20L,"g" -> 20L,"h" -> 20L)
+    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = Chisquare) == 6.827423492761593)
+  }
+
+  "Categorial distance should compute correct chisquare distance with regrouping ( dimensions after regrouping are too small)" in {
+    val baseline = scala.collection.mutable.Map(
+      "a" -> 100L, "b" -> 4L, "c" -> 3L)
+    val sample = scala.collection.mutable.Map(
+      "a" -> 100L, "b" -> 4L, "c" -> 3L)
+    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = Chisquare).isNaN)
+  }
+
 }

--- a/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
+++ b/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
@@ -17,7 +17,7 @@
 package com.amazon.deequ.KLL
 
 import com.amazon.deequ.SparkContextSpec
-import com.amazon.deequ.analyzers.Distance.Chisquare
+import com.amazon.deequ.analyzers.Distance.{ChisquareMethod, LInfinityMethod}
 import com.amazon.deequ.analyzers.{Distance, QuantileNonSample}
 import com.amazon.deequ.utils.FixtureSupport
 import org.scalatest.{Matchers, WordSpec}
@@ -76,74 +76,90 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
   }
 
 
+  "Categorial distance should compute correct linf_robust with different alpha value .003" in {
+    val sample1 = scala.collection.mutable.Map(
+      "a" -> 207L, "b" -> 20L, "c" -> 25L, "d" -> 14L, "e" -> 25L, "g" -> 13L)
+    val sample2 = scala.collection.mutable.Map(
+      "a" -> 22L, "b" -> 20L, "c" -> 25L, "d" -> 12L, "e" -> 13L, "f" -> 15L)
+    assert(Distance.categoricalDistance(sample1, sample2,  method = LInfinityMethod(alpha = Some(0.003))) == 0.2726338046550349)
+  }
+
+  "Categorial distance should compute correct linf_robust with different alpha value .1" in {
+    val sample1 = scala.collection.mutable.Map(
+      "a" -> 207L, "b" -> 20L, "c" -> 25L, "d" -> 14L, "e" -> 25L, "g" -> 13L)
+    val sample2 = scala.collection.mutable.Map(
+      "a" -> 22L, "b" -> 20L, "c" -> 25L, "d" -> 12L, "e" -> 13L, "f" -> 15L)
+    assert(Distance.categoricalDistance(sample1, sample2, method = LInfinityMethod(alpha = Some(0.1))) == 0.33774199396969184)
+  }
+
+
   // Tests using chi-square method for categorical variables
-
-  "Categorial distance should compute correct chisquare stats with missing bin values" in {
+  "Categorical distance should compute correct chisquare stats with missing bin values" in {
     val sample1 = scala.collection.mutable.Map(
       "a" -> 207L, "b" -> 20L, "c" -> 25L, "d" -> 14L, "e" -> 25L, "g" -> 13L)
     val sample2 = scala.collection.mutable.Map(
       "a" -> 223L, "b" -> 20L, "c" -> 25L, "d" -> 12L, "e" -> 13L, "f" -> 15L)
 
-    assert(Distance.categoricalDistance(sample1, sample2, correctForLowNumberOfSamples = true, method = Chisquare()) == 28.175042782458068)
+    assert(Distance.categoricalDistance(sample1, sample2, correctForLowNumberOfSamples = true, method = ChisquareMethod()) == 28.175042782458068)
   }
 
 
 
-  "Categorial distance should compute correct chisquare test with missing bin values" in {
+  "Categorical distance should compute correct chisquare test with missing bin values" in {
     val sample1 = scala.collection.mutable.Map(
       "a" -> 207L, "b" -> 20L, "c" -> 25L, "d" -> 14L, "e" -> 25L, "g" -> 13L)
     val sample2 = scala.collection.mutable.Map(
       "a" -> 223L, "b" -> 20L, "c" -> 25L, "d" -> 12L, "e" -> 13L, "f" -> 15L)
-    assert(Distance.categoricalDistance(sample1, sample2, method = Chisquare()) ==  3.3640191298478506E-5)
+    assert(Distance.categoricalDistance(sample1, sample2, method = ChisquareMethod()) ==  3.3640191298478506E-5)
   }
 
 
-  "Categorial distance should compute correct chisquare test" in {
+  "Categorical distance should compute correct chisquare test" in {
     val sample1 = scala.collection.mutable.Map(
       "a" -> 207L, "b" -> 20L, "c" -> 25L, "d" -> 14L, "e" -> 25L)
     val sample2 = scala.collection.mutable.Map(
       "a" -> 223L, "b" -> 20L, "c" -> 25L, "d" -> 12L, "e" -> 13L)
-    assert(Distance.categoricalDistance(sample1, sample2, method = Chisquare()) == 0.013227994814265176)
+    assert(Distance.categoricalDistance(sample1, sample2, method = ChisquareMethod()) == 0.013227994814265176)
   }
 
-  "Categorial distance should compute correct chisquare distance with regrouping 2 categories (yates) after normalizing" in {
+  "Categorical distance should compute correct chisquare distance (low samples) with regrouping 2 categories (yates) after normalizing" in {
     val sample1 = scala.collection.mutable.Map(
       "a" -> 100L, "b" -> 20L, "c" -> 25L, "d" -> 10L, "e" -> 5L, "f" -> 2L)
     val sample2 = scala.collection.mutable.Map(
       "a" -> 100L, "b" -> 22L, "c" -> 25L, "d" -> 5L, "e" -> 13L, "f" -> 2L)
-    assert(Distance.categoricalDistance(sample1, sample2, correctForLowNumberOfSamples = true, method = Chisquare()) == 8.789790456457125)
+    assert(Distance.categoricalDistance(sample1, sample2, correctForLowNumberOfSamples = true, method = ChisquareMethod()) == 8.789790456457125)
   }
 
-  "Categorial distance should compute correct chisquare distance with regrouping (yates)" in {
+  "Categorical distance should compute correct chisquare distance (low samples) with regrouping (yates)" in {
     val baseline = scala.collection.mutable.Map(
       "a" -> 100L, "b" -> 40L, "c" -> 30L,"e" -> 4L)
     val sample = scala.collection.mutable.Map(
       "a" -> 100L, "b" -> 40L, "c" -> 30L,"d" -> 10L)
-    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = Chisquare()) == 0.38754325259515626)
+    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = ChisquareMethod()) == 0.38754325259515626)
   }
 
-  "Categorial distance should compute correct chisquare distance with regrouping 2 categories (yates)" in {
+  "Categorical distance should compute correct chisquare distance (low samples) with regrouping 2 categories (yates)" in {
     val baseline = scala.collection.mutable.Map(
       "a" -> 100L, "b" -> 4L, "c" -> 3L, "d" -> 34L)
     val sample = scala.collection.mutable.Map(
       "a" -> 100L, "b" -> 4L, "c" -> 3L, "d" -> 27L)
-    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = Chisquare()) == 1.1507901668129925)
+    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = ChisquareMethod()) == 1.1507901668129925)
   }
 
-  "Categorial distance should compute correct chisquare distance with regrouping ( sum of 2 grouped categories is below threshold, but small categories represent less than 20%)  (yates)" in {
+  "Categorical distance should compute correct chisquare distance (low samples) with regrouping ( sum of 2 grouped categories is below threshold, but small categories represent less than 20%)  (yates)" in {
     val baseline = scala.collection.mutable.Map(
       "a" -> 100L, "b" -> 2L, "c" -> 1L, "d" -> 34L,"e" -> 20L,"f" -> 20L,"g" -> 20L,"h" -> 20L)
     val sample = scala.collection.mutable.Map(
       "a" -> 100L, "b" -> 4L, "c" -> 3L, "d" -> 27L,"e" -> 20L,"f" -> 20L,"g" -> 20L,"h" -> 20L)
-    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = Chisquare()) == 6.827423492761593)
+    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = ChisquareMethod()) == 6.827423492761593)
   }
 
-  "Categorial distance should compute correct chisquare distance with regrouping ( dimensions after regrouping are too small)" in {
+  "Categorical distance should compute correct chisquare distance (low samples) with regrouping ( dimensions after regrouping are too small)" in {
     val baseline = scala.collection.mutable.Map(
       "a" -> 100L, "b" -> 4L, "c" -> 3L)
     val sample = scala.collection.mutable.Map(
       "a" -> 100L, "b" -> 4L, "c" -> 3L)
-    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = Chisquare()).isNaN)
+    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = ChisquareMethod()).isNaN)
   }
 
 }

--- a/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
+++ b/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
@@ -17,7 +17,7 @@
 package com.amazon.deequ.KLL
 
 import com.amazon.deequ.SparkContextSpec
-import com.amazon.deequ.analyzers.CategoricalDistanceMethod.Chisquare
+import com.amazon.deequ.analyzers.Distance.Chisquare
 import com.amazon.deequ.analyzers.{Distance, QuantileNonSample}
 import com.amazon.deequ.utils.FixtureSupport
 import org.scalatest.{Matchers, WordSpec}
@@ -84,7 +84,7 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
     val sample2 = scala.collection.mutable.Map(
       "a" -> 223L, "b" -> 20L, "c" -> 25L, "d" -> 12L, "e" -> 13L, "f" -> 15L)
 
-    assert(Distance.categoricalDistance(sample1, sample2, correctForLowNumberOfSamples = true, method = Chisquare) == 28.175042782458068)
+    assert(Distance.categoricalDistance(sample1, sample2, correctForLowNumberOfSamples = true, method = Chisquare()) == 28.175042782458068)
   }
 
 
@@ -94,7 +94,7 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
       "a" -> 207L, "b" -> 20L, "c" -> 25L, "d" -> 14L, "e" -> 25L, "g" -> 13L)
     val sample2 = scala.collection.mutable.Map(
       "a" -> 223L, "b" -> 20L, "c" -> 25L, "d" -> 12L, "e" -> 13L, "f" -> 15L)
-    assert(Distance.categoricalDistance(sample1, sample2, method = Chisquare) ==  3.3640191298478506E-5)
+    assert(Distance.categoricalDistance(sample1, sample2, method = Chisquare()) ==  3.3640191298478506E-5)
   }
 
 
@@ -103,7 +103,7 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
       "a" -> 207L, "b" -> 20L, "c" -> 25L, "d" -> 14L, "e" -> 25L)
     val sample2 = scala.collection.mutable.Map(
       "a" -> 223L, "b" -> 20L, "c" -> 25L, "d" -> 12L, "e" -> 13L)
-    assert(Distance.categoricalDistance(sample1, sample2, method = Chisquare) == 0.013227994814265176)
+    assert(Distance.categoricalDistance(sample1, sample2, method = Chisquare()) == 0.013227994814265176)
   }
 
   "Categorial distance should compute correct chisquare distance with regrouping 2 categories (yates) after normalizing" in {
@@ -111,7 +111,7 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
       "a" -> 100L, "b" -> 20L, "c" -> 25L, "d" -> 10L, "e" -> 5L, "f" -> 2L)
     val sample2 = scala.collection.mutable.Map(
       "a" -> 100L, "b" -> 22L, "c" -> 25L, "d" -> 5L, "e" -> 13L, "f" -> 2L)
-    assert(Distance.categoricalDistance(sample1, sample2, correctForLowNumberOfSamples = true, method = Chisquare) == 8.789790456457125)
+    assert(Distance.categoricalDistance(sample1, sample2, correctForLowNumberOfSamples = true, method = Chisquare()) == 8.789790456457125)
   }
 
   "Categorial distance should compute correct chisquare distance with regrouping (yates)" in {
@@ -119,7 +119,7 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
       "a" -> 100L, "b" -> 40L, "c" -> 30L,"e" -> 4L)
     val sample = scala.collection.mutable.Map(
       "a" -> 100L, "b" -> 40L, "c" -> 30L,"d" -> 10L)
-    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = Chisquare) == 0.38754325259515626)
+    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = Chisquare()) == 0.38754325259515626)
   }
 
   "Categorial distance should compute correct chisquare distance with regrouping 2 categories (yates)" in {
@@ -127,7 +127,7 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
       "a" -> 100L, "b" -> 4L, "c" -> 3L, "d" -> 34L)
     val sample = scala.collection.mutable.Map(
       "a" -> 100L, "b" -> 4L, "c" -> 3L, "d" -> 27L)
-    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = Chisquare) == 1.1507901668129925)
+    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = Chisquare()) == 1.1507901668129925)
   }
 
   "Categorial distance should compute correct chisquare distance with regrouping ( sum of 2 grouped categories is below threshold, but small categories represent less than 20%)  (yates)" in {
@@ -135,7 +135,7 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
       "a" -> 100L, "b" -> 2L, "c" -> 1L, "d" -> 34L,"e" -> 20L,"f" -> 20L,"g" -> 20L,"h" -> 20L)
     val sample = scala.collection.mutable.Map(
       "a" -> 100L, "b" -> 4L, "c" -> 3L, "d" -> 27L,"e" -> 20L,"f" -> 20L,"g" -> 20L,"h" -> 20L)
-    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = Chisquare) == 6.827423492761593)
+    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = Chisquare()) == 6.827423492761593)
   }
 
   "Categorial distance should compute correct chisquare distance with regrouping ( dimensions after regrouping are too small)" in {
@@ -143,7 +143,7 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
       "a" -> 100L, "b" -> 4L, "c" -> 3L)
     val sample = scala.collection.mutable.Map(
       "a" -> 100L, "b" -> 4L, "c" -> 3L)
-    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = Chisquare).isNaN)
+    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = Chisquare()).isNaN)
   }
 
 }


### PR DESCRIPTION
*Description of changes:*

The distance method used in `src/main/scala/com/amazon/deequ/analyzers/Distance.scala` applies the Kolmogorov–Smirnov(KS) test to numerical and categorical variables. As the KS test is mostly [suited](https://www.ncbi.nlm.nih.gov/pmc/articles/PMC2996580/) for numerical variables this PR adds the chi-square test method that can be optionally used with categorical variables. The function signature of `categoricalDistance`  remains unchanged and still applies the KS test as default method.

Modified files:
`src/main/scala/com/amazon/deequ/analyzers/Distance.scala` : added chi-square method
`src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala` : added tests for chi-square method
`pom.xml` : added dependency to spark-mllib


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
