### PR TITLE
Update pom.xml to publish to https://aws.oss.sonatype.org/

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -407,8 +407,8 @@
                         <extensions>true</extensions>
                         <configuration>
                             <serverId>ossrh</serverId>
-                            <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <nexusUrl>https://aws.oss.sonatype.org/</nexusUrl>
+                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
Updates the url in `pom.xml` to https://aws.oss.sonatype.org/ to publish to the correct maven repository.
Change the tag `<autoReleaseAfterClose>` to false, which allows us the review the release after the validation passes. (https://help.sonatype.com/repomanager2/staging-releases/configuring-your-project-for-deployment)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
