### PR TITLE
Feature: Row Level Results

### DIFF
--- a/deequ-scalastyle.xml
+++ b/deequ-scalastyle.xml
@@ -16,7 +16,7 @@
 
     <check level="error" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
         <parameters>
-            <parameter name="maxLineLength"><![CDATA[100]]></parameter>
+            <parameter name="maxLineLength"><![CDATA[120]]></parameter>
             <parameter name="tabSize"><![CDATA[2]]></parameter>
             <parameter name="ignoreImports">true</parameter>
         </parameters>

--- a/src/main/scala/com/amazon/deequ/VerificationResult.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationResult.scala
@@ -20,7 +20,9 @@ import com.amazon.deequ.analyzers.Analyzer
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
 import com.amazon.deequ.checks.{Check, CheckResult, CheckStatus}
 import com.amazon.deequ.constraints.AnalysisBasedConstraint
+import com.amazon.deequ.constraints.ConstraintResult
 import com.amazon.deequ.constraints.NamedConstraint
+import com.amazon.deequ.constraints.RowLevelAssertedConstraint
 import com.amazon.deequ.constraints.RowLevelConstraint
 import com.amazon.deequ.metrics.FullColumn
 import com.amazon.deequ.metrics.Metric
@@ -120,11 +122,24 @@ object VerificationResult {
   }
 
   private def columnForCheckResult(check: Check, checkResult: CheckResult): Option[(String, Column)] = {
-    val metrics: Seq[Column] = checkResult.constraintResults.flatMap(_.metric).flatMap(metricToColumn)
+    // Convert non-boolean columns to boolean by using the assertion
+
+    val metrics: Seq[Column] = checkResult.constraintResults.flatMap(constraintResultToColumn)
     if (metrics.isEmpty) {
       None
     } else {
       Some(check.description, metrics.reduce(_ and _))
+    }
+  }
+
+  private def constraintResultToColumn(constraintResult: ConstraintResult): Option[Column] = {
+    val constraint = constraintResult.constraint
+    constraint match {
+      case asserted: RowLevelAssertedConstraint =>
+        constraintResult.metric.flatMap(metricToColumn).map(asserted.assertion(_))
+      case _: RowLevelConstraint =>
+        constraintResult.metric.flatMap(metricToColumn)
+      case _ => None
     }
   }
 

--- a/src/main/scala/com/amazon/deequ/VerificationResult.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationResult.scala
@@ -83,7 +83,7 @@ object VerificationResult {
    *
    * Accepts a naming rule
    */
-  def toRowLevelResults(
+  def rowLevelResultsAsDataFrame(
       sparkSession: SparkSession,
       verificationResult: VerificationResult,
       data: DataFrame): DataFrame = {

--- a/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
@@ -246,9 +246,6 @@ case class NumMatchesAndCount(numMatches: Long, count: Long, override val fullCo
       numMatches.toDouble / count
     }
   }
-
-  private def sum(colA: Option[Column], colB: Option[Column]): Option[Column] =
-    if (colA.equals(colB)) colA else None
 }
 
 /** Base class for analyzers that compute ratios of matching predicates */

--- a/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
@@ -54,7 +54,7 @@ trait DoubleValuedState[S <: DoubleValuedState[S]] extends State[S] {
 }
 
 /** Common trait for all analyzers which generates metrics from states computed on data frames */
-trait Analyzer[S <: State[_], +M <: Metric[_]] {
+trait Analyzer[S <: State[_], +M <: Metric[_]] extends Serializable {
 
   /**
     * Compute the state (sufficient statistics) from the data

--- a/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
@@ -206,13 +206,12 @@ abstract class StandardScanShareableAnalyzer[S <: DoubleValuedState[_]](
 
   override def computeMetricFrom(state: Option[S]): DoubleMetric = {
     state match {
-      case Some(theState) => {
+      case Some(theState) =>
         val col = theState match {
           case withColumn: FullColumn => withColumn.fullColumn
           case _ => None
         }
         metricFromValue(theState.metricValue(), name, instance, entity, col)
-      }
       case _ =>
         metricFromEmpty(this, name, instance, entity)
     }

--- a/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
@@ -236,7 +236,7 @@ case class NumMatchesAndCount(numMatches: Long, count: Long, override val fullCo
   extends DoubleValuedState[NumMatchesAndCount] with FullColumn {
 
   override def sum(other: NumMatchesAndCount): NumMatchesAndCount = {
-    NumMatchesAndCount(numMatches + other.numMatches, count + other.count)
+    NumMatchesAndCount(numMatches + other.numMatches, count + other.count, sum(fullColumn, other.fullColumn))
   }
 
   override def metricValue(): Double = {
@@ -246,6 +246,9 @@ case class NumMatchesAndCount(numMatches: Long, count: Long, override val fullCo
       numMatches.toDouble / count
     }
   }
+
+  private def sum(colA: Option[Column], colB: Option[Column]): Option[Column] =
+    if (colA.equals(colB)) colA else None
 }
 
 /** Base class for analyzers that compute ratios of matching predicates */

--- a/src/main/scala/com/amazon/deequ/analyzers/Completeness.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Completeness.scala
@@ -31,7 +31,8 @@ case class Completeness(column: String, where: Option[String] = None) extends
   override def fromAggregationResult(result: Row, offset: Int): Option[NumMatchesAndCount] = {
 
     ifNoNullsIn(result, offset, howMany = 2) { _ =>
-      NumMatchesAndCount(result.getLong(offset), result.getLong(offset + 1), Some(criterion)) // TODO: optimize to not re-compute
+      // TODO: optimize to not re-compute
+      NumMatchesAndCount(result.getLong(offset), result.getLong(offset + 1), Some(criterion))
     }
   }
 

--- a/src/main/scala/com/amazon/deequ/analyzers/Completeness.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Completeness.scala
@@ -31,7 +31,6 @@ case class Completeness(column: String, where: Option[String] = None) extends
   override def fromAggregationResult(result: Row, offset: Int): Option[NumMatchesAndCount] = {
 
     ifNoNullsIn(result, offset, howMany = 2) { _ =>
-      // TODO: optimize to not re-compute
       NumMatchesAndCount(result.getLong(offset), result.getLong(offset + 1), Some(criterion))
     }
   }

--- a/src/main/scala/com/amazon/deequ/analyzers/Completeness.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Completeness.scala
@@ -20,6 +20,7 @@ import com.amazon.deequ.analyzers.Preconditions.{hasColumn, isNotNested}
 import org.apache.spark.sql.functions.sum
 import org.apache.spark.sql.types.{IntegerType, StructType}
 import Analyzers._
+import com.google.common.annotations.VisibleForTesting
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.{Column, Row}
 
@@ -48,5 +49,6 @@ case class Completeness(column: String, where: Option[String] = None) extends
 
   override def filterCondition: Option[String] = where
 
-  def criterion: Column = conditionalSelection(column, where).isNotNull
+  @VisibleForTesting // required by some tests that compare analyzer results to an expected state
+  private[deequ] def criterion: Column = conditionalSelection(column, where).isNotNull
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/MaxLength.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/MaxLength.scala
@@ -27,12 +27,12 @@ case class MaxLength(column: String, where: Option[String] = None)
   with FilterableAnalyzer {
 
   override def aggregationFunctions(): Seq[Column] = {
-    max(length(conditionalSelection(column, where))).cast(DoubleType) :: Nil
+    max(criterion) :: Nil
   }
 
   override def fromAggregationResult(result: Row, offset: Int): Option[MaxState] = {
     ifNoNullsIn(result, offset) { _ =>
-      MaxState(result.getDouble(offset))
+      MaxState(result.getDouble(offset), Some(criterion))
     }
   }
 
@@ -41,4 +41,6 @@ case class MaxLength(column: String, where: Option[String] = None)
   }
 
   override def filterCondition: Option[String] = where
+
+  private def criterion: Column = length(conditionalSelection(column, where)).cast(DoubleType)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Maximum.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Maximum.scala
@@ -21,11 +21,13 @@ import org.apache.spark.sql.{Column, Row}
 import org.apache.spark.sql.functions.max
 import org.apache.spark.sql.types.{DoubleType, StructType}
 import Analyzers._
+import com.amazon.deequ.metrics.FullColumn
 
-case class MaxState(maxValue: Double) extends DoubleValuedState[MaxState] {
+case class MaxState(maxValue: Double, override val fullColumn: Option[Column] = None)
+  extends DoubleValuedState[MaxState] with FullColumn {
 
   override def sum(other: MaxState): MaxState = {
-    MaxState(math.max(maxValue, other.maxValue))
+    MaxState(math.max(maxValue, other.maxValue), sum(fullColumn, other.fullColumn))
   }
 
   override def metricValue(): Double = {

--- a/src/main/scala/com/amazon/deequ/analyzers/catalyst/DeequFunctions.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/catalyst/DeequFunctions.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql
 
 
-import com.amazon.deequ.analyzers.KLLSketch
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateFunction, StatefulApproxQuantile, StatefulHyperloglogPlus}
 import org.apache.spark.sql.catalyst.expressions.Literal
 

--- a/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
@@ -79,7 +79,7 @@ object AnalysisRunner {
   }
 
   /**
-    * Compute the metrics from the analyzers configured in the analyis
+    * Compute the metrics from the analyzers configured in the analysis
     *
     * @param data data on which to operate
     * @param analyzers the analyzers to run
@@ -169,7 +169,7 @@ object AnalysisRunner {
     // TODO this can be further improved, we can get the number of rows from other metrics as well
     // TODO we could also insert an extra Size() computation if we have to scan the data anyways
     var numRowsOfData = nonGroupedMetrics.metric(Size()).collect {
-      case DoubleMetric(_, _, _, Success(value: Double)) => value.toLong
+      case DoubleMetric(_, _, _, Success(value: Double), None) => value.toLong
     }
 
     var groupedMetrics = AnalyzerContext.empty

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -65,7 +65,7 @@ case class Check(
 
   /**
    * Returns the name of the columns where each Constraint puts row-level results, if any
-   * 
+   *
    */
   def getRowLevelConstraintColumnNames(): Seq[String] = {
     constraints.flatMap(c => {

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -63,6 +63,18 @@ case class Check(
   description: String,
   private[deequ] val constraints: Seq[Constraint] = Seq.empty) {
 
+  /**
+   * Returns the name of the columns where each Constraint puts row-level results, if any
+   * 
+   */
+  def getRowLevelConstraintColumnNames(): Seq[String] = {
+    constraints.flatMap(c => {
+      c match {
+        case c: RowLevelConstraint => Some(c.getColumnName)
+        case _ => None
+      }
+    })
+  }
 
   /**
     * Returns a new Check object with the given constraint added to the constraints list.

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -438,7 +438,7 @@ object Constraint {
     new RowLevelAssertedConstraint(
       constraint,
       s"MaxLengthConstraint($maxLength)",
-      s"StringLength-$column",
+      s"ColumnLength-$column",
       sparkAssertion)
   }
 

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -426,7 +426,7 @@ object Constraint {
     val constraint = AnalysisBasedConstraint[MaxState, Double, Double](maxLength, assertion,
       hint = hint)
 
-    new NamedConstraint(constraint, s"MaxLengthConstraint($maxLength)")
+    new RowLevelConstraint(constraint, s"MaxLengthConstraint($maxLength)", s"StringLength-$column")
   }
 
   /**

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -33,7 +33,7 @@ case class ConstraintResult(
     metric: Option[Metric[_]] = None)
 
 /** Common trait for all data quality constraints */
-trait Constraint {
+trait Constraint extends Serializable {
   def evaluate(analysisResults: Map[Analyzer[_, Metric[_]], Metric[_]]): ConstraintResult
 }
 
@@ -77,7 +77,7 @@ class NamedConstraint(private[deequ] val constraint: Constraint, name: String)
  */
 class RowLevelConstraint(private[deequ] override val constraint: Constraint, name: String, columnName: String)
   extends NamedConstraint(constraint, name) {
-  def getColumnName: String = columnName
+  val getColumnName: String = columnName
 }
 
 /**

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -69,6 +69,18 @@ class NamedConstraint(private[deequ] val constraint: Constraint, name: String)
 }
 
 /**
+ * Constraint decorator which holds a name of the constraint and a name for the column-level result
+ *
+ * @param constraint Delegate
+ * @param name       Name (Detailed message) for the constraint
+ * @param columnName Name for the column containing row-level results for this constraint
+ */
+class RowLevelConstraint(private[deequ] override val constraint: Constraint, name: String, columnName: String)
+  extends NamedConstraint(constraint, name) {
+  def getColumnName: String = columnName
+}
+
+/**
   * Companion object to create constraint objects
   * These methods can be used from the unit tests or during creation of Check configuration
   */
@@ -170,7 +182,7 @@ object Constraint {
     val constraint = AnalysisBasedConstraint[NumMatchesAndCount, Double, Double](
       completeness, assertion, hint = hint)
 
-    new NamedConstraint(constraint, s"CompletenessConstraint($completeness)")
+    new RowLevelConstraint(constraint, s"CompletenessConstraint($completeness)", s"Completeness-$column")
   }
 
   /**

--- a/src/main/scala/com/amazon/deequ/metrics/Metric.scala
+++ b/src/main/scala/com/amazon/deequ/metrics/Metric.scala
@@ -44,6 +44,9 @@ trait Metric[T] {
  */
 trait FullColumn {
   val fullColumn: Option[Column] = None
+
+  def sum(colA: Option[Column], colB: Option[Column]): Option[Column] =
+    if (colA.equals(colB)) colA else None
 }
 
 /** Common trait for all data quality metrics where the value is double */

--- a/src/main/scala/com/amazon/deequ/metrics/Metric.scala
+++ b/src/main/scala/com/amazon/deequ/metrics/Metric.scala
@@ -45,6 +45,16 @@ trait Metric[T] {
 trait FullColumn {
   val fullColumn: Option[Column] = None
 
+  /**
+   * State::sum is used to combine two states, e.g. when the same analyzer has run on two parts
+   * of a dataset and then the states are combined to produce the state for the entire dataset.
+   * For FullColumn analyzers, their sum implementation should invoke this sum method to
+   * combine the columns.
+   *
+   * As Column is a Spark expression of a transformation on data, rather than the data itself,
+   * the sum of two Spark columns whose expression equal to each other is the expression.
+   * The sum of two different Spark columns is not defined, so an empty Option is returned.
+   */
   def sum(colA: Option[Column], colB: Option[Column]): Option[Column] =
     if (colA.equals(colB)) colA else None
 }

--- a/src/main/scala/com/amazon/deequ/metrics/Metric.scala
+++ b/src/main/scala/com/amazon/deequ/metrics/Metric.scala
@@ -16,6 +16,8 @@
 
 package com.amazon.deequ.metrics
 
+import org.apache.spark.sql.Column
+
 import scala.util.{Failure, Success, Try}
 
 object Entity extends Enumeration {
@@ -37,13 +39,21 @@ trait Metric[T] {
   def flatten(): Seq[DoubleMetric]
 }
 
+/**
+ * Full-column metrics store the entire column of row-level pass/fail results
+ */
+trait FullColumn {
+  val fullColumn: Option[Column] = None
+}
+
 /** Common trait for all data quality metrics where the value is double */
 case class DoubleMetric(
-    entity: Entity.Value,
-    name: String,
-    instance: String,
-    value: Try[Double])
-  extends Metric[Double] {
+                         entity: Entity.Value,
+                         name: String,
+                         instance: String,
+                         value: Try[Double],
+                         override val fullColumn: Option[Column] = None)
+  extends Metric[Double] with FullColumn {
 
   override def flatten(): Seq[DoubleMetric] = Seq(this)
 }

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -376,8 +376,9 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
       val statePersister = mock[StatePersister]
 
       val df = getDfWithNumericValues(sparkSession)
-      val analyzers = Sum("att2") :: Completeness("att1") :: Nil
-      val states = SumState(18.0) :: NumMatchesAndCount(6, 6) :: Nil
+      val completeness =  Completeness("att1")
+      val analyzers = Sum("att2") :: completeness :: Nil
+      val states = SumState(18.0) :: NumMatchesAndCount(6, 6, Some(completeness.criterion)) :: Nil
 
       analyzers.zip(states).foreach { case (analyzer: Analyzer[_, _], state: State[_]) =>
         (statePersister.persist[state.type] _)

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -99,7 +99,7 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
 
       assert(result.status == CheckStatus.Error)
 
-      val resultData = VerificationResult.toRowLevelResults(session, result, data)
+      val resultData = VerificationResult.rowLevelResultsAsDataFrame(session, result, data)
       resultData.show()
 
       val expectedColumns: Seq[String] = data.columns :+ expectedColumn1
@@ -134,7 +134,7 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
 
       assert(result.status == CheckStatus.Error)
 
-      val resultData = VerificationResult.toRowLevelResults(session, result, data)
+      val resultData = VerificationResult.rowLevelResultsAsDataFrame(session, result, data)
 
       resultData.show()
       val expectedColumns: Set[String] =

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -111,20 +111,23 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
     }
 
     "generate a result that contains row-level results" in withSparkSession { session =>
-      val data = getDfCompleteAndInCompleteColumns(session)
+      val data = getDfCompleteAndInCompleteColumnsAndVarLengthStrings(session)
 
       val isComplete = new Check(CheckLevel.Error, "rule1").isComplete("att1")
       val completeness = new Check(CheckLevel.Error, "rule2").hasCompleteness("att2", _ > 0.7)
       val isPrimaryKey = new Check(CheckLevel.Error, "rule3").isPrimaryKey("item")
-      val maxLength = new Check(CheckLevel.Error, "rule4").hasMaxLength("att2", _ == 1)
+      val minLength = new Check(CheckLevel.Error, "rule4").hasMaxLength("item", _ <= 3)
+      val maxLength = new Check(CheckLevel.Error, "rule5").hasMaxLength("item", _ > 1)
       val expectedColumn1 = isComplete.description
       val expectedColumn2 = completeness.description
-      val expectedColumn3 = maxLength.description
+      val expectedColumn3 = minLength.description
+      val expectedColumn4 = maxLength.description
 
       val suite = new VerificationSuite().onData(data)
         .addCheck(isComplete)
         .addCheck(completeness)
         .addCheck(isPrimaryKey)
+        .addCheck(minLength)
         .addCheck(maxLength)
 
       val result: VerificationResult = suite.run()
@@ -134,8 +137,10 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
       val resultData = VerificationResult.toRowLevelResults(session, result, data)
 
       resultData.show()
-      val expectedColumns: Seq[String] = data.columns :+ expectedColumn1 :+ expectedColumn2 :+ expectedColumn3
-      assert(resultData.columns.sameElements(expectedColumns))
+      val expectedColumns: Set[String] =
+        data.columns.toSet + expectedColumn1 + expectedColumn2 + expectedColumn3 + expectedColumn4
+      assert(resultData.columns.toSet == expectedColumns)
+
 
       val rowLevel1 = resultData.select(expectedColumn1).collect().map(r => r.getBoolean(0))
       assert(Seq(true, true, true, true, true, true).sameElements(rowLevel1))
@@ -143,10 +148,11 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
       val rowLevel2 = resultData.select(expectedColumn2).collect().map(r => r.getBoolean(0))
       assert(Seq(true, true, false, true, false, true).sameElements(rowLevel2))
 
-      // TODO: This should be boolean, not double
-      val rowLevel3 = resultData.select(expectedColumn3).collect().map(r => r.getAs[Double](0))
-      println(rowLevel3.mkString(", "))
-      assert(Seq(1.0, 1.0, 0.0, 1.0, 0.0, 1.0).sameElements(rowLevel3))
+      val rowLevel3 = resultData.select(expectedColumn3).collect().map(r => r.getAs[Boolean](0))
+      assert(Seq(true, true, true, false, false, false).sameElements(rowLevel3))
+
+      val rowLevel4 = resultData.select(expectedColumn4).collect().map(r => r.getAs[Boolean](0))
+      assert(Seq(false, true, true, true, true, true).sameElements(rowLevel4))
     }
 
     "accept analysis config for mandatory analysis" in withSparkSession { sparkSession =>

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -376,7 +376,7 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
       val statePersister = mock[StatePersister]
 
       val df = getDfWithNumericValues(sparkSession)
-      val completeness =  Completeness("att1")
+      val completeness = Completeness("att1")
       val analyzers = Sum("att2") :: completeness :: Nil
       val states = SumState(18.0) :: NumMatchesAndCount(6, 6, Some(completeness.criterion)) :: Nil
 

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -85,24 +85,25 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
         }
       }
 
-    "generate a result that contains row-level results" in withSparkSession { session =>
+    "generate a result that 1" in withSparkSession { session =>
       val data = getDfCompleteAndInCompleteColumns(session)
 
-      val isComplete = new Check(CheckLevel.Error, "rule1").isComplete("att1")
-      val completeness = new Check(CheckLevel.Error, "rule2").hasCompleteness("att2", _ > 0.7)
-      val isPrimaryKey = new Check(CheckLevel.Error, "rule3").isPrimaryKey("item")
+      val isComplete = new Check(CheckLevel.Error, "rule1")
+        .isComplete("att1")
+        .isComplete("att2")
       val expectedColumn1 = isComplete.constraints.head.asInstanceOf[RowLevelConstraint].getColumnName
-      val expectedColumn2 = completeness.constraints.head.asInstanceOf[RowLevelConstraint].getColumnName
+      val expectedColumn2 = isComplete.constraints.tail.head.asInstanceOf[RowLevelConstraint].getColumnName
 
-      val suite = new VerificationSuite().onData(data).addChecks(Seq(isComplete, completeness, isPrimaryKey))
+      val suite = new VerificationSuite().onData(data).addChecks(Seq(isComplete))
 
       val result: VerificationResult = suite.run()
 
       assert(result.status == CheckStatus.Error)
 
       val resultData = VerificationResult.toRowLevelResults(session, result, data)
+      resultData.show()
 
-      val expectedColumns: Seq[String] = data.columns :+ expectedColumn1 :+ expectedColumn2
+      val expectedColumns: Seq[String] = data.columns :+ expectedColumn1
       assert(resultData.columns.sameElements(expectedColumns))
 
       val rowLevel1 = resultData.select(expectedColumn1).collect().map(r => r.getBoolean(0))
@@ -110,6 +111,44 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
 
       val rowLevel2 = resultData.select(expectedColumn2).collect().map(r => r.getBoolean(0))
       assert(Seq(true, true, false, true, false, true).sameElements(rowLevel2))
+
+    }
+
+    "generate a result that contains row-level results" in withSparkSession { session =>
+      val data = getDfCompleteAndInCompleteColumns(session)
+
+      val isComplete = new Check(CheckLevel.Error, "rule1").isComplete("att1")
+      val completeness = new Check(CheckLevel.Error, "rule2").hasCompleteness("att2", _ > 0.7)
+      val isPrimaryKey = new Check(CheckLevel.Error, "rule3").isPrimaryKey("item")
+      val maxLength = new Check(CheckLevel.Error, "rule4").hasMaxLength("att2", _ == 1)
+      val expectedColumn1 = isComplete.constraints.head.asInstanceOf[RowLevelConstraint].getColumnName
+      val expectedColumn2 = completeness.constraints.head.asInstanceOf[RowLevelConstraint].getColumnName
+      val expectedColumn3 = maxLength.constraints.head.asInstanceOf[RowLevelConstraint].getColumnName
+
+      val suite = new VerificationSuite().onData(data)
+        .addCheck(isComplete)
+        .addCheck(completeness)
+        .addCheck(isPrimaryKey)
+        .addCheck(maxLength)
+
+      val result: VerificationResult = suite.run()
+
+      assert(result.status == CheckStatus.Error)
+
+      val resultData = VerificationResult.toRowLevelResults(session, result, data)
+
+      resultData.show()
+      val expectedColumns: Seq[String] = data.columns :+ expectedColumn1 :+ expectedColumn2 :+ expectedColumn3
+      assert(resultData.columns.sameElements(expectedColumns))
+
+      val rowLevel1 = resultData.select(expectedColumn1).collect().map(r => r.getBoolean(0))
+      assert(Seq(true, true, true, true, true, true).sameElements(rowLevel1))
+
+      val rowLevel2 = resultData.select(expectedColumn2).collect().map(r => r.getBoolean(0))
+      assert(Seq(true, true, false, true, false, true).sameElements(rowLevel2))
+
+      val rowLevel3 = resultData.select(expectedColumn3).collect().map(r => r.getDouble(0))
+      assert(Seq(1.0, 1.0, 0.0, 1.0, 0.0, 0.0).sameElements(rowLevel3))
     }
 
     "accept analysis config for mandatory analysis" in withSparkSession { sparkSession =>

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalysisTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalysisTest.scala
@@ -22,6 +22,7 @@ import com.amazon.deequ.metrics.{DoubleMetric, Entity}
 import com.amazon.deequ.utils.FixtureSupport
 import com.amazon.deequ.utils.AssertionUtils.TryUtils
 import org.apache.spark.sql.{DataFrame, Row}
+import org.scalatest.Inside.inside
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -122,8 +123,16 @@ class AnalysisTest extends AnyWordSpec with Matchers with SparkContextSpec with 
 
       assert(resultMetrics.size == analysis.analyzers.size)
 
-      resultMetrics should contain(DoubleMetric(Entity.Column, "MaxLength", "att1",
-        Success(4.0)))
+      // Partially check the max length metric - don't verify the full column content
+      val maxLengthMetric = resultMetrics.head
+      inside (maxLengthMetric) { case DoubleMetric(entity, name, instance, value, fullColumn) =>
+        entity shouldBe Entity.Column
+        name shouldBe "MaxLength"
+        instance shouldBe "att1"
+        value shouldBe Success(4.0)
+        fullColumn.isDefined shouldBe true
+      }
+
       resultMetrics should contain(DoubleMetric(Entity.Column, "MinLength", "att1",
         Success(0.0)))
     }

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
@@ -21,6 +21,7 @@ import com.amazon.deequ.analyzers.runners.{NoSuchColumnException, WrongColumnTyp
 import com.amazon.deequ.metrics.{Distribution, DistributionValue, DoubleMetric, Entity}
 import com.amazon.deequ.utils.AssertionUtils.TryUtils
 import com.amazon.deequ.utils.FixtureSupport
+import org.apache.spark.sql.Column
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions.{col, udf}
 import org.apache.spark.sql.types._
@@ -50,10 +51,12 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
 
       assert(Completeness("someMissingColumn").preconditions.size == 2,
         "should check column name availability")
-      assert(Completeness("att1").calculate(dfMissing) == DoubleMetric(Entity.Column,
-        "Completeness", "att1", Success(0.5)))
-      assert(Completeness("att2").calculate(dfMissing) == DoubleMetric(Entity.Column,
-        "Completeness", "att2", Success(0.75)))
+      val result1 = Completeness("att1").calculate(dfMissing)
+      assert(result1 == DoubleMetric(Entity.Column,
+        "Completeness", "att1", Success(0.5), result1.fullColumn))
+      val result2 = Completeness("att2").calculate(dfMissing)
+      assert(result2 == DoubleMetric(Entity.Column,
+        "Completeness", "att2", Success(0.75), result2.fullColumn))
 
     }
 
@@ -82,7 +85,7 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
       val dfMissing = getDfMissing(sparkSession)
 
       val result = Completeness("att1", Some("item IN ('1', '2')")).calculate(dfMissing)
-      assert(result == DoubleMetric(Entity.Column, "Completeness", "att1", Success(1.0)))
+      assert(result == DoubleMetric(Entity.Column, "Completeness", "att1", Success(1.0), result.fullColumn))
     }
 
   }

--- a/src/test/scala/com/amazon/deequ/analyzers/CompletenessTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/CompletenessTest.scala
@@ -1,6 +1,29 @@
+/**
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
 package com.amazon.deequ.analyzers
 
 import com.amazon.deequ.SparkContextSpec
+import com.amazon.deequ.VerificationResult
+import com.amazon.deequ.VerificationSuite
+import com.amazon.deequ.checks.Check
+import com.amazon.deequ.checks.CheckLevel
+import com.amazon.deequ.checks.CheckStatus
+import com.amazon.deequ.constraints.NamedConstraint
+import com.amazon.deequ.constraints.RowLevelConstraint
 import com.amazon.deequ.metrics.DoubleMetric
 import com.amazon.deequ.metrics.FullColumn
 import com.amazon.deequ.utils.FixtureSupport
@@ -37,6 +60,37 @@ class CompletenessTest extends AnyWordSpec with Matchers with SparkContextSpec w
       val metric: DoubleMetric with FullColumn = completenessCountry.computeMetricFrom(state)
 
       data.withColumn("new", metric.fullColumn.get).show()
+    }
+  }
+
+  "VerificationSuite" should {
+    "generate a result that contains row-level results" in withSparkSession { session =>
+      val data = completenessSampleData(session)
+
+      val isComplete = new Check(CheckLevel.Error, "rule1").isComplete("Address Line 2")
+      val completeness = new Check(CheckLevel.Error, "rule2").hasCompleteness("Country", _ > 0.7)
+      val isPrimaryKey = new Check(CheckLevel.Error, "rule3").isPrimaryKey("Address Line 1")
+      val expectedColumn1 = isComplete.constraints.head.asInstanceOf[RowLevelConstraint].getColumnName
+      val expectedColumn2 = completeness.constraints.head.asInstanceOf[RowLevelConstraint].getColumnName
+
+      val suite = new VerificationSuite().onData(data).addChecks(Seq(isComplete, completeness, isPrimaryKey))
+
+      data.show()
+      val result: VerificationResult = suite.run()
+
+      assert(result.status == CheckStatus.Error)
+
+      val resultData = VerificationResult.toRowLevelResults(session, result, data)
+      resultData.show()
+
+      val expectedColumns: Seq[String] = data.columns :+ expectedColumn1 :+ expectedColumn2
+      assert(resultData.columns.sameElements(expectedColumns))
+
+      val rowLevel1 = resultData.select(expectedColumn1).collect().map(r => r.getBoolean(0))
+      assert(Seq(true, true, true, true, false, true, true, false).sameElements(rowLevel1))
+
+      val rowLevel2 = resultData.select(expectedColumn2).collect().map(r => r.getBoolean(0))
+      assert(Seq(true, true, true, true, true, true, true, true).sameElements(rowLevel2))
     }
   }
 }

--- a/src/test/scala/com/amazon/deequ/analyzers/CompletenessTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/CompletenessTest.scala
@@ -1,0 +1,42 @@
+package com.amazon.deequ.analyzers
+
+import com.amazon.deequ.SparkContextSpec
+import com.amazon.deequ.metrics.DoubleMetric
+import com.amazon.deequ.metrics.FullColumn
+import com.amazon.deequ.utils.FixtureSupport
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.SparkSession
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class CompletenessTest extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport {
+  def completenessSampleData(sparkSession: SparkSession): DataFrame = {
+    import sparkSession.implicits._
+
+    // Example from https://github.com/awslabs/deequ/issues/178
+    Seq(
+      ("India", "Xavier House, 2nd Floor", "St. Peter Colony, Perry Road", "Bandra (West)"),
+      ("India", "503 Godavari", "Sir Pochkhanwala Road", "Worli"),
+      ("India", "4/4 Seema Society", "N Dutta Road, Four Bungalows", "Andheri"),
+      ("India", "1001D Abhishek Apartments", "Juhu Versova Road", "Andheri"),
+      ("India", "95, Hill Road", null, null),
+      ("India", "90 Cuffe Parade", "Taj President Hotel", "Cuffe Parade"),
+      ("India", "4, Seven PM", "Sir Pochkhanwala Rd", "Worli"),
+      ("India", "1453 Sahar Road", null, null)
+    )
+      .toDF("Country", "Address Line 1", "Address Line 2", "Address Line 3")
+  }
+
+  "Completeness" should {
+    "return row-level results for columns" in withSparkSession { session =>
+
+      val data = completenessSampleData(session)
+
+      val completenessCountry = Completeness("Address Line 3")
+      val state = completenessCountry.computeStateFrom(data)
+      val metric: DoubleMetric with FullColumn = completenessCountry.computeMetricFrom(state)
+
+      data.withColumn("new", metric.fullColumn.get).show()
+    }
+  }
+}

--- a/src/test/scala/com/amazon/deequ/analyzers/CompletenessTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/CompletenessTest.scala
@@ -75,13 +75,11 @@ class CompletenessTest extends AnyWordSpec with Matchers with SparkContextSpec w
 
       val suite = new VerificationSuite().onData(data).addChecks(Seq(isComplete, completeness, isPrimaryKey))
 
-      data.show()
       val result: VerificationResult = suite.run()
 
       assert(result.status == CheckStatus.Error)
 
       val resultData = VerificationResult.toRowLevelResults(session, result, data)
-      resultData.show()
 
       val expectedColumns: Seq[String] = data.columns :+ expectedColumn1 :+ expectedColumn2
       assert(resultData.columns.sameElements(expectedColumns))

--- a/src/test/scala/com/amazon/deequ/analyzers/CompletenessTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/CompletenessTest.scala
@@ -17,12 +17,6 @@
 package com.amazon.deequ.analyzers
 
 import com.amazon.deequ.SparkContextSpec
-import com.amazon.deequ.VerificationResult
-import com.amazon.deequ.VerificationSuite
-import com.amazon.deequ.checks.Check
-import com.amazon.deequ.checks.CheckLevel
-import com.amazon.deequ.checks.CheckStatus
-import com.amazon.deequ.constraints.RowLevelConstraint
 import com.amazon.deequ.metrics.DoubleMetric
 import com.amazon.deequ.metrics.FullColumn
 import com.amazon.deequ.utils.FixtureSupport

--- a/src/test/scala/com/amazon/deequ/analyzers/CompletenessTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/CompletenessTest.scala
@@ -22,7 +22,6 @@ import com.amazon.deequ.VerificationSuite
 import com.amazon.deequ.checks.Check
 import com.amazon.deequ.checks.CheckLevel
 import com.amazon.deequ.checks.CheckStatus
-import com.amazon.deequ.constraints.NamedConstraint
 import com.amazon.deequ.constraints.RowLevelConstraint
 import com.amazon.deequ.metrics.DoubleMetric
 import com.amazon.deequ.metrics.FullColumn

--- a/src/test/scala/com/amazon/deequ/analyzers/CompletenessTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/CompletenessTest.scala
@@ -79,7 +79,9 @@ class CompletenessTest extends AnyWordSpec with Matchers with SparkContextSpec w
 
       assert(result.status == CheckStatus.Error)
 
+      data.show()
       val resultData = VerificationResult.toRowLevelResults(session, result, data)
+      resultData.show()
 
       val expectedColumns: Seq[String] = data.columns :+ expectedColumn1 :+ expectedColumn2
       assert(resultData.columns.sameElements(expectedColumns))

--- a/src/test/scala/com/amazon/deequ/analyzers/CompletenessTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/CompletenessTest.scala
@@ -26,39 +26,22 @@ import com.amazon.deequ.constraints.RowLevelConstraint
 import com.amazon.deequ.metrics.DoubleMetric
 import com.amazon.deequ.metrics.FullColumn
 import com.amazon.deequ.utils.FixtureSupport
-import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.SparkSession
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
 class CompletenessTest extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport {
-  def completenessSampleData(sparkSession: SparkSession): DataFrame = {
-    import sparkSession.implicits._
-
-    // Example from https://github.com/awslabs/deequ/issues/178
-    Seq(
-      ("India", "Xavier House, 2nd Floor", "St. Peter Colony, Perry Road", "Bandra (West)"),
-      ("India", "503 Godavari", "Sir Pochkhanwala Road", "Worli"),
-      ("India", "4/4 Seema Society", "N Dutta Road, Four Bungalows", "Andheri"),
-      ("India", "1001D Abhishek Apartments", "Juhu Versova Road", "Andheri"),
-      ("India", "95, Hill Road", null, null),
-      ("India", "90 Cuffe Parade", "Taj President Hotel", "Cuffe Parade"),
-      ("India", "4, Seven PM", "Sir Pochkhanwala Rd", "Worli"),
-      ("India", "1453 Sahar Road", null, null)
-    )
-      .toDF("Country", "Address Line 1", "Address Line 2", "Address Line 3")
-  }
 
   "Completeness" should {
     "return row-level results for columns" in withSparkSession { session =>
 
-      val data = completenessSampleData(session)
+      val data = getDfWithStringColumns(session)
 
       val completenessCountry = Completeness("Address Line 3")
       val state = completenessCountry.computeStateFrom(data)
       val metric: DoubleMetric with FullColumn = completenessCountry.computeMetricFrom(state)
 
-      data.withColumn("new", metric.fullColumn.get).show()
+      data.withColumn("new", metric.fullColumn.get).collect().map(_.getAs[Boolean]("new")) shouldBe
+        Seq(true, true, true, true, false, true, true, false)
     }
   }
 }

--- a/src/test/scala/com/amazon/deequ/analyzers/MaxLengthTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/MaxLengthTest.scala
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+package com.amazon.deequ.analyzers
+
+import com.amazon.deequ.SparkContextSpec
+import com.amazon.deequ.metrics.DoubleMetric
+import com.amazon.deequ.metrics.FullColumn
+import com.amazon.deequ.utils.FixtureSupport
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class MaxLengthTest extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport {
+
+  "MaxLength" should {
+    "return row-level results for non-null columns" in withSparkSession { session =>
+
+      val data = getDfWithStringColumns(session)
+
+      val countryLength = MaxLength("Country") // It's "India" in every row
+      val state: Option[MaxState] = countryLength.computeStateFrom(data)
+      val metric: DoubleMetric with FullColumn = countryLength.computeMetricFrom(state)
+
+      data.withColumn("new", metric.fullColumn.get)
+        .collect().map(_.getAs[Double]("new")) shouldBe Seq(5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0)
+    }
+
+    "return row-level results for null columns" in withSparkSession { session =>
+
+      val data = getEmptyColumnDataDf(session)
+
+      val addressLength = MaxLength("att3") // It's null in two rows
+      val state: Option[MaxState] = addressLength.computeStateFrom(data)
+      val metric: DoubleMetric with FullColumn = addressLength.computeMetricFrom(state)
+
+      data.withColumn("new", metric.fullColumn.get)
+        .collect().map(_.getAs[Double]("new")) shouldBe Seq(1.0, 1.0, 0.0, 1.0, 0.0, 1.0)
+    }
+
+    "return row-level results for blank strings" in withSparkSession { session =>
+
+      val data = getEmptyColumnDataDf(session)
+
+      val addressLength = MaxLength("att1") // It's empty strings
+      val state: Option[MaxState] = addressLength.computeStateFrom(data)
+      val metric: DoubleMetric with FullColumn = addressLength.computeMetricFrom(state)
+
+      data.withColumn("new", metric.fullColumn.get)
+        .collect().map(_.getAs[Double]("new")) shouldBe Seq(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    }
+  }
+
+}

--- a/src/test/scala/com/amazon/deequ/analyzers/NullHandlingTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/NullHandlingTests.scala
@@ -62,7 +62,8 @@ class NullHandlingTests extends AnyWordSpec
       val data = dataWithNullColumns(session)
 
       Size().computeStateFrom(data) shouldBe Some(NumMatches(8))
-      Completeness("stringCol").computeStateFrom(data) shouldBe Some(NumMatchesAndCount(0, 8))
+      val completeness = Completeness("stringCol")
+      completeness.computeStateFrom(data) shouldBe Some(NumMatchesAndCount(0, 8, Some(completeness.criterion)))
 
       Mean("numericCol").computeStateFrom(data) shouldBe None
       StandardDeviation("numericCol").computeStateFrom(data) shouldBe None

--- a/src/test/scala/com/amazon/deequ/analyzers/StateProviderTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/StateProviderTest.scala
@@ -88,11 +88,11 @@ class StateProviderTest extends AnyWordSpec
       assertCorrectlyRestoresState[SumState](provider, provider, Sum("price"), data)
       assertCorrectlyRestoresState[MeanState](provider, provider, Mean("price"), data)
       assertCorrectlyRestoresState[MinState](provider, provider, Minimum("price"), data)
-      assertCorrectlyRestoresState[MaxState](provider, provider, Maximum("price"), data)
+      assertCorrectlyRestoresMaxState(provider, provider, Maximum("price"), data)
       assertCorrectlyRestoresState[StandardDeviationState](provider, provider,
         StandardDeviation("price"), data)
 
-      assertCorrectlyRestoresState[MaxState](provider, provider, MaxLength("att1"), data)
+      assertCorrectlyRestoresMaxState(provider, provider, MaxLength("att1"), data)
       assertCorrectlyRestoresState[MinState](provider, provider, MinLength("att1"), data)
 
       assertCorrectlyRestoresState[DataTypeHistogram](provider, provider, DataType("item"), data)
@@ -188,6 +188,22 @@ class StateProviderTest extends AnyWordSpec
     assert(expectedState == clonedState.get)
   }
 
+  def assertCorrectlyRestoresMaxState(persister: StatePersister,
+                                      loader: StateLoader,
+                                      analyzer: Analyzer[MaxState, _],
+                                      data: DataFrame): Unit = {
+
+    val stateResult = analyzer.computeStateFrom(data)
+    assert(stateResult.isDefined)
+    val expectedState = stateResult.get
+
+    persister.persist[MaxState](analyzer, expectedState)
+    val restoredState = loader.load[MaxState](analyzer)
+
+    assert(restoredState.isDefined)
+    assert(MaxState(expectedState.maxValue, None) == restoredState.get)
+  }
+
   def assertCorrectlyRestoresState[S <: State[S]](
       persister: StatePersister,
       loader: StateLoader,
@@ -196,13 +212,13 @@ class StateProviderTest extends AnyWordSpec
 
     val stateResult = analyzer.computeStateFrom(data)
     assert(stateResult.isDefined)
-    val state = stateResult.get
+    val expectedState = stateResult.get
 
-    persister.persist[S](analyzer, state)
-    val clonedState = loader.load[S](analyzer)
+    persister.persist[S](analyzer, expectedState)
+    val restoredState = loader.load[S](analyzer)
 
-    assert(clonedState.isDefined)
-    assert(state == clonedState.get)
+    assert(restoredState.isDefined)
+    assert(expectedState == restoredState.get)
   }
 
   def assertCorrectlyApproxQuantileState(

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -60,6 +60,10 @@ class CheckTest extends AnyWordSpec with Matchers with SparkContextSpec with Fix
       assertEvaluatesTo(check1, context, CheckStatus.Success)
       assertEvaluatesTo(check2, context, CheckStatus.Error)
       assertEvaluatesTo(check3, context, CheckStatus.Warning)
+
+      assert(check1.getRowLevelConstraintColumnNames() == Seq("Completeness-att1", "Completeness-att1"))
+      assert(check2.getRowLevelConstraintColumnNames() == Seq("Completeness-att2"))
+      assert(check3.getRowLevelConstraintColumnNames() == Seq("Completeness-att2"))
     }
 
     "return the correct check status for combined completeness" in

--- a/src/test/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunnerTest.scala
+++ b/src/test/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunnerTest.scala
@@ -282,9 +282,9 @@ object ConstraintSuggestionRunnerTest {
            |  com.amazon.deequ.VerificationSuite()
            |    .onData(df)
            |    .addCheck(
-           |      com.amazon.deequ.checks.Check(com.amazon.deequ.checks.CheckLevel.Error, "Test")
-           |        $constraint
-           |    )
+           |      com.amazon.deequ.checks.Check(
+           |        com.amazon.deequ.checks.CheckLevel.Error, "Test")
+           |        $constraint)
            |    .run()
            |}
          """.stripMargin.trim()

--- a/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
+++ b/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
@@ -155,6 +155,19 @@ trait FixtureSupport {
     ).toDF("item", "att1", "att2")
   }
 
+  def getDfCompleteAndInCompleteColumnsAndVarLengthStrings(sparkSession: SparkSession): DataFrame = {
+    import sparkSession.implicits._
+
+    Seq(
+      ("1", "a", "f"),
+      ("22", "b", "d"),
+      ("333", "a", null),
+      ("4444", "a", "f"),
+      ("55555", "b", null),
+      ("666666", "a", "f")
+    ).toDF("item", "att1", "att2")
+  }
+
   def getDfCompleteAndInCompleteColumnsDelta(sparkSession: SparkSession): DataFrame = {
     import sparkSession.implicits._
 

--- a/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
+++ b/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
@@ -325,4 +325,20 @@ trait FixtureSupport {
       "dddd"
     ).toDF("att1")
   }
+
+  def getDfWithStringColumns(sparkSession: SparkSession): DataFrame = {
+    import sparkSession.implicits._
+
+    Seq(
+      ("India", "Xavier House, 2nd Floor", "St. Peter Colony, Perry Road", "Bandra (West)"),
+      ("India", "503 Godavari", "Sir Pochkhanwala Road", "Worli"),
+      ("India", "4/4 Seema Society", "N Dutta Road, Four Bungalows", "Andheri"),
+      ("India", "1001D Abhishek Apartments", "Juhu Versova Road", "Andheri"),
+      ("India", "95, Hill Road", null, null),
+      ("India", "90 Cuffe Parade", "Taj President Hotel", "Cuffe Parade"),
+      ("India", "4, Seven PM", "Sir Pochkhanwala Rd", "Worli"),
+      ("India", "1453 Sahar Road", null, null)
+    )
+      .toDF("Country", "Address Line 1", "Address Line 2", "Address Line 3")
+  }
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

This is an early version of the row-level results feature. I have enabled row-level results in three constraints: `IsComplete`, `HasCompleteness`, and `MaxLength`.

This requires the definition and change of certain classes defined in Deequ both to expose information previously not available, and to allow distinguishing between different analyzers' results.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
