### PR TITLE
Feature: Row Level Results

### DIFF
--- a/deequ-scalastyle.xml
+++ b/deequ-scalastyle.xml
@@ -16,7 +16,7 @@
 
     <check level="error" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
         <parameters>
-            <parameter name="maxLineLength"><![CDATA[100]]></parameter>
+            <parameter name="maxLineLength"><![CDATA[120]]></parameter>
             <parameter name="tabSize"><![CDATA[2]]></parameter>
             <parameter name="ignoreImports">true</parameter>
         </parameters>

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
     <groupId>com.amazon.deequ</groupId>
     <artifactId>deequ</artifactId>
     <version>2.0.2-spark-3.3</version>
+    <version>2.0.0-spark-3.1</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/scala/com/amazon/deequ/VerificationResult.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationResult.scala
@@ -19,8 +19,15 @@ package com.amazon.deequ
 import com.amazon.deequ.analyzers.Analyzer
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
 import com.amazon.deequ.checks.{Check, CheckResult, CheckStatus}
+import com.amazon.deequ.constraints.AnalysisBasedConstraint
+import com.amazon.deequ.constraints.ConstraintResult
+import com.amazon.deequ.constraints.NamedConstraint
+import com.amazon.deequ.constraints.RowLevelAssertedConstraint
+import com.amazon.deequ.constraints.RowLevelConstraint
+import com.amazon.deequ.metrics.FullColumn
 import com.amazon.deequ.metrics.Metric
 import com.amazon.deequ.repository.SimpleResultSerde
+import org.apache.spark.sql.Column
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 /**
@@ -70,6 +77,23 @@ object VerificationResult {
       "constraint_status", "constraint_message")
   }
 
+  /**
+   * For each check in the verification suite, adds a column of row-level results
+   * to the input data if that check contains a column.
+   *
+   * Accepts a naming rule
+   */
+  def rowLevelResultsAsDataFrame(
+      sparkSession: SparkSession,
+      verificationResult: VerificationResult,
+      data: DataFrame): DataFrame = {
+
+    val columnNamesToMetrics: Map[String, Column] = verificationResultToColumn(verificationResult)
+
+    columnNamesToMetrics.foldLeft(data)(
+      (data, newColumn: (String, Column)) => data.withColumn(newColumn._1, newColumn._2))
+  }
+
   def checkResultsAsJson(verificationResult: VerificationResult,
     forChecks: Seq[Check] = Seq.empty): String = {
 
@@ -89,6 +113,43 @@ object VerificationResult {
 
     SimpleResultSerde.serialize(checkResults)
   }
+
+  /**
+   * Returns a column for each check whose values are the result of each of the check's constraints
+   */
+  private def verificationResultToColumn(verificationResult: VerificationResult): Map[String, Column] = {
+    verificationResult.checkResults.flatMap(pair => columnForCheckResult(pair._1, pair._2))
+  }
+
+  private def columnForCheckResult(check: Check, checkResult: CheckResult): Option[(String, Column)] = {
+    // Convert non-boolean columns to boolean by using the assertion
+
+    val metrics: Seq[Column] = checkResult.constraintResults.flatMap(constraintResultToColumn)
+    if (metrics.isEmpty) {
+      None
+    } else {
+      Some(check.description, metrics.reduce(_ and _))
+    }
+  }
+
+  private def constraintResultToColumn(constraintResult: ConstraintResult): Option[Column] = {
+    val constraint = constraintResult.constraint
+    constraint match {
+      case asserted: RowLevelAssertedConstraint =>
+        constraintResult.metric.flatMap(metricToColumn).map(asserted.assertion(_))
+      case _: RowLevelConstraint =>
+        constraintResult.metric.flatMap(metricToColumn)
+      case _ => None
+    }
+  }
+
+  private def metricToColumn(metric: Metric[_]): Option[Column] = {
+    metric match {
+      case fullColumn: FullColumn => fullColumn.fullColumn
+      case _ => None
+    }
+  }
+
 
   private[this] def getSimplifiedCheckResultOutput(
       verificationResult: VerificationResult)

--- a/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Column, DataFrame, Row, SparkSession}
 import com.amazon.deequ.analyzers.runners._
+import com.amazon.deequ.metrics.FullColumn
 
 import scala.language.existentials
 import scala.util.{Failure, Success}
@@ -53,7 +54,7 @@ trait DoubleValuedState[S <: DoubleValuedState[S]] extends State[S] {
 }
 
 /** Common trait for all analyzers which generates metrics from states computed on data frames */
-trait Analyzer[S <: State[_], +M <: Metric[_]] {
+trait Analyzer[S <: State[_], +M <: Metric[_]] extends Serializable {
 
   /**
     * Compute the state (sufficient statistics) from the data
@@ -206,7 +207,11 @@ abstract class StandardScanShareableAnalyzer[S <: DoubleValuedState[_]](
   override def computeMetricFrom(state: Option[S]): DoubleMetric = {
     state match {
       case Some(theState) =>
-        metricFromValue(theState.metricValue(), name, instance, entity)
+        val col = theState match {
+          case withColumn: FullColumn => withColumn.fullColumn
+          case _ => None
+        }
+        metricFromValue(theState.metricValue(), name, instance, entity, col)
       case _ =>
         metricFromEmpty(this, name, instance, entity)
     }
@@ -227,11 +232,11 @@ abstract class StandardScanShareableAnalyzer[S <: DoubleValuedState[_]](
 
 /** A state for computing ratio-based metrics,
   * contains #rows that match a predicate and overall #rows */
-case class NumMatchesAndCount(numMatches: Long, count: Long)
-  extends DoubleValuedState[NumMatchesAndCount] {
+case class NumMatchesAndCount(numMatches: Long, count: Long, override val fullColumn: Option[Column] = None)
+  extends DoubleValuedState[NumMatchesAndCount] with FullColumn {
 
   override def sum(other: NumMatchesAndCount): NumMatchesAndCount = {
-    NumMatchesAndCount(numMatches + other.numMatches, count + other.count)
+    NumMatchesAndCount(numMatches + other.numMatches, count + other.count, sum(fullColumn, other.fullColumn))
   }
 
   override def metricValue(): Double = {
@@ -472,10 +477,11 @@ private[deequ] object Analyzers {
       value: Double,
       name: String,
       instance: String,
-      entity: Entity.Value = Entity.Column)
+      entity: Entity.Value = Entity.Column,
+      fullColumn: Option[Column] = None)
     : DoubleMetric = {
 
-    DoubleMetric(entity, name, instance, Success(value))
+    DoubleMetric(entity, name, instance, Success(value), fullColumn)
   }
 
   def emptyStateException(analyzer: Analyzer[_, _]): EmptyStateException = {

--- a/src/main/scala/com/amazon/deequ/analyzers/Completeness.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Completeness.scala
@@ -20,6 +20,8 @@ import com.amazon.deequ.analyzers.Preconditions.{hasColumn, isNotNested}
 import org.apache.spark.sql.functions.sum
 import org.apache.spark.sql.types.{IntegerType, StructType}
 import Analyzers._
+import com.google.common.annotations.VisibleForTesting
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.{Column, Row}
 
 /** Completeness is the fraction of non-null values in a column of a DataFrame. */
@@ -30,13 +32,13 @@ case class Completeness(column: String, where: Option[String] = None) extends
   override def fromAggregationResult(result: Row, offset: Int): Option[NumMatchesAndCount] = {
 
     ifNoNullsIn(result, offset, howMany = 2) { _ =>
-      NumMatchesAndCount(result.getLong(offset), result.getLong(offset + 1))
+      NumMatchesAndCount(result.getLong(offset), result.getLong(offset + 1), Some(criterion))
     }
   }
 
   override def aggregationFunctions(): Seq[Column] = {
 
-    val summation = sum(conditionalSelection(column, where).isNotNull.cast(IntegerType))
+    val summation = sum(criterion.cast(IntegerType))
 
     summation :: conditionalCount(where) :: Nil
   }
@@ -46,4 +48,7 @@ case class Completeness(column: String, where: Option[String] = None) extends
   }
 
   override def filterCondition: Option[String] = where
+
+  @VisibleForTesting // required by some tests that compare analyzer results to an expected state
+  private[deequ] def criterion: Column = conditionalSelection(column, where).isNotNull
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/MaxLength.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/MaxLength.scala
@@ -27,12 +27,12 @@ case class MaxLength(column: String, where: Option[String] = None)
   with FilterableAnalyzer {
 
   override def aggregationFunctions(): Seq[Column] = {
-    max(length(conditionalSelection(column, where))).cast(DoubleType) :: Nil
+    max(criterion) :: Nil
   }
 
   override def fromAggregationResult(result: Row, offset: Int): Option[MaxState] = {
     ifNoNullsIn(result, offset) { _ =>
-      MaxState(result.getDouble(offset))
+      MaxState(result.getDouble(offset), Some(criterion))
     }
   }
 
@@ -41,4 +41,6 @@ case class MaxLength(column: String, where: Option[String] = None)
   }
 
   override def filterCondition: Option[String] = where
+
+  private def criterion: Column = length(conditionalSelection(column, where)).cast(DoubleType)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Maximum.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Maximum.scala
@@ -21,11 +21,13 @@ import org.apache.spark.sql.{Column, Row}
 import org.apache.spark.sql.functions.max
 import org.apache.spark.sql.types.{DoubleType, StructType}
 import Analyzers._
+import com.amazon.deequ.metrics.FullColumn
 
-case class MaxState(maxValue: Double) extends DoubleValuedState[MaxState] {
+case class MaxState(maxValue: Double, override val fullColumn: Option[Column] = None)
+  extends DoubleValuedState[MaxState] with FullColumn {
 
   override def sum(other: MaxState): MaxState = {
-    MaxState(math.max(maxValue, other.maxValue))
+    MaxState(math.max(maxValue, other.maxValue), sum(fullColumn, other.fullColumn))
   }
 
   override def metricValue(): Double = {

--- a/src/main/scala/com/amazon/deequ/analyzers/catalyst/DeequFunctions.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/catalyst/DeequFunctions.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql
 
 
-import com.amazon.deequ.analyzers.KLLSketch
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateFunction, StatefulApproxQuantile, StatefulHyperloglogPlus}
 import org.apache.spark.sql.catalyst.expressions.Literal
 

--- a/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
@@ -79,7 +79,7 @@ object AnalysisRunner {
   }
 
   /**
-    * Compute the metrics from the analyzers configured in the analyis
+    * Compute the metrics from the analyzers configured in the analysis
     *
     * @param data data on which to operate
     * @param analyzers the analyzers to run
@@ -169,7 +169,7 @@ object AnalysisRunner {
     // TODO this can be further improved, we can get the number of rows from other metrics as well
     // TODO we could also insert an extra Size() computation if we have to scan the data anyways
     var numRowsOfData = nonGroupedMetrics.metric(Size()).collect {
-      case DoubleMetric(_, _, _, Success(value: Double)) => value.toLong
+      case DoubleMetric(_, _, _, Success(value: Double), None) => value.toLong
     }
 
     var groupedMetrics = AnalyzerContext.empty

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -63,6 +63,18 @@ case class Check(
   description: String,
   private[deequ] val constraints: Seq[Constraint] = Seq.empty) {
 
+  /**
+   * Returns the name of the columns where each Constraint puts row-level results, if any
+   *
+   */
+  def getRowLevelConstraintColumnNames(): Seq[String] = {
+    constraints.flatMap(c => {
+      c match {
+        case c: RowLevelConstraint => Some(c.getColumnName)
+        case _ => None
+      }
+    })
+  }
 
   /**
     * Returns a new Check object with the given constraint added to the constraints list.

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalysisTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalysisTest.scala
@@ -22,6 +22,7 @@ import com.amazon.deequ.metrics.{DoubleMetric, Entity}
 import com.amazon.deequ.utils.FixtureSupport
 import com.amazon.deequ.utils.AssertionUtils.TryUtils
 import org.apache.spark.sql.{DataFrame, Row}
+import org.scalatest.Inside.inside
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -122,8 +123,16 @@ class AnalysisTest extends AnyWordSpec with Matchers with SparkContextSpec with 
 
       assert(resultMetrics.size == analysis.analyzers.size)
 
-      resultMetrics should contain(DoubleMetric(Entity.Column, "MaxLength", "att1",
-        Success(4.0)))
+      // Partially check the max length metric - don't verify the full column content
+      val maxLengthMetric = resultMetrics.head
+      inside (maxLengthMetric) { case DoubleMetric(entity, name, instance, value, fullColumn) =>
+        entity shouldBe Entity.Column
+        name shouldBe "MaxLength"
+        instance shouldBe "att1"
+        value shouldBe Success(4.0)
+        fullColumn.isDefined shouldBe true
+      }
+
       resultMetrics should contain(DoubleMetric(Entity.Column, "MinLength", "att1",
         Success(0.0)))
     }

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
@@ -21,6 +21,7 @@ import com.amazon.deequ.analyzers.runners.{NoSuchColumnException, WrongColumnTyp
 import com.amazon.deequ.metrics.{Distribution, DistributionValue, DoubleMetric, Entity}
 import com.amazon.deequ.utils.AssertionUtils.TryUtils
 import com.amazon.deequ.utils.FixtureSupport
+import org.apache.spark.sql.Column
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions.{col, udf}
 import org.apache.spark.sql.types._
@@ -50,10 +51,12 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
 
       assert(Completeness("someMissingColumn").preconditions.size == 2,
         "should check column name availability")
-      assert(Completeness("att1").calculate(dfMissing) == DoubleMetric(Entity.Column,
-        "Completeness", "att1", Success(0.5)))
-      assert(Completeness("att2").calculate(dfMissing) == DoubleMetric(Entity.Column,
-        "Completeness", "att2", Success(0.75)))
+      val result1 = Completeness("att1").calculate(dfMissing)
+      assert(result1 == DoubleMetric(Entity.Column,
+        "Completeness", "att1", Success(0.5), result1.fullColumn))
+      val result2 = Completeness("att2").calculate(dfMissing)
+      assert(result2 == DoubleMetric(Entity.Column,
+        "Completeness", "att2", Success(0.75), result2.fullColumn))
 
     }
 
@@ -82,7 +85,7 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
       val dfMissing = getDfMissing(sparkSession)
 
       val result = Completeness("att1", Some("item IN ('1', '2')")).calculate(dfMissing)
-      assert(result == DoubleMetric(Entity.Column, "Completeness", "att1", Success(1.0)))
+      assert(result == DoubleMetric(Entity.Column, "Completeness", "att1", Success(1.0), result.fullColumn))
     }
 
   }

--- a/src/test/scala/com/amazon/deequ/analyzers/CompletenessTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/CompletenessTest.scala
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.analyzers
+
+import com.amazon.deequ.SparkContextSpec
+import com.amazon.deequ.metrics.DoubleMetric
+import com.amazon.deequ.metrics.FullColumn
+import com.amazon.deequ.utils.FixtureSupport
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class CompletenessTest extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport {
+
+  "Completeness" should {
+    "return row-level results for columns" in withSparkSession { session =>
+
+      val data = getDfWithStringColumns(session)
+
+      val completenessCountry = Completeness("Address Line 3")
+      val state = completenessCountry.computeStateFrom(data)
+      val metric: DoubleMetric with FullColumn = completenessCountry.computeMetricFrom(state)
+
+      data.withColumn("new", metric.fullColumn.get).collect().map(_.getAs[Boolean]("new")) shouldBe
+        Seq(true, true, true, true, false, true, true, false)
+    }
+  }
+}

--- a/src/test/scala/com/amazon/deequ/analyzers/MaxLengthTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/MaxLengthTest.scala
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+package com.amazon.deequ.analyzers
+
+import com.amazon.deequ.SparkContextSpec
+import com.amazon.deequ.metrics.DoubleMetric
+import com.amazon.deequ.metrics.FullColumn
+import com.amazon.deequ.utils.FixtureSupport
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class MaxLengthTest extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport {
+
+  "MaxLength" should {
+    "return row-level results for non-null columns" in withSparkSession { session =>
+
+      val data = getDfWithStringColumns(session)
+
+      val countryLength = MaxLength("Country") // It's "India" in every row
+      val state: Option[MaxState] = countryLength.computeStateFrom(data)
+      val metric: DoubleMetric with FullColumn = countryLength.computeMetricFrom(state)
+
+      data.withColumn("new", metric.fullColumn.get)
+        .collect().map(_.getAs[Double]("new")) shouldBe Seq(5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0)
+    }
+
+    "return row-level results for null columns" in withSparkSession { session =>
+
+      val data = getEmptyColumnDataDf(session)
+
+      val addressLength = MaxLength("att3") // It's null in two rows
+      val state: Option[MaxState] = addressLength.computeStateFrom(data)
+      val metric: DoubleMetric with FullColumn = addressLength.computeMetricFrom(state)
+
+      data.withColumn("new", metric.fullColumn.get)
+        .collect().map(_.getAs[Double]("new")) shouldBe Seq(1.0, 1.0, 0.0, 1.0, 0.0, 1.0)
+    }
+
+    "return row-level results for blank strings" in withSparkSession { session =>
+
+      val data = getEmptyColumnDataDf(session)
+
+      val addressLength = MaxLength("att1") // It's empty strings
+      val state: Option[MaxState] = addressLength.computeStateFrom(data)
+      val metric: DoubleMetric with FullColumn = addressLength.computeMetricFrom(state)
+
+      data.withColumn("new", metric.fullColumn.get)
+        .collect().map(_.getAs[Double]("new")) shouldBe Seq(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    }
+  }
+
+}

--- a/src/test/scala/com/amazon/deequ/analyzers/NullHandlingTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/NullHandlingTests.scala
@@ -62,7 +62,8 @@ class NullHandlingTests extends AnyWordSpec
       val data = dataWithNullColumns(session)
 
       Size().computeStateFrom(data) shouldBe Some(NumMatches(8))
-      Completeness("stringCol").computeStateFrom(data) shouldBe Some(NumMatchesAndCount(0, 8))
+      val completeness = Completeness("stringCol")
+      completeness.computeStateFrom(data) shouldBe Some(NumMatchesAndCount(0, 8, Some(completeness.criterion)))
 
       Mean("numericCol").computeStateFrom(data) shouldBe None
       StandardDeviation("numericCol").computeStateFrom(data) shouldBe None

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -60,6 +60,10 @@ class CheckTest extends AnyWordSpec with Matchers with SparkContextSpec with Fix
       assertEvaluatesTo(check1, context, CheckStatus.Success)
       assertEvaluatesTo(check2, context, CheckStatus.Error)
       assertEvaluatesTo(check3, context, CheckStatus.Warning)
+
+      assert(check1.getRowLevelConstraintColumnNames() == Seq("Completeness-att1", "Completeness-att1"))
+      assert(check2.getRowLevelConstraintColumnNames() == Seq("Completeness-att2"))
+      assert(check3.getRowLevelConstraintColumnNames() == Seq("Completeness-att2"))
     }
 
     "return the correct check status for combined completeness" in

--- a/src/test/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunnerTest.scala
+++ b/src/test/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunnerTest.scala
@@ -282,9 +282,9 @@ object ConstraintSuggestionRunnerTest {
            |  com.amazon.deequ.VerificationSuite()
            |    .onData(df)
            |    .addCheck(
-           |      com.amazon.deequ.checks.Check(com.amazon.deequ.checks.CheckLevel.Error, "Test")
-           |        $constraint
-           |    )
+           |      com.amazon.deequ.checks.Check(
+           |        com.amazon.deequ.checks.CheckLevel.Error, "Test")
+           |        $constraint)
            |    .run()
            |}
          """.stripMargin.trim()

--- a/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
+++ b/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
@@ -155,6 +155,19 @@ trait FixtureSupport {
     ).toDF("item", "att1", "att2")
   }
 
+  def getDfCompleteAndInCompleteColumnsAndVarLengthStrings(sparkSession: SparkSession): DataFrame = {
+    import sparkSession.implicits._
+
+    Seq(
+      ("1", "a", "f"),
+      ("22", "b", "d"),
+      ("333", "a", null),
+      ("4444", "a", "f"),
+      ("55555", "b", null),
+      ("666666", "a", "f")
+    ).toDF("item", "att1", "att2")
+  }
+
   def getDfCompleteAndInCompleteColumnsDelta(sparkSession: SparkSession): DataFrame = {
     import sparkSession.implicits._
 
@@ -324,5 +337,21 @@ trait FixtureSupport {
       "ccc",
       "dddd"
     ).toDF("att1")
+  }
+
+  def getDfWithStringColumns(sparkSession: SparkSession): DataFrame = {
+    import sparkSession.implicits._
+
+    Seq(
+      ("India", "Xavier House, 2nd Floor", "St. Peter Colony, Perry Road", "Bandra (West)"),
+      ("India", "503 Godavari", "Sir Pochkhanwala Road", "Worli"),
+      ("India", "4/4 Seema Society", "N Dutta Road, Four Bungalows", "Andheri"),
+      ("India", "1001D Abhishek Apartments", "Juhu Versova Road", "Andheri"),
+      ("India", "95, Hill Road", null, null),
+      ("India", "90 Cuffe Parade", "Taj President Hotel", "Cuffe Parade"),
+      ("India", "4, Seven PM", "Sir Pochkhanwala Rd", "Worli"),
+      ("India", "1453 Sahar Road", null, null)
+    )
+      .toDF("Country", "Address Line 1", "Address Line 2", "Address Line 3")
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*

This is an early version of the row-level results feature. I have enabled row-level results in three constraints: `IsComplete`, `HasCompleteness`, and `MaxLength`.

This requires the definition and change of certain classes defined in Deequ both to expose information previously not available, and to allow distinguishing between different analyzers' results.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
