### PR TITLE
[Bugfix] Improve histogram performance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ target/
 .metals/
 .vscode/
 .bloop/
+.DS_Store
+

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .idea/
 *.iml
 **/*.iml
-target/.travis/public-signing-key.gpg
 target/
+.metals/
+.vscode/
+.bloop/

--- a/deequ-scalastyle.xml
+++ b/deequ-scalastyle.xml
@@ -16,7 +16,7 @@
 
     <check level="error" class="org.scalastyle.file.FileLineLengthChecker" enabled="true">
         <parameters>
-            <parameter name="maxLineLength"><![CDATA[100]]></parameter>
+            <parameter name="maxLineLength"><![CDATA[120]]></parameter>
             <parameter name="tabSize"><![CDATA[2]]></parameter>
             <parameter name="ignoreImports">true</parameter>
         </parameters>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.amazon.deequ</groupId>
     <artifactId>deequ</artifactId>
-    <version>1.3.0-SNAPSHOT</version>
+    <version>2.0.0-spark-3.1</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>
@@ -360,6 +360,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-javadoc-plugin</artifactId>
                         <version>2.9.1</version>
+                        <configuration>
+                            <source>8</source>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>attach-javadocs</id>

--- a/pom.xml
+++ b/pom.xml
@@ -87,6 +87,12 @@
         </dependency>
 
         <dependency>
+            <groupId>org.apache.spark</groupId>
+            <artifactId>spark-mllib_${scala.major.version}</artifactId>
+            <version>${spark.version}</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.scalanlp</groupId>
             <artifactId>breeze_${scala.major.version}</artifactId>
             <version>0.13.2</version>

--- a/src/main/scala/com/amazon/deequ/VerificationResult.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationResult.scala
@@ -19,8 +19,15 @@ package com.amazon.deequ
 import com.amazon.deequ.analyzers.Analyzer
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
 import com.amazon.deequ.checks.{Check, CheckResult, CheckStatus}
+import com.amazon.deequ.constraints.AnalysisBasedConstraint
+import com.amazon.deequ.constraints.ConstraintResult
+import com.amazon.deequ.constraints.NamedConstraint
+import com.amazon.deequ.constraints.RowLevelAssertedConstraint
+import com.amazon.deequ.constraints.RowLevelConstraint
+import com.amazon.deequ.metrics.FullColumn
 import com.amazon.deequ.metrics.Metric
 import com.amazon.deequ.repository.SimpleResultSerde
+import org.apache.spark.sql.Column
 import org.apache.spark.sql.{DataFrame, SparkSession}
 
 /**
@@ -70,6 +77,23 @@ object VerificationResult {
       "constraint_status", "constraint_message")
   }
 
+  /**
+   * For each check in the verification suite, adds a column of row-level results
+   * to the input data if that check contains a column.
+   *
+   * Accepts a naming rule
+   */
+  def rowLevelResultsAsDataFrame(
+      sparkSession: SparkSession,
+      verificationResult: VerificationResult,
+      data: DataFrame): DataFrame = {
+
+    val columnNamesToMetrics: Map[String, Column] = verificationResultToColumn(verificationResult)
+
+    columnNamesToMetrics.foldLeft(data)(
+      (data, newColumn: (String, Column)) => data.withColumn(newColumn._1, newColumn._2))
+  }
+
   def checkResultsAsJson(verificationResult: VerificationResult,
     forChecks: Seq[Check] = Seq.empty): String = {
 
@@ -89,6 +113,43 @@ object VerificationResult {
 
     SimpleResultSerde.serialize(checkResults)
   }
+
+  /**
+   * Returns a column for each check whose values are the result of each of the check's constraints
+   */
+  private def verificationResultToColumn(verificationResult: VerificationResult): Map[String, Column] = {
+    verificationResult.checkResults.flatMap(pair => columnForCheckResult(pair._1, pair._2))
+  }
+
+  private def columnForCheckResult(check: Check, checkResult: CheckResult): Option[(String, Column)] = {
+    // Convert non-boolean columns to boolean by using the assertion
+
+    val metrics: Seq[Column] = checkResult.constraintResults.flatMap(constraintResultToColumn)
+    if (metrics.isEmpty) {
+      None
+    } else {
+      Some(check.description, metrics.reduce(_ and _))
+    }
+  }
+
+  private def constraintResultToColumn(constraintResult: ConstraintResult): Option[Column] = {
+    val constraint = constraintResult.constraint
+    constraint match {
+      case asserted: RowLevelAssertedConstraint =>
+        constraintResult.metric.flatMap(metricToColumn).map(asserted.assertion(_))
+      case _: RowLevelConstraint =>
+        constraintResult.metric.flatMap(metricToColumn)
+      case _ => None
+    }
+  }
+
+  private def metricToColumn(metric: Metric[_]): Option[Column] = {
+    metric match {
+      case fullColumn: FullColumn => fullColumn.fullColumn
+      case _ => None
+    }
+  }
+
 
   private[this] def getSimplifiedCheckResultOutput(
       verificationResult: VerificationResult)

--- a/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
@@ -22,6 +22,7 @@ import org.apache.spark.sql.functions._
 import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Column, DataFrame, Row, SparkSession}
 import com.amazon.deequ.analyzers.runners._
+import com.amazon.deequ.metrics.FullColumn
 
 import scala.language.existentials
 import scala.util.{Failure, Success}
@@ -53,7 +54,7 @@ trait DoubleValuedState[S <: DoubleValuedState[S]] extends State[S] {
 }
 
 /** Common trait for all analyzers which generates metrics from states computed on data frames */
-trait Analyzer[S <: State[_], +M <: Metric[_]] {
+trait Analyzer[S <: State[_], +M <: Metric[_]] extends Serializable {
 
   /**
     * Compute the state (sufficient statistics) from the data
@@ -206,7 +207,11 @@ abstract class StandardScanShareableAnalyzer[S <: DoubleValuedState[_]](
   override def computeMetricFrom(state: Option[S]): DoubleMetric = {
     state match {
       case Some(theState) =>
-        metricFromValue(theState.metricValue(), name, instance, entity)
+        val col = theState match {
+          case withColumn: FullColumn => withColumn.fullColumn
+          case _ => None
+        }
+        metricFromValue(theState.metricValue(), name, instance, entity, col)
       case _ =>
         metricFromEmpty(this, name, instance, entity)
     }
@@ -227,11 +232,11 @@ abstract class StandardScanShareableAnalyzer[S <: DoubleValuedState[_]](
 
 /** A state for computing ratio-based metrics,
   * contains #rows that match a predicate and overall #rows */
-case class NumMatchesAndCount(numMatches: Long, count: Long)
-  extends DoubleValuedState[NumMatchesAndCount] {
+case class NumMatchesAndCount(numMatches: Long, count: Long, override val fullColumn: Option[Column] = None)
+  extends DoubleValuedState[NumMatchesAndCount] with FullColumn {
 
   override def sum(other: NumMatchesAndCount): NumMatchesAndCount = {
-    NumMatchesAndCount(numMatches + other.numMatches, count + other.count)
+    NumMatchesAndCount(numMatches + other.numMatches, count + other.count, sum(fullColumn, other.fullColumn))
   }
 
   override def metricValue(): Double = {
@@ -472,10 +477,11 @@ private[deequ] object Analyzers {
       value: Double,
       name: String,
       instance: String,
-      entity: Entity.Value = Entity.Column)
+      entity: Entity.Value = Entity.Column,
+      fullColumn: Option[Column] = None)
     : DoubleMetric = {
 
-    DoubleMetric(entity, name, instance, Success(value))
+    DoubleMetric(entity, name, instance, Success(value), fullColumn)
   }
 
   def emptyStateException(analyzer: Analyzer[_, _]): EmptyStateException = {

--- a/src/main/scala/com/amazon/deequ/analyzers/Completeness.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Completeness.scala
@@ -20,6 +20,8 @@ import com.amazon.deequ.analyzers.Preconditions.{hasColumn, isNotNested}
 import org.apache.spark.sql.functions.sum
 import org.apache.spark.sql.types.{IntegerType, StructType}
 import Analyzers._
+import com.google.common.annotations.VisibleForTesting
+import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.{Column, Row}
 
 /** Completeness is the fraction of non-null values in a column of a DataFrame. */
@@ -30,13 +32,13 @@ case class Completeness(column: String, where: Option[String] = None) extends
   override def fromAggregationResult(result: Row, offset: Int): Option[NumMatchesAndCount] = {
 
     ifNoNullsIn(result, offset, howMany = 2) { _ =>
-      NumMatchesAndCount(result.getLong(offset), result.getLong(offset + 1))
+      NumMatchesAndCount(result.getLong(offset), result.getLong(offset + 1), Some(criterion))
     }
   }
 
   override def aggregationFunctions(): Seq[Column] = {
 
-    val summation = sum(conditionalSelection(column, where).isNotNull.cast(IntegerType))
+    val summation = sum(criterion.cast(IntegerType))
 
     summation :: conditionalCount(where) :: Nil
   }
@@ -46,4 +48,7 @@ case class Completeness(column: String, where: Option[String] = None) extends
   }
 
   override def filterCondition: Option[String] = where
+
+  @VisibleForTesting // required by some tests that compare analyzer results to an expected state
+  private[deequ] def criterion: Column = conditionalSelection(column, where).isNotNull
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Distance.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Distance.scala
@@ -15,48 +15,46 @@
  */
 
 package com.amazon.deequ.analyzers
-import org.apache.spark.SparkContext
 import org.apache.spark.mllib.linalg._
-import org.apache.spark.mllib.regression.LabeledPoint
 import org.apache.spark.mllib.stat.Statistics
-import org.apache.spark.mllib.stat.Statistics._
 import org.apache.spark.mllib.stat.test.ChiSqTestResult
 
-
-
-
+import scala.annotation.tailrec
 
 object Distance {
-
     // Chi-square constants
     // at least two distinct categories are required to run the chi-square test for a categorical variable
     private val chisquareMinDimension: Int = 2
 
-    //for tables larger than 2 x 2: "No more than 20% of the expected counts are less than 5 and all individual expected counts are 1 or greater" (Yates, Moore & McCabe, 1999, The Practice of Statistics, p. 734)
+    // for tables larger than 2 x 2:
+    //   "No more than 20% of the expected counts are less than 5 and all individual expected counts are 1 or greater"
+    //     - Yates, Moore & McCabe, 1999, The Practice of Statistics, p. 734
     private val defaultAbsThresholdYates: Integer = 5
     private val defaultPercThresholdYates: Double = 0.2
 
-    // for 2x2 tables: all expected counts should be 10 or greater (Cochran, William G. "The χ2 test of goodness of fit." The Annals of mathematical statistics (1952): 315-345.)
+    // for 2x2 tables:
+    //   all expected counts should be 10 or greater
+    //     - Cochran, William G. "The (chi)**2 test of goodness of fit."
+    //       The Annals of mathematical statistics (1952): 315-345.
     private val defaultAbsThresholdCochran: Integer = 10
 
-    // Default c(alpha) value corresponding to an alpha value of 0.003, Eq. (15) in Section 3.3.1 of Knuth, D.E., The Art of Computer Programming, Volume 2 (Seminumerical Algorithms), 3rd Edition, Addison Wesley, Reading Mass, 1998.
+    // Default c(alpha) value corresponding to an alpha value of 0.003,
+    // Eq. (15) in Section 3.3.1 of Knuth, D.E., The Art of Computer Programming, Volume 2 (Seminumerical Algorithms),
+    // 3rd Edition, Addison Wesley, Reading Mass, 1998.
     private val defaultCAlpha : Double = 1.8
 
     trait CategoricalDistanceMethod
     case class LInfinityMethod(alpha: Option[Double] = None) extends CategoricalDistanceMethod
-    case class ChisquareMethod(
-                          absThresholdYates: Integer = defaultAbsThresholdYates,
-                          percThresholdYates: Double = defaultPercThresholdYates,
-                          absThresholdCochran: Integer = defaultAbsThresholdCochran)
+    case class ChisquareMethod(absThresholdYates: Integer = defaultAbsThresholdYates,
+                               percThresholdYates: Double = defaultPercThresholdYates,
+                               absThresholdCochran: Integer = defaultAbsThresholdCochran)
       extends CategoricalDistanceMethod
 
-  /** Calculate distance of numerical profiles based on KLL Sketches and L-Infinity Distance */
-    def numericalDistance(
-      sample1: QuantileNonSample[Double],
-      sample2: QuantileNonSample[Double],
-      correctForLowNumberOfSamples: Boolean = false,
-      alpha: Option[Double] = None)
-    : Double = {
+    /** Calculate distance of numerical profiles based on KLL Sketches and L-Infinity Distance */
+    def numericalDistance(sample1: QuantileNonSample[Double],
+                          sample2: QuantileNonSample[Double],
+                          correctForLowNumberOfSamples: Boolean = false,
+                          alpha: Option[Double] = None): Double = {
       val rankMap1 = sample1.getRankMap()
       val rankMap2 = sample2.getRankMap()
       val combinedKeys = rankMap1.keySet.union(rankMap2.keySet)
@@ -76,24 +74,27 @@ object Distance {
   /** Calculate distance of categorical profiles based on different distance methods
    *
    * Thresholds for chi-square method:
-   *    - for 2x2 tables: all expected counts should be 10 or greater (Cochran, William G. "The χ2 test of goodness of fit." The Annals of mathematical statistics (1952): 315-345.)
-   *    - for tables larger than 2 x 2: "No more than 20% of the expected counts are less than 5 and all individual expected counts are 1 or greater" (Yates, Moore & McCabe, 1999, The Practice of Statistics, p. 734)
+   *  - for 2x2 tables:
+   *      all expected counts should be 10 or greater
+   *        - Cochran, William G. "The (chi)**2 test of goodness of fit."
+   *          The Annals of mathematical statistics (1952): 315-345.
+   *  - for tables larger than 2 x 2:
+   *      "No more than 20% of the expected counts are less than 5 and all individual expected counts are 1 or greater"
+   *        - (Yates, Moore & McCabe, 1999, The Practice of Statistics, p. 734)
    *
-   * @param sample1                      the mapping between categories(keys) and counts(values) of the observed sample
-   * @param sample2                      the mapping between categories(keys) and counts(values) of the expected baseline
+   * @param sample1                      the mapping between categories(keys) and
+   *                                     counts(values) of the observed sample
+   * @param sample2                      the mapping between categories(keys) and
+   *                                     counts(values) of the expected baseline
    * @param correctForLowNumberOfSamples if true returns chi-square statistics otherwise p-value
    * @param method                       Method to use: LInfinity or Chisquare
-   * @param absThresholdYates            Yates absolute threshold for tables larger than 2x2
-   * @param percThresholdYates           Yates percentage of categories that can be below threshold for tables larger than 2x2
-   * @param absThresholdCochran          Cochran absolute threshold for 2x2 tables
-   * @return distance                    can be an absolute distance or a p-value based on the correctForLowNumberOfSamples argument
+   * @return distance                    can be an absolute distance or
+   *                                     a p-value based on the correctForLowNumberOfSamples argument
    */
-  def categoricalDistance(
-    sample1: scala.collection.mutable.Map[String, Long],
-    sample2: scala.collection.mutable.Map[String, Long],
-    correctForLowNumberOfSamples: Boolean = false,
-    method: CategoricalDistanceMethod = LInfinityMethod())
-  : Double = {
+  def categoricalDistance(sample1: scala.collection.mutable.Map[String, Long],
+                          sample2: scala.collection.mutable.Map[String, Long],
+                          correctForLowNumberOfSamples: Boolean = false,
+                          method: CategoricalDistanceMethod = LInfinityMethod()): Double = {
     method match {
       case LInfinityMethod(alpha) => categoricalLInfinityDistance(sample1, sample2, correctForLowNumberOfSamples, alpha)
       case ChisquareMethod(absThresholdYates, percThresholdYates, absThresholdCochran)
@@ -109,38 +110,47 @@ object Distance {
 
   /** Calculate distance of categorical profiles based on Chisquare test or stats
    *
-   *  for 2x2 tables: all expected counts should be 10 or greater (Cochran, William G. "The χ2 test of goodness of fit." The Annals of mathematical statistics (1952): 315-345.)
-   *  for tables larger than 2 x 2: "No more than 20% of the expected counts are less than 5 and all individual expected counts are 1 or greater" (Yates, Moore & McCabe, 1999, The Practice of Statistics, p. 734)
+   *  for 2x2 tables:
+   *    all expected counts should be 10 or greater
+   *      - Cochran, William G. "The (chi)**2 test of goodness of fit."
+   *        The Annals of mathematical statistics (1952): 315-345.
+   *  for tables larger than 2 x 2:
+   *    "No more than 20% of the expected counts are less than 5 and all individual expected counts are 1 or greater"
+   *      - Yates, Moore & McCabe, 1999, The Practice of Statistics, p. 734
    *
-   *  @param sample                       the mapping between categories(keys) and counts(values) of the observed sample
-   *  @param expected                     the mapping between categories(keys) and counts(values) of the expected baseline
+   *  @param sample                       the mapping between categories(keys) and
+   *                                      counts(values) of the observed sample
+   *  @param expected                     the mapping between categories(keys) and
+   *                                      counts(values) of the expected baseline
    *  @param correctForLowNumberOfSamples if true returns chi-square statistics otherwise p-value
    *  @param absThresholdYates            Yates absolute threshold for tables larger than 2x2
-   *  @param percThresholdYates           Yates percentage of categories that can be below threshold for tables larger than 2x2
+   *  @param percThresholdYates           Yates percentage of categories that can be
+   *                                      below threshold for tables larger than 2x2
    *  @param absThresholdCochran          Cochran absolute threshold for 2x2 tables
-   *  @return distance                    can be an absolute distance or a p-value based on the correctForLowNumberOfSamples argument
+   *  @return distance                    can be an absolute distance or
+   *                                      a p-value based on the correctForLowNumberOfSamples argument
    *
    */
-  private[this] def categoricalChiSquareTest(
-    sample: scala.collection.mutable.Map[String, Long],
-    expected: scala.collection.mutable.Map[String, Long],
-    correctForLowNumberOfSamples: Boolean = false,
-    absThresholdYates : Integer = defaultAbsThresholdYates ,
-    percThresholdYates : Double = defaultPercThresholdYates,
-    absThresholdCochran : Integer = defaultAbsThresholdCochran,
-    normalizeExpected : Boolean = true)
-  : Double = {
+  private[this] def categoricalChiSquareTest(sample: scala.collection.mutable.Map[String, Long],
+                                             expected: scala.collection.mutable.Map[String, Long],
+                                             correctForLowNumberOfSamples: Boolean = false,
+                                             absThresholdYates : Integer = defaultAbsThresholdYates,
+                                             percThresholdYates : Double = defaultPercThresholdYates,
+                                             absThresholdCochran : Integer = defaultAbsThresholdCochran): Double = {
 
-    val sampleSum: Double = sample.filter(e => expected.contains(e._1)).map((e => e._2)).sum
-    val expectedSum: Double = expected.map(e => e._2).sum
+    val sampleSum: Double = sample.filter(e => expected.contains(e._1)).values.sum
+    val expectedSum: Double = expected.values.sum
 
     // Normalize the expected input, normalization is required to conduct the chi-square test
-    // While normalization is already included in the mllib chi-square test, we perform normalization manually to execute proper regrouping
-    // https://spark.apache.org/docs/3.1.3/api/scala/org/apache/spark/mllib/stat/Statistics$.html#chiSqTest:org.apache.spark.mllib.stat.test.ChiSqTestResult
-    val expectedNorm: scala.collection.mutable.Map[String, Double] = expected.map(e => (e._1, (e._2 / expectedSum * sampleSum)))
+    // While normalization is already included in the mllib chi-square test,
+    // we perform normalization manually to execute proper regrouping
+    // https://spark.apache.org/docs/3.1.3/api/scala/org/apache/spark/mllib/stat/Statistics$.html#chiSqTest
+    val expectedNorm: scala.collection.mutable.Map[String, Double] =
+      expected.map(e => (e._1, e._2 / expectedSum * sampleSum))
 
     // Call the function that regroups categories if necessary depending on thresholds
-    val (regroupedSample, regroupedExpected) = regroupCategories(sample.map(e => (e._1, e._2.toDouble)), expectedNorm, absThresholdYates, percThresholdYates, absThresholdCochran)
+    val (regroupedSample, regroupedExpected) = regroupCategories(
+      sample.map(e => (e._1, e._2.toDouble)), expectedNorm, absThresholdYates, percThresholdYates, absThresholdCochran)
 
     // If less than 2 categories remain we cannot conduct the test
     if (regroupedSample.keySet.size < chisquareMinDimension) {
@@ -158,30 +168,39 @@ object Distance {
 
   /** Regroup categories with elements below threshold, required for chi-square test
    *
-   * for 2x2 tables: all expected counts should be 10 or greater (Cochran, William G. "The χ2 test of goodness of fit." The Annals of mathematical statistics (1952): 315-345.)
-   * for tables larger than 2 x 2: "No more than 20% of the expected counts are less than 5 and all individual expected counts are 1 or greater" (Yates, Moore & McCabe, 1999, The Practice of Statistics, p. 734)
+   * for 2x2 tables:
+   *   all expected counts should be 10 or greater
+   *     - Cochran, William G. "The (chi)**2 test of goodness of fit."
+   *       The Annals of mathematical statistics (1952): 315-345.
+   * for tables larger than 2 x 2:
+   *   "No more than 20% of the expected counts are less than 5 and all individual expected counts are 1 or greater"
+   *     - Yates, Moore & McCabe, 1999, The Practice of Statistics, p. 734
    *
-   * @param sample                       the mapping between categories(keys) and counts(values) of the observed sample
-   * @param expected                     the mapping between categories(keys) and counts(values) of the expected baseline
+   * @param sample                       the mapping between categories(keys) and
+   *                                     counts(values) of the observed sample
+   * @param expected                     the mapping between categories(keys) and
+   *                                     counts(values) of the expected baseline
    * @param absThresholdYates            Yates absolute threshold for tables larger than 2x2
-   * @param percThresholdYates           Yates percentage of categories that can be below threshold for tables larger than 2x2
+   * @param percThresholdYates           Yates percentage of categories that can be
+   *                                     below threshold for tables larger than 2x2
    * @param absThresholdCochran          Cochran absolute threshold for 2x2 tables
    * @return (sample, expected)          returns the two regrouped mappings
    *
    */
-  private[this] def regroupCategories(
-    sample: scala.collection.mutable.Map[String, Double],
-    expected: scala.collection.mutable.Map[String, Double],
-    absThresholdYates: Integer = defaultAbsThresholdYates,
-    percThresholdYates: Double = defaultPercThresholdYates,
-    absThresholdCochran: Integer = defaultAbsThresholdCochran)
+  @tailrec
+  private[this] def regroupCategories(sample: scala.collection.mutable.Map[String, Double],
+                                      expected: scala.collection.mutable.Map[String, Double],
+                                      absThresholdYates: Integer = defaultAbsThresholdYates,
+                                      percThresholdYates: Double = defaultPercThresholdYates,
+                                      absThresholdCochran: Integer = defaultAbsThresholdCochran)
     : (scala.collection.mutable.Map[String, Double], scala.collection.mutable.Map[String, Double]) = {
 
     // If number of categories is below the minimum return original mappings
     if (expected.keySet.size < chisquareMinDimension) {
       (sample, expected)
     } else {
-      // Determine thresholds depending on dimensions of mapping (2x2 tables use Cochran, all other tables Yates thresholds)
+      // Determine thresholds depending on dimensions of mapping
+      // 2x2 tables use Cochran, all other tables Yates thresholds
       var absThresholdPerColumn : Integer = absThresholdCochran
       var maxNbColumnsBelowThreshold: Integer = 0
       if (expected.keySet.size > chisquareMinDimension) {
@@ -191,8 +210,9 @@ object Distance {
       // Count number of categories below threshold
       val nbExpectedColumnsBelowThreshold = expected.filter(e => e._2 < absThresholdPerColumn).keySet.size
 
-      // If the number of categories below threshold exceeds the authorized maximum, small categories are regrouped until valid
-      if (nbExpectedColumnsBelowThreshold > maxNbColumnsBelowThreshold){
+      // If the number of categories below threshold exceeds
+      // the authorized maximum, small categories are regrouped until valid
+      if (nbExpectedColumnsBelowThreshold > maxNbColumnsBelowThreshold) {
 
         // Identified key that holds minimum value
         val expectedMin: (String, Double) = expected.minBy(e => e._2)
@@ -226,10 +246,8 @@ object Distance {
    * @return ChiSqTestResult    returns the chi-square test result object (contains both statistics and p-value)
    *
    */
-  private[this] def chiSquareTest(
-                                   sample: scala.collection.mutable.Map[String, Double],
-                                   expected: scala.collection.mutable.Map[String, Double])
-  : ChiSqTestResult = {
+  private[this] def chiSquareTest(sample: scala.collection.mutable.Map[String, Double],
+                                  expected: scala.collection.mutable.Map[String, Double]): ChiSqTestResult = {
 
     var sampleArray = Array[Double]()
     var expectedArray = Array[Double]()
@@ -248,12 +266,10 @@ object Distance {
   }
 
   /** Calculate distance of categorical profiles based on L-Infinity Distance */
-  private[this] def categoricalLInfinityDistance(
-    sample1: scala.collection.mutable.Map[String, Long],
-    sample2: scala.collection.mutable.Map[String, Long],
-    correctForLowNumberOfSamples: Boolean = false,
-    alpha: Option[Double])
-  : Double = {
+  private[this] def categoricalLInfinityDistance(sample1: scala.collection.mutable.Map[String, Long],
+                                                 sample2: scala.collection.mutable.Map[String, Long],
+                                                 correctForLowNumberOfSamples: Boolean = false,
+                                                 alpha: Option[Double]): Double = {
     var n = 0.0
     var m = 0.0
     sample1.keySet.foreach { key =>
@@ -276,21 +292,19 @@ object Distance {
 
   /** Select which metrics to compute (linf_simple or linf_robust)
    *  based on whether samples are enough */
-   private[this] def selectMetrics(
-     linfSimple: Double,
-     n: Double,
-     m: Double,
-     correctForLowNumberOfSamples: Boolean = false,
-     alpha: Option[Double])
-   : Double = {
+   private[this] def selectMetrics(linfSimple: Double,
+                                   n: Double,
+                                   m: Double,
+                                   correctForLowNumberOfSamples: Boolean = false,
+                                   alpha: Option[Double]): Double = {
      if (correctForLowNumberOfSamples) {
        linfSimple
      } else {
        // This formula is based on  “Two-sample Kolmogorov–Smirnov test"
        // Reference: https://en.m.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test
 
-       val cAlpha : Double =  alpha match {
-         case Some(a)  => Math.sqrt(-Math.log(a/2) * 1/2)
+       val cAlpha: Double = alpha match {
+         case Some(a) => Math.sqrt(-Math.log(a/2) * 1/2)
          case None => defaultCAlpha
        }
        val linfRobust = Math.max(0.0, linfSimple - cAlpha * Math.sqrt((n + m) / (n * m)))
@@ -298,4 +312,3 @@ object Distance {
      }
    }
 }
-

--- a/src/main/scala/com/amazon/deequ/analyzers/Distance.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Distance.scala
@@ -15,14 +15,47 @@
  */
 
 package com.amazon.deequ.analyzers
+import org.apache.spark.SparkContext
+import org.apache.spark.mllib.linalg._
+import org.apache.spark.mllib.regression.LabeledPoint
+import org.apache.spark.mllib.stat.Statistics
+import org.apache.spark.mllib.stat.Statistics._
+import org.apache.spark.mllib.stat.test.ChiSqTestResult
+
+
+
+
 
 object Distance {
 
-    /** Calculate distance of numerical profiles based on KLL Sketches and L-Infinity Distance */
+    // Chi-square constants
+    // at least two distinct categories are required to run the chi-square test for a categorical variable
+    private val chisquareMinDimension: Int = 2
+
+    //for tables larger than 2 x 2: "No more than 20% of the expected counts are less than 5 and all individual expected counts are 1 or greater" (Yates, Moore & McCabe, 1999, The Practice of Statistics, p. 734)
+    private val defaultAbsThresholdYates: Integer = 5
+    private val defaultPercThresholdYates: Double = 0.2
+
+    // for 2x2 tables: all expected counts should be 10 or greater (Cochran, William G. "The χ2 test of goodness of fit." The Annals of mathematical statistics (1952): 315-345.)
+    private val defaultAbsThresholdCochran: Integer = 10
+
+    // Default c(alpha) value corresponding to an alpha value of 0.003, Eq. (15) in Section 3.3.1 of Knuth, D.E., The Art of Computer Programming, Volume 2 (Seminumerical Algorithms), 3rd Edition, Addison Wesley, Reading Mass, 1998.
+    private val defaultCAlpha : Double = 1.8
+
+    trait CategoricalDistanceMethod
+    case class LInfinityMethod(alpha: Option[Double] = None) extends CategoricalDistanceMethod
+    case class ChisquareMethod(
+                          absThresholdYates: Integer = defaultAbsThresholdYates,
+                          percThresholdYates: Double = defaultPercThresholdYates,
+                          absThresholdCochran: Integer = defaultAbsThresholdCochran)
+      extends CategoricalDistanceMethod
+
+  /** Calculate distance of numerical profiles based on KLL Sketches and L-Infinity Distance */
     def numericalDistance(
       sample1: QuantileNonSample[Double],
       sample2: QuantileNonSample[Double],
-      correctForLowNumberOfSamples: Boolean = false)
+      correctForLowNumberOfSamples: Boolean = false,
+      alpha: Option[Double] = None)
     : Double = {
       val rankMap1 = sample1.getRankMap()
       val rankMap2 = sample2.getRankMap()
@@ -37,35 +70,209 @@ object Distance {
         val cdfDiff = Math.abs(cdf1 - cdf2)
         linfSimple = Math.max(linfSimple, cdfDiff)
       }
-      selectMetrics(linfSimple, n, m, correctForLowNumberOfSamples)
+      selectMetrics(linfSimple, n, m, correctForLowNumberOfSamples, alpha)
     }
 
-    /** Calculate distance of categorical profiles based on L-Infinity Distance */
-    def categoricalDistance(
-      sample1: scala.collection.mutable.Map[String, Long],
-      sample2: scala.collection.mutable.Map[String, Long],
-      correctForLowNumberOfSamples: Boolean = false)
-    : Double = {
-
-      var n = 0.0
-      var m = 0.0
-      sample1.keySet.foreach { key =>
-        n += sample1(key)
-      }
-      sample2.keySet.foreach { key =>
-        m += sample2(key)
-      }
-      val combinedKeys = sample1.keySet.union(sample2.keySet)
-      var linfSimple = 0.0
-
-      combinedKeys.foreach { key =>
-        val cdf1 = sample1.getOrElse(key, 0L) / n
-        val cdf2 = sample2.getOrElse(key, 0L) / m
-        val cdfDiff = Math.abs(cdf1 - cdf2)
-        linfSimple = Math.max(linfSimple, cdfDiff)
-      }
-      selectMetrics(linfSimple, n, m, correctForLowNumberOfSamples)
+  /** Calculate distance of categorical profiles based on different distance methods
+   *
+   * Thresholds for chi-square method:
+   *    - for 2x2 tables: all expected counts should be 10 or greater (Cochran, William G. "The χ2 test of goodness of fit." The Annals of mathematical statistics (1952): 315-345.)
+   *    - for tables larger than 2 x 2: "No more than 20% of the expected counts are less than 5 and all individual expected counts are 1 or greater" (Yates, Moore & McCabe, 1999, The Practice of Statistics, p. 734)
+   *
+   * @param sample1                      the mapping between categories(keys) and counts(values) of the observed sample
+   * @param sample2                      the mapping between categories(keys) and counts(values) of the expected baseline
+   * @param correctForLowNumberOfSamples if true returns chi-square statistics otherwise p-value
+   * @param method                       Method to use: LInfinity or Chisquare
+   * @param absThresholdYates            Yates absolute threshold for tables larger than 2x2
+   * @param percThresholdYates           Yates percentage of categories that can be below threshold for tables larger than 2x2
+   * @param absThresholdCochran          Cochran absolute threshold for 2x2 tables
+   * @return distance                    can be an absolute distance or a p-value based on the correctForLowNumberOfSamples argument
+   */
+  def categoricalDistance(
+    sample1: scala.collection.mutable.Map[String, Long],
+    sample2: scala.collection.mutable.Map[String, Long],
+    correctForLowNumberOfSamples: Boolean = false,
+    method: CategoricalDistanceMethod = LInfinityMethod())
+  : Double = {
+    method match {
+      case LInfinityMethod(alpha) => categoricalLInfinityDistance(sample1, sample2, correctForLowNumberOfSamples, alpha)
+      case ChisquareMethod(absThresholdYates, percThresholdYates, absThresholdCochran)
+        => categoricalChiSquareTest(
+            sample1,
+            sample2,
+            correctForLowNumberOfSamples,
+            absThresholdYates,
+            percThresholdYates,
+            absThresholdCochran )
     }
+  }
+
+  /** Calculate distance of categorical profiles based on Chisquare test or stats
+   *
+   *  for 2x2 tables: all expected counts should be 10 or greater (Cochran, William G. "The χ2 test of goodness of fit." The Annals of mathematical statistics (1952): 315-345.)
+   *  for tables larger than 2 x 2: "No more than 20% of the expected counts are less than 5 and all individual expected counts are 1 or greater" (Yates, Moore & McCabe, 1999, The Practice of Statistics, p. 734)
+   *
+   *  @param sample                       the mapping between categories(keys) and counts(values) of the observed sample
+   *  @param expected                     the mapping between categories(keys) and counts(values) of the expected baseline
+   *  @param correctForLowNumberOfSamples if true returns chi-square statistics otherwise p-value
+   *  @param absThresholdYates            Yates absolute threshold for tables larger than 2x2
+   *  @param percThresholdYates           Yates percentage of categories that can be below threshold for tables larger than 2x2
+   *  @param absThresholdCochran          Cochran absolute threshold for 2x2 tables
+   *  @return distance                    can be an absolute distance or a p-value based on the correctForLowNumberOfSamples argument
+   *
+   */
+  private[this] def categoricalChiSquareTest(
+    sample: scala.collection.mutable.Map[String, Long],
+    expected: scala.collection.mutable.Map[String, Long],
+    correctForLowNumberOfSamples: Boolean = false,
+    absThresholdYates : Integer = defaultAbsThresholdYates ,
+    percThresholdYates : Double = defaultPercThresholdYates,
+    absThresholdCochran : Integer = defaultAbsThresholdCochran,
+    normalizeExpected : Boolean = true)
+  : Double = {
+
+    val sampleSum: Double = sample.filter(e => expected.contains(e._1)).map((e => e._2)).sum
+    val expectedSum: Double = expected.map(e => e._2).sum
+
+    // Normalize the expected input, normalization is required to conduct the chi-square test
+    // While normalization is already included in the mllib chi-square test, we perform normalization manually to execute proper regrouping
+    // https://spark.apache.org/docs/3.1.3/api/scala/org/apache/spark/mllib/stat/Statistics$.html#chiSqTest:org.apache.spark.mllib.stat.test.ChiSqTestResult
+    val expectedNorm: scala.collection.mutable.Map[String, Double] = expected.map(e => (e._1, (e._2 / expectedSum * sampleSum)))
+
+    // Call the function that regroups categories if necessary depending on thresholds
+    val (regroupedSample, regroupedExpected) = regroupCategories(sample.map(e => (e._1, e._2.toDouble)), expectedNorm, absThresholdYates, percThresholdYates, absThresholdCochran)
+
+    // If less than 2 categories remain we cannot conduct the test
+    if (regroupedSample.keySet.size < chisquareMinDimension) {
+      Double.NaN
+    } else {
+      // run chi-square test and return statistics or p-value
+      val result = chiSquareTest(regroupedSample, regroupedExpected)
+      if (correctForLowNumberOfSamples) {
+        result.statistic
+      } else {
+        result.pValue
+      }
+    }
+  }
+
+  /** Regroup categories with elements below threshold, required for chi-square test
+   *
+   * for 2x2 tables: all expected counts should be 10 or greater (Cochran, William G. "The χ2 test of goodness of fit." The Annals of mathematical statistics (1952): 315-345.)
+   * for tables larger than 2 x 2: "No more than 20% of the expected counts are less than 5 and all individual expected counts are 1 or greater" (Yates, Moore & McCabe, 1999, The Practice of Statistics, p. 734)
+   *
+   * @param sample                       the mapping between categories(keys) and counts(values) of the observed sample
+   * @param expected                     the mapping between categories(keys) and counts(values) of the expected baseline
+   * @param absThresholdYates            Yates absolute threshold for tables larger than 2x2
+   * @param percThresholdYates           Yates percentage of categories that can be below threshold for tables larger than 2x2
+   * @param absThresholdCochran          Cochran absolute threshold for 2x2 tables
+   * @return (sample, expected)          returns the two regrouped mappings
+   *
+   */
+  private[this] def regroupCategories(
+    sample: scala.collection.mutable.Map[String, Double],
+    expected: scala.collection.mutable.Map[String, Double],
+    absThresholdYates: Integer = defaultAbsThresholdYates,
+    percThresholdYates: Double = defaultPercThresholdYates,
+    absThresholdCochran: Integer = defaultAbsThresholdCochran)
+    : (scala.collection.mutable.Map[String, Double], scala.collection.mutable.Map[String, Double]) = {
+
+    // If number of categories is below the minimum return original mappings
+    if (expected.keySet.size < chisquareMinDimension) {
+      (sample, expected)
+    } else {
+      // Determine thresholds depending on dimensions of mapping (2x2 tables use Cochran, all other tables Yates thresholds)
+      var absThresholdPerColumn : Integer = absThresholdCochran
+      var maxNbColumnsBelowThreshold: Integer = 0
+      if (expected.keySet.size > chisquareMinDimension) {
+        absThresholdPerColumn = absThresholdYates
+        maxNbColumnsBelowThreshold = (percThresholdYates * expected.keySet.size).toInt
+      }
+      // Count number of categories below threshold
+      val nbExpectedColumnsBelowThreshold = expected.filter(e => e._2 < absThresholdPerColumn).keySet.size
+
+      // If the number of categories below threshold exceeds the authorized maximum, small categories are regrouped until valid
+      if (nbExpectedColumnsBelowThreshold > maxNbColumnsBelowThreshold){
+
+        // Identified key that holds minimum value
+        val expectedMin: (String, Double) = expected.minBy(e => e._2)
+        val sampleMinValue : Double = sample.getOrElse(expectedMin._1, 0)
+
+        // Remove smallest category
+        expected.remove(expectedMin._1)
+        sample.remove(expectedMin._1)
+
+        // Add value of smallest category to second smallest category
+        val expectedSecondMin = expected.minBy(e => e._2)
+        val sampleSecondMinValue : Double = sample.getOrElse(expectedSecondMin._1, 0)
+
+        expected.update(expectedSecondMin._1, expectedSecondMin._2 + expectedMin._2 )
+        sample.update(expectedSecondMin._1, sampleMinValue + sampleSecondMinValue )
+
+        // Recursively call function until mappings are valid
+        regroupCategories(sample, expected, absThresholdYates, percThresholdYates, absThresholdCochran)
+      } else {
+        // In case the mappings are valid the original mappings are returned
+        (sample, expected)
+      }
+    }
+  }
+
+
+  /** Runs chi-square test on two mappings
+   *
+   * @param sample              the mapping between categories(keys) and counts(values) of the observed sample
+   * @param expected            the mapping between categories(keys) and counts(values) of the expected baseline
+   * @return ChiSqTestResult    returns the chi-square test result object (contains both statistics and p-value)
+   *
+   */
+  private[this] def chiSquareTest(
+                                   sample: scala.collection.mutable.Map[String, Double],
+                                   expected: scala.collection.mutable.Map[String, Double])
+  : ChiSqTestResult = {
+
+    var sampleArray = Array[Double]()
+    var expectedArray = Array[Double]()
+
+    expected.keySet.foreach { key =>
+      val cdf1: Double = sample.getOrElse(key, 0.0)
+      val cdf2: Double = expected(key)
+      sampleArray = sampleArray :+ cdf1
+      expectedArray = expectedArray :+ cdf2
+    }
+
+    val vecSample: Vector = Vectors.dense(sampleArray)
+    val vecExpected: Vector = Vectors.dense(expectedArray)
+
+    Statistics.chiSqTest(vecSample, vecExpected)
+  }
+
+  /** Calculate distance of categorical profiles based on L-Infinity Distance */
+  private[this] def categoricalLInfinityDistance(
+    sample1: scala.collection.mutable.Map[String, Long],
+    sample2: scala.collection.mutable.Map[String, Long],
+    correctForLowNumberOfSamples: Boolean = false,
+    alpha: Option[Double])
+  : Double = {
+    var n = 0.0
+    var m = 0.0
+    sample1.keySet.foreach { key =>
+      n += sample1(key)
+    }
+    sample2.keySet.foreach { key =>
+      m += sample2(key)
+    }
+    val combinedKeys = sample1.keySet.union(sample2.keySet)
+    var linfSimple = 0.0
+
+    combinedKeys.foreach { key =>
+      val cdf1 = sample1.getOrElse(key, 0L) / n
+      val cdf2 = sample2.getOrElse(key, 0L) / m
+      val cdfDiff = Math.abs(cdf1 - cdf2)
+      linfSimple = Math.max(linfSimple, cdfDiff)
+    }
+    selectMetrics(linfSimple, n, m, correctForLowNumberOfSamples, alpha)
+  }
 
   /** Select which metrics to compute (linf_simple or linf_robust)
    *  based on whether samples are enough */
@@ -73,14 +280,20 @@ object Distance {
      linfSimple: Double,
      n: Double,
      m: Double,
-     correctForLowNumberOfSamples: Boolean = false)
+     correctForLowNumberOfSamples: Boolean = false,
+     alpha: Option[Double])
    : Double = {
      if (correctForLowNumberOfSamples) {
        linfSimple
      } else {
        // This formula is based on  “Two-sample Kolmogorov–Smirnov test"
        // Reference: https://en.m.wikipedia.org/wiki/Kolmogorov%E2%80%93Smirnov_test
-       val linfRobust = Math.max(0.0, linfSimple - 1.8 * Math.sqrt((n + m) / (n * m)))
+
+       val cAlpha : Double =  alpha match {
+         case Some(a)  => Math.sqrt(-Math.log(a/2) * 1/2)
+         case None => defaultCAlpha
+       }
+       val linfRobust = Math.max(0.0, linfSimple - cAlpha * Math.sqrt((n + m) / (n * m)))
        linfRobust
      }
    }

--- a/src/main/scala/com/amazon/deequ/analyzers/Histogram.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Histogram.scala
@@ -42,7 +42,8 @@ case class Histogram(
     column: String,
     binningUdf: Option[UserDefinedFunction] = None,
     maxDetailBins: Integer = Histogram.MaximumAllowedDetailBins,
-    where: Option[String] = None)
+    where: Option[String] = None,
+    computeFrequenciesAsRatio: Boolean = true)
   extends Analyzer[FrequenciesAndNumRows, HistogramMetric]
   with FilterableAnalyzer {
 
@@ -56,7 +57,11 @@ case class Histogram(
   override def computeStateFrom(data: DataFrame): Option[FrequenciesAndNumRows] = {
 
     // TODO figure out a way to pass this in if its known before hand
-    val totalCount = data.count()
+    val totalCount = if (computeFrequenciesAsRatio) {
+      data.count()
+    } else {
+      1
+    }
 
     val frequencies = data
       .transform(filterOptional(where))

--- a/src/main/scala/com/amazon/deequ/analyzers/MaxLength.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/MaxLength.scala
@@ -27,12 +27,12 @@ case class MaxLength(column: String, where: Option[String] = None)
   with FilterableAnalyzer {
 
   override def aggregationFunctions(): Seq[Column] = {
-    max(length(conditionalSelection(column, where))).cast(DoubleType) :: Nil
+    max(criterion) :: Nil
   }
 
   override def fromAggregationResult(result: Row, offset: Int): Option[MaxState] = {
     ifNoNullsIn(result, offset) { _ =>
-      MaxState(result.getDouble(offset))
+      MaxState(result.getDouble(offset), Some(criterion))
     }
   }
 
@@ -41,4 +41,6 @@ case class MaxLength(column: String, where: Option[String] = None)
   }
 
   override def filterCondition: Option[String] = where
+
+  private def criterion: Column = length(conditionalSelection(column, where)).cast(DoubleType)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Maximum.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Maximum.scala
@@ -21,11 +21,13 @@ import org.apache.spark.sql.{Column, Row}
 import org.apache.spark.sql.functions.max
 import org.apache.spark.sql.types.{DoubleType, StructType}
 import Analyzers._
+import com.amazon.deequ.metrics.FullColumn
 
-case class MaxState(maxValue: Double) extends DoubleValuedState[MaxState] {
+case class MaxState(maxValue: Double, override val fullColumn: Option[Column] = None)
+  extends DoubleValuedState[MaxState] with FullColumn {
 
   override def sum(other: MaxState): MaxState = {
-    MaxState(math.max(maxValue, other.maxValue))
+    MaxState(math.max(maxValue, other.maxValue), sum(fullColumn, other.fullColumn))
   }
 
   override def metricValue(): Double = {

--- a/src/main/scala/com/amazon/deequ/analyzers/catalyst/DeequFunctions.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/catalyst/DeequFunctions.scala
@@ -17,7 +17,6 @@
 package org.apache.spark.sql
 
 
-import com.amazon.deequ.analyzers.KLLSketch
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateFunction, StatefulApproxQuantile, StatefulHyperloglogPlus}
 import org.apache.spark.sql.catalyst.expressions.Literal
 

--- a/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
@@ -79,7 +79,7 @@ object AnalysisRunner {
   }
 
   /**
-    * Compute the metrics from the analyzers configured in the analyis
+    * Compute the metrics from the analyzers configured in the analysis
     *
     * @param data data on which to operate
     * @param analyzers the analyzers to run
@@ -169,7 +169,7 @@ object AnalysisRunner {
     // TODO this can be further improved, we can get the number of rows from other metrics as well
     // TODO we could also insert an extra Size() computation if we have to scan the data anyways
     var numRowsOfData = nonGroupedMetrics.metric(Size()).collect {
-      case DoubleMetric(_, _, _, Success(value: Double)) => value.toLong
+      case DoubleMetric(_, _, _, Success(value: Double), None) => value.toLong
     }
 
     var groupedMetrics = AnalyzerContext.empty

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -63,6 +63,18 @@ case class Check(
   description: String,
   private[deequ] val constraints: Seq[Constraint] = Seq.empty) {
 
+  /**
+   * Returns the name of the columns where each Constraint puts row-level results, if any
+   *
+   */
+  def getRowLevelConstraintColumnNames(): Seq[String] = {
+    constraints.flatMap(c => {
+      c match {
+        case c: RowLevelConstraint => Some(c.getColumnName)
+        case _ => None
+      }
+    })
+  }
 
   /**
     * Returns a new Check object with the given constraint added to the constraints list.

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -357,7 +357,7 @@ case class Check(
     : CheckWithLastConstraintFilterable = {
 
     addFilterableConstraint { filter =>
-      histogramBinConstraint(column, assertion, binningUdf, maxBins, filter, hint) }
+      histogramBinConstraint(column, assertion, binningUdf, maxBins, filter, hint, computeFrequenciesAsRatio = false) }
   }
 
   /**

--- a/src/main/scala/com/amazon/deequ/comparison/ComparisonResult.scala
+++ b/src/main/scala/com/amazon/deequ/comparison/ComparisonResult.scala
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.comparison
+
+sealed trait ComparisonResult
+case class ComparisonFailed(errorMessage: String) extends ComparisonResult
+case class ComparisonSucceeded() extends ComparisonResult

--- a/src/main/scala/com/amazon/deequ/comparison/DataSynchronization.scala
+++ b/src/main/scala/com/amazon/deequ/comparison/DataSynchronization.scala
@@ -1,0 +1,169 @@
+/**
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.comparison
+
+import org.apache.spark.sql.{Column, DataFrame}
+import org.apache.spark.sql.functions.col
+
+/**
+ * Compare two DataFrames 1 to 1 with specific columns inputted by the customer.
+ *
+ * This is an experimental utility.
+ *
+ * For example, consider the two dataframes below:
+ *
+ * DataFrame A:
+ *
+ * |--ID--|---City---|--State--|
+ * |  1   | New York |    NY   |
+ * |  2   | Chicago  |    IL   |
+ * |  3   | Boston   |    MA   |
+ *
+ * DataFrame B:
+ *
+ * |--CityID--|---City---|-----State-----|
+ * |     1    | New York |    New York   |
+ * |     2    | Chicago  |    Illinois   |
+ * |     3    | Boston   | Massachusetts |
+ *
+ * Note that dataframe B is almost equal to dataframe B, but for two things:
+ *  1) The ID column in B is called CityID
+ *  2) The State column in B is the full name, whereas A uses the abbreviation.
+ *
+ * To compare A with B, for just the City column, we can use the function like the following.
+ *
+ * DataSynchronization.columnMatch(
+ *   ds1 = dfA,
+ *   ds2 = dfB,
+ *   colKeyMap = Map("ID" -> "CityID"), // Mapping for the key columns
+ *   compCols = Map("City" -> "City"), // Mapping for the columns that should be compared
+ *   assertion = _ > 0.8
+ * )
+ *
+ * This will evaluate to true since the City column matches in A and B for the corresponding ID.
+ *
+ * To compare A with B, for all columns, we can use the function like the following.
+ *
+ * DataSynchronization.columnMatch(
+ *   ds1 = dfA,
+ *   ds2 = dfB,
+ *   colKeyMap = Map("ID" -> "CityID"), // Mapping for the key columns
+ *   assertion = _ > 0.8
+ * )
+ *
+ * This will evaluate to false. The city column will match, but the state column will not.
+ */
+
+object DataSynchronization {
+  /**
+   * This will evaluate to false. The city column will match, but the state column will not.
+   *
+   * @param ds1                The first data set which the customer will select for comparison.
+   * @param ds2                The second data set which the customer will select for comparison.
+   * @param colKeyMap          A map of columns to columns used for joining the two datasets.
+   *                           The keys in the map are composite key forming columns from the first dataset.
+   *                           The values for each key is the equivalent column from the second dataset.
+   * @param assertion          A function which accepts the match ratio and returns a Boolean.
+   * @return ComparisonResult  An appropriate subtype of ComparisonResult is returned.
+   *                           Once all preconditions are met, we calculate the ratio of the rows
+   *                           that match and we run the assertion on that outcome.
+   *                           The response is then converted to ComparisonResult.
+   */
+  def columnMatch(ds1: DataFrame,
+                  ds2: DataFrame,
+                  colKeyMap: Map[String, String],
+                  assertion: Double => Boolean): ComparisonResult = {
+    if (areKeyColumnsValid(ds1, ds2, colKeyMap)) {
+      val colsDS1 = ds1.columns.filterNot(x => colKeyMap.keys.toSeq.contains(x)).sorted
+      val colsDS2 = ds2.columns.filterNot(x => colKeyMap.values.toSeq.contains(x)).sorted
+
+      if (!(colsDS1 sameElements colsDS2)) {
+        ComparisonFailed("Non key columns in the given data frames do not match.")
+      } else {
+        val mergedMaps = colKeyMap ++ colsDS1.map(x => x -> x).toMap
+        finalAssertion(ds1, ds2, mergedMaps, assertion)
+      }
+    } else {
+      ComparisonFailed("Provided key map not suitable for given data frames.")
+    }
+  }
+
+  /**
+   * This will evaluate to false. The city column will match, but the state column will not.
+   *
+   * @param ds1                The first data set which the customer will select for comparison.
+   * @param ds2                The second data set which the customer will select for comparison.
+   * @param colKeyMap          A map of columns to columns used for joining the two datasets.
+   *                           The keys in the map are composite key forming columns from the first dataset.
+   *                           The values for each key is the equivalent column from the second dataset.
+   * @param compCols           A map of columns to columns which we will check for equality, post joining.
+   * @param assertion          A function which accepts the match ratio and returns a Boolean.
+   * @return ComparisonResult  An appropriate subtype of ComparisonResult is returned.
+   *                           Once all preconditions are met, we calculate the ratio of the rows
+   *                           that match and we run the assertion on that outcome.
+   *                           The response is then converted to ComparisonResult.
+   */
+  def columnMatch(ds1: DataFrame,
+                  ds2: DataFrame,
+                  colKeyMap: Map[String, String],
+                  compCols: Map[String, String],
+                  assertion: Double => Boolean): ComparisonResult = {
+    if (areKeyColumnsValid(ds1, ds2, colKeyMap)) {
+      val mergedMaps = colKeyMap ++ compCols
+      finalAssertion(ds1, ds2, mergedMaps, assertion)
+    } else {
+      ComparisonFailed("Provided key map not suitable for given data frames.")
+    }
+  }
+
+  private def areKeyColumnsValid(ds1: DataFrame,
+                                 ds2: DataFrame,
+                                 colKeyMap: Map[String, String]): Boolean = {
+    // We verify that the key columns provided form a valid primary/composite key.
+    // To achieve this, we group the dataframes and compare their count with the original count.
+    // If the key columns provided are valid, then the two columns should match.
+    val ds1Unique = ds1.groupBy(colKeyMap.keys.toSeq.map(col): _*).count()
+    val ds2Unique = ds2.groupBy(colKeyMap.values.toSeq.map(col): _*).count()
+    (ds1Unique.count() == ds1.count()) && (ds2Unique.count() == ds2.count())
+  }
+
+  private def finalAssertion(ds1: DataFrame,
+                             ds2: DataFrame,
+                             mergedMaps: Map[String, String],
+                             assertion: Double => Boolean): ComparisonResult = {
+
+    val ds1Count = ds1.count()
+    val ds2Count = ds2.count()
+
+    if (ds1Count != ds2Count) {
+      ComparisonFailed(s"The row counts of the two data frames do not match.")
+    } else {
+      val joinExpression: Column = mergedMaps
+        .map { case (col1, col2) => ds1(col1) === ds2(col2)}
+        .reduce((e1, e2) => e1 && e2)
+
+      val joined = ds1.join(ds2, joinExpression, "inner")
+      val ratio = joined.count().toDouble / ds1Count
+
+      if (assertion(ratio)) {
+        ComparisonSucceeded()
+      } else {
+        ComparisonFailed(s"Value: $ratio does not meet the constraint requirement.")
+      }
+    }
+  }
+}

--- a/src/main/scala/com/amazon/deequ/comparison/ReferentialIntegrity.scala
+++ b/src/main/scala/com/amazon/deequ/comparison/ReferentialIntegrity.scala
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.comparison
+
+import org.apache.spark.sql.DataFrame
+
+object ReferentialIntegrity {
+
+  /**
+   * Checks to what extent a column from a DataFrame is a subset of another column
+   * from another DataFrame.
+   *
+   * This is an experimental utility.
+   *
+   * @param primary      The primary data set which contains the column which the customer
+   *                     will select the column to do the Referential Integrity check.
+   * @param primaryCol   The name of the column selected from the primary data set.
+   * @param reference    The reference data set which contains the possible values for the column
+   *                     from the primary dataset.
+   * @param referenceCol The name of the column selected from the reference data set, which
+   *                     contains those values.
+   * @param assertion    A function which accepts the match ratio and returns a Boolean.
+   *
+   * @return Boolean   Internally we calculate the referential integrity as a
+   *                   ratio, and we run the assertion on that outcome
+   *                   that ends up being a true or false response.
+   */
+
+  def subsetCheck(primary: DataFrame,
+                  primaryCol: String,
+                  reference: DataFrame,
+                  referenceCol: String,
+                  assertion: Double => Boolean): ComparisonResult = {
+    val primaryCount = primary.count()
+
+    if (!primary.columns.contains(primaryCol)) {
+      ComparisonFailed(s"Column $primaryCol does not exist in primary data frame.")
+    } else if (!reference.columns.contains(referenceCol)) {
+      ComparisonFailed(s"Column $referenceCol does not exist in reference data frame.")
+    } else if (primaryCount == 0) {
+      ComparisonFailed(s"Primary data frame contains no data.")
+    } else {
+      val primarySparkCol = primary.select(primaryCol)
+      val referenceSparkCol = reference.select(referenceCol)
+      val mismatchCount = primarySparkCol.except(referenceSparkCol).count()
+
+      val ratio = if (mismatchCount == 0) 1.0 else (primaryCount - mismatchCount).toDouble / primaryCount
+
+      if (assertion(ratio)) {
+        ComparisonSucceeded()
+      } else {
+        ComparisonFailed(s"Value: $ratio does not meet the constraint requirement.")
+      }
+    }
+  }
+}

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -158,10 +158,11 @@ object Constraint {
       binningUdf: Option[UserDefinedFunction] = None,
       maxBins: Integer = Histogram.MaximumAllowedDetailBins,
       where: Option[String] = None,
-      hint: Option[String] = None)
+      hint: Option[String] = None,
+      computeFrequenciesAsRatio: Boolean = true)
     : Constraint = {
 
-    val histogram = Histogram(column, binningUdf, maxBins, where)
+    val histogram = Histogram(column, binningUdf, maxBins, where, computeFrequenciesAsRatio)
 
     val constraint = AnalysisBasedConstraint[FrequenciesAndNumRows, Distribution, Long](
       histogram, assertion, Some(_.numberOfBins), hint)

--- a/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
+++ b/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
@@ -17,6 +17,7 @@
 package com.amazon.deequ.KLL
 
 import com.amazon.deequ.SparkContextSpec
+import com.amazon.deequ.analyzers.Distance.{ChisquareMethod, LInfinityMethod}
 import com.amazon.deequ.analyzers.{Distance, QuantileNonSample}
 import com.amazon.deequ.utils.FixtureSupport
 import org.scalatest.{Matchers, WordSpec}
@@ -73,4 +74,92 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
       "f" -> 11L, "a" -> 20L, "c" -> 25L, "d" -> 10L, "e" -> 10L)
     assert(Distance.categoricalDistance(sample1, sample2) == 0.0)
   }
+
+
+  "Categorial distance should compute correct linf_robust with different alpha value .003" in {
+    val sample1 = scala.collection.mutable.Map(
+      "a" -> 207L, "b" -> 20L, "c" -> 25L, "d" -> 14L, "e" -> 25L, "g" -> 13L)
+    val sample2 = scala.collection.mutable.Map(
+      "a" -> 22L, "b" -> 20L, "c" -> 25L, "d" -> 12L, "e" -> 13L, "f" -> 15L)
+    assert(Distance.categoricalDistance(sample1, sample2,  method = LInfinityMethod(alpha = Some(0.003))) == 0.2726338046550349)
+  }
+
+  "Categorial distance should compute correct linf_robust with different alpha value .1" in {
+    val sample1 = scala.collection.mutable.Map(
+      "a" -> 207L, "b" -> 20L, "c" -> 25L, "d" -> 14L, "e" -> 25L, "g" -> 13L)
+    val sample2 = scala.collection.mutable.Map(
+      "a" -> 22L, "b" -> 20L, "c" -> 25L, "d" -> 12L, "e" -> 13L, "f" -> 15L)
+    assert(Distance.categoricalDistance(sample1, sample2, method = LInfinityMethod(alpha = Some(0.1))) == 0.33774199396969184)
+  }
+
+
+  // Tests using chi-square method for categorical variables
+  "Categorical distance should compute correct chisquare stats with missing bin values" in {
+    val sample1 = scala.collection.mutable.Map(
+      "a" -> 207L, "b" -> 20L, "c" -> 25L, "d" -> 14L, "e" -> 25L, "g" -> 13L)
+    val sample2 = scala.collection.mutable.Map(
+      "a" -> 223L, "b" -> 20L, "c" -> 25L, "d" -> 12L, "e" -> 13L, "f" -> 15L)
+
+    assert(Distance.categoricalDistance(sample1, sample2, correctForLowNumberOfSamples = true, method = ChisquareMethod()) == 28.175042782458068)
+  }
+
+
+
+  "Categorical distance should compute correct chisquare test with missing bin values" in {
+    val sample1 = scala.collection.mutable.Map(
+      "a" -> 207L, "b" -> 20L, "c" -> 25L, "d" -> 14L, "e" -> 25L, "g" -> 13L)
+    val sample2 = scala.collection.mutable.Map(
+      "a" -> 223L, "b" -> 20L, "c" -> 25L, "d" -> 12L, "e" -> 13L, "f" -> 15L)
+    assert(Distance.categoricalDistance(sample1, sample2, method = ChisquareMethod()) ==  3.3640191298478506E-5)
+  }
+
+
+  "Categorical distance should compute correct chisquare test" in {
+    val sample1 = scala.collection.mutable.Map(
+      "a" -> 207L, "b" -> 20L, "c" -> 25L, "d" -> 14L, "e" -> 25L)
+    val sample2 = scala.collection.mutable.Map(
+      "a" -> 223L, "b" -> 20L, "c" -> 25L, "d" -> 12L, "e" -> 13L)
+    assert(Distance.categoricalDistance(sample1, sample2, method = ChisquareMethod()) == 0.013227994814265176)
+  }
+
+  "Categorical distance should compute correct chisquare distance (low samples) with regrouping 2 categories (yates) after normalizing" in {
+    val sample1 = scala.collection.mutable.Map(
+      "a" -> 100L, "b" -> 20L, "c" -> 25L, "d" -> 10L, "e" -> 5L, "f" -> 2L)
+    val sample2 = scala.collection.mutable.Map(
+      "a" -> 100L, "b" -> 22L, "c" -> 25L, "d" -> 5L, "e" -> 13L, "f" -> 2L)
+    assert(Distance.categoricalDistance(sample1, sample2, correctForLowNumberOfSamples = true, method = ChisquareMethod()) == 8.789790456457125)
+  }
+
+  "Categorical distance should compute correct chisquare distance (low samples) with regrouping (yates)" in {
+    val baseline = scala.collection.mutable.Map(
+      "a" -> 100L, "b" -> 40L, "c" -> 30L,"e" -> 4L)
+    val sample = scala.collection.mutable.Map(
+      "a" -> 100L, "b" -> 40L, "c" -> 30L,"d" -> 10L)
+    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = ChisquareMethod()) == 0.38754325259515626)
+  }
+
+  "Categorical distance should compute correct chisquare distance (low samples) with regrouping 2 categories (yates)" in {
+    val baseline = scala.collection.mutable.Map(
+      "a" -> 100L, "b" -> 4L, "c" -> 3L, "d" -> 34L)
+    val sample = scala.collection.mutable.Map(
+      "a" -> 100L, "b" -> 4L, "c" -> 3L, "d" -> 27L)
+    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = ChisquareMethod()) == 1.1507901668129925)
+  }
+
+  "Categorical distance should compute correct chisquare distance (low samples) with regrouping ( sum of 2 grouped categories is below threshold, but small categories represent less than 20%)  (yates)" in {
+    val baseline = scala.collection.mutable.Map(
+      "a" -> 100L, "b" -> 2L, "c" -> 1L, "d" -> 34L,"e" -> 20L,"f" -> 20L,"g" -> 20L,"h" -> 20L)
+    val sample = scala.collection.mutable.Map(
+      "a" -> 100L, "b" -> 4L, "c" -> 3L, "d" -> 27L,"e" -> 20L,"f" -> 20L,"g" -> 20L,"h" -> 20L)
+    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = ChisquareMethod()) == 6.827423492761593)
+  }
+
+  "Categorical distance should compute correct chisquare distance (low samples) with regrouping ( dimensions after regrouping are too small)" in {
+    val baseline = scala.collection.mutable.Map(
+      "a" -> 100L, "b" -> 4L, "c" -> 3L)
+    val sample = scala.collection.mutable.Map(
+      "a" -> 100L, "b" -> 4L, "c" -> 3L)
+    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = ChisquareMethod()).isNaN)
+  }
+
 }

--- a/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
+++ b/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
@@ -20,25 +20,27 @@ import com.amazon.deequ.SparkContextSpec
 import com.amazon.deequ.analyzers.Distance.{ChisquareMethod, LInfinityMethod}
 import com.amazon.deequ.analyzers.{Distance, QuantileNonSample}
 import com.amazon.deequ.utils.FixtureSupport
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.WordSpec
 
-class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
+class KLLDistanceTest extends WordSpec with SparkContextSpec
   with FixtureSupport{
 
   "KLL distance calculator should compute correct linf_simple" in {
-    var sample1 = new QuantileNonSample[Double](4, 0.64)
-    var sample2 = new QuantileNonSample[Double](4, 0.64)
+    val sample1 = new QuantileNonSample[Double](4, 0.64)
+    val sample2 = new QuantileNonSample[Double](4, 0.64)
     sample1.reconstruct(4, 0.64, Array(Array(1, 2, 3, 4)))
     sample2.reconstruct(4, 0.64, Array(Array(2, 3, 4, 5)))
-    assert(Distance.numericalDistance(sample1, sample2, true) == 0.25)
+    val distance = Distance.numericalDistance(sample1, sample2, correctForLowNumberOfSamples = true)
+    assert(distance == 0.25)
   }
 
   "KLL distance calculator should compute correct linf_robust" in {
-    var sample1 = new QuantileNonSample[Double](4, 0.64)
-    var sample2 = new QuantileNonSample[Double](4, 0.64)
+    val sample1 = new QuantileNonSample[Double](4, 0.64)
+    val sample2 = new QuantileNonSample[Double](4, 0.64)
     sample1.reconstruct(4, 0.64, Array(Array(1, 2, 3, 4)))
     sample2.reconstruct(4, 0.64, Array(Array(2, 3, 4, 5)))
-    assert(Distance.numericalDistance(sample1, sample2) == 0.0)
+    val distance = Distance.numericalDistance(sample1, sample2)
+    assert(distance == 0.0)
   }
 
   "Categorial distance should compute correct linf_simple" in {
@@ -46,8 +48,8 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
       "a" -> 10L, "b" -> 20L, "c" -> 25L, "d" -> 10L, "e" -> 5L)
     val sample2 = scala.collection.mutable.Map(
       "a" -> 11L, "b" -> 20L, "c" -> 25L, "d" -> 10L, "e" -> 10L)
-    assert(Distance.categoricalDistance(sample1,
-      sample2, true) == 0.06015037593984962)
+    val distance = Distance.categoricalDistance(sample1, sample2, correctForLowNumberOfSamples = true)
+    assert(distance == 0.06015037593984962)
   }
 
   "Categorial distance should compute correct linf_robust" in {
@@ -55,7 +57,8 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
       "a" -> 10L, "b" -> 20L, "c" -> 25L, "d" -> 10L, "e" -> 5L)
     val sample2 = scala.collection.mutable.Map(
       "a" -> 11L, "b" -> 20L, "c" -> 25L, "d" -> 10L, "e" -> 10L)
-    assert(Distance.categoricalDistance(sample1, sample2) == 0.0)
+    val distance = Distance.categoricalDistance(sample1, sample2)
+    assert(distance == 0.0)
   }
 
   "Categorial distance should compute correct linf_simple with different bin value" in {
@@ -63,8 +66,8 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
       "a" -> 10L, "b" -> 20L, "c" -> 25L, "d" -> 10L, "e" -> 5L)
     val sample2 = scala.collection.mutable.Map(
       "f" -> 11L, "a" -> 20L, "c" -> 25L, "d" -> 10L, "e" -> 10L)
-    assert(Distance.categoricalDistance(sample1,
-      sample2, true) == 0.2857142857142857)
+    val distance = Distance.categoricalDistance(sample1, sample2, correctForLowNumberOfSamples = true)
+    assert(distance == 0.2857142857142857)
   }
 
   "Categorial distance should compute correct linf_robust with different bin value" in {
@@ -72,16 +75,17 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
       "a" -> 10L, "b" -> 20L, "c" -> 25L, "d" -> 10L, "e" -> 5L)
     val sample2 = scala.collection.mutable.Map(
       "f" -> 11L, "a" -> 20L, "c" -> 25L, "d" -> 10L, "e" -> 10L)
-    assert(Distance.categoricalDistance(sample1, sample2) == 0.0)
+    val distance = Distance.categoricalDistance(sample1, sample2)
+    assert(distance == 0.0)
   }
-
 
   "Categorial distance should compute correct linf_robust with different alpha value .003" in {
     val sample1 = scala.collection.mutable.Map(
       "a" -> 207L, "b" -> 20L, "c" -> 25L, "d" -> 14L, "e" -> 25L, "g" -> 13L)
     val sample2 = scala.collection.mutable.Map(
       "a" -> 22L, "b" -> 20L, "c" -> 25L, "d" -> 12L, "e" -> 13L, "f" -> 15L)
-    assert(Distance.categoricalDistance(sample1, sample2,  method = LInfinityMethod(alpha = Some(0.003))) == 0.2726338046550349)
+    val distance = Distance.categoricalDistance(sample1, sample2, method = LInfinityMethod(alpha = Some(0.003)))
+    assert(distance == 0.2726338046550349)
   }
 
   "Categorial distance should compute correct linf_robust with different alpha value .1" in {
@@ -89,9 +93,9 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
       "a" -> 207L, "b" -> 20L, "c" -> 25L, "d" -> 14L, "e" -> 25L, "g" -> 13L)
     val sample2 = scala.collection.mutable.Map(
       "a" -> 22L, "b" -> 20L, "c" -> 25L, "d" -> 12L, "e" -> 13L, "f" -> 15L)
-    assert(Distance.categoricalDistance(sample1, sample2, method = LInfinityMethod(alpha = Some(0.1))) == 0.33774199396969184)
+    val distance = Distance.categoricalDistance(sample1, sample2, method = LInfinityMethod(alpha = Some(0.1)))
+    assert(distance == 0.33774199396969184)
   }
-
 
   // Tests using chi-square method for categorical variables
   "Categorical distance should compute correct chisquare stats with missing bin values" in {
@@ -99,67 +103,81 @@ class KLLDistanceTest extends WordSpec with Matchers with SparkContextSpec
       "a" -> 207L, "b" -> 20L, "c" -> 25L, "d" -> 14L, "e" -> 25L, "g" -> 13L)
     val sample2 = scala.collection.mutable.Map(
       "a" -> 223L, "b" -> 20L, "c" -> 25L, "d" -> 12L, "e" -> 13L, "f" -> 15L)
-
-    assert(Distance.categoricalDistance(sample1, sample2, correctForLowNumberOfSamples = true, method = ChisquareMethod()) == 28.175042782458068)
+    val distance = Distance.categoricalDistance(
+      sample1, sample2, correctForLowNumberOfSamples = true, method = ChisquareMethod())
+    assert(distance == 28.175042782458068)
   }
-
-
 
   "Categorical distance should compute correct chisquare test with missing bin values" in {
     val sample1 = scala.collection.mutable.Map(
       "a" -> 207L, "b" -> 20L, "c" -> 25L, "d" -> 14L, "e" -> 25L, "g" -> 13L)
     val sample2 = scala.collection.mutable.Map(
       "a" -> 223L, "b" -> 20L, "c" -> 25L, "d" -> 12L, "e" -> 13L, "f" -> 15L)
-    assert(Distance.categoricalDistance(sample1, sample2, method = ChisquareMethod()) ==  3.3640191298478506E-5)
+    val distance = Distance.categoricalDistance(sample1, sample2, method = ChisquareMethod())
+    assert(distance ==  3.3640191298478506E-5)
   }
-
 
   "Categorical distance should compute correct chisquare test" in {
     val sample1 = scala.collection.mutable.Map(
       "a" -> 207L, "b" -> 20L, "c" -> 25L, "d" -> 14L, "e" -> 25L)
     val sample2 = scala.collection.mutable.Map(
       "a" -> 223L, "b" -> 20L, "c" -> 25L, "d" -> 12L, "e" -> 13L)
-    assert(Distance.categoricalDistance(sample1, sample2, method = ChisquareMethod()) == 0.013227994814265176)
+    val distance = Distance.categoricalDistance(sample1, sample2, method = ChisquareMethod())
+    assert(distance == 0.013227994814265176)
   }
 
-  "Categorical distance should compute correct chisquare distance (low samples) with regrouping 2 categories (yates) after normalizing" in {
+  "Categorical distance should compute correct chisquare distance (low samples) " +
+    "with regrouping 2 categories (yates) after normalizing" in {
     val sample1 = scala.collection.mutable.Map(
       "a" -> 100L, "b" -> 20L, "c" -> 25L, "d" -> 10L, "e" -> 5L, "f" -> 2L)
     val sample2 = scala.collection.mutable.Map(
       "a" -> 100L, "b" -> 22L, "c" -> 25L, "d" -> 5L, "e" -> 13L, "f" -> 2L)
-    assert(Distance.categoricalDistance(sample1, sample2, correctForLowNumberOfSamples = true, method = ChisquareMethod()) == 8.789790456457125)
+    val distance = Distance.categoricalDistance(
+      sample1, sample2, correctForLowNumberOfSamples = true, method = ChisquareMethod())
+    assert(distance == 8.789790456457125)
   }
 
   "Categorical distance should compute correct chisquare distance (low samples) with regrouping (yates)" in {
     val baseline = scala.collection.mutable.Map(
-      "a" -> 100L, "b" -> 40L, "c" -> 30L,"e" -> 4L)
+      "a" -> 100L, "b" -> 40L, "c" -> 30L, "e" -> 4L)
     val sample = scala.collection.mutable.Map(
-      "a" -> 100L, "b" -> 40L, "c" -> 30L,"d" -> 10L)
-    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = ChisquareMethod()) == 0.38754325259515626)
+      "a" -> 100L, "b" -> 40L, "c" -> 30L, "d" -> 10L)
+    val distance = Distance.categoricalDistance(
+      sample, baseline, correctForLowNumberOfSamples = true, method = ChisquareMethod())
+    assert(distance == 0.38754325259515626)
   }
 
-  "Categorical distance should compute correct chisquare distance (low samples) with regrouping 2 categories (yates)" in {
+  "Categorical distance should compute correct chisquare distance (low samples) " +
+    "with regrouping 2 categories (yates)" in {
     val baseline = scala.collection.mutable.Map(
       "a" -> 100L, "b" -> 4L, "c" -> 3L, "d" -> 34L)
     val sample = scala.collection.mutable.Map(
       "a" -> 100L, "b" -> 4L, "c" -> 3L, "d" -> 27L)
-    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = ChisquareMethod()) == 1.1507901668129925)
+    val distance = Distance.categoricalDistance(
+      sample, baseline, correctForLowNumberOfSamples = true, method = ChisquareMethod())
+    assert(distance == 1.1507901668129925)
   }
 
-  "Categorical distance should compute correct chisquare distance (low samples) with regrouping ( sum of 2 grouped categories is below threshold, but small categories represent less than 20%)  (yates)" in {
+  "Categorical distance should compute correct chisquare distance (low samples) " +
+    "with regrouping " +
+    "(sum of 2 grouped categories is below threshold, but small categories represent less than 20%) (yates)" in {
     val baseline = scala.collection.mutable.Map(
-      "a" -> 100L, "b" -> 2L, "c" -> 1L, "d" -> 34L,"e" -> 20L,"f" -> 20L,"g" -> 20L,"h" -> 20L)
+      "a" -> 100L, "b" -> 2L, "c" -> 1L, "d" -> 34L, "e" -> 20L, "f" -> 20L, "g" -> 20L, "h" -> 20L)
     val sample = scala.collection.mutable.Map(
-      "a" -> 100L, "b" -> 4L, "c" -> 3L, "d" -> 27L,"e" -> 20L,"f" -> 20L,"g" -> 20L,"h" -> 20L)
-    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = ChisquareMethod()) == 6.827423492761593)
+      "a" -> 100L, "b" -> 4L, "c" -> 3L, "d" -> 27L, "e" -> 20L, "f" -> 20L, "g" -> 20L, "h" -> 20L)
+    val distance = Distance.categoricalDistance(
+      sample, baseline, correctForLowNumberOfSamples = true, method = ChisquareMethod())
+    assert(distance == 6.827423492761593)
   }
 
-  "Categorical distance should compute correct chisquare distance (low samples) with regrouping ( dimensions after regrouping are too small)" in {
+  "Categorical distance should compute correct chisquare distance (low samples) " +
+    "with regrouping ( dimensions after regrouping are too small)" in {
     val baseline = scala.collection.mutable.Map(
       "a" -> 100L, "b" -> 4L, "c" -> 3L)
     val sample = scala.collection.mutable.Map(
       "a" -> 100L, "b" -> 4L, "c" -> 3L)
-    assert(Distance.categoricalDistance(sample, baseline, correctForLowNumberOfSamples = true, method = ChisquareMethod()).isNaN)
+    val distance = Distance.categoricalDistance(
+      sample, baseline, correctForLowNumberOfSamples = true, method = ChisquareMethod())
+    assert(distance.isNaN)
   }
-
 }

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalysisTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalysisTest.scala
@@ -22,6 +22,7 @@ import com.amazon.deequ.metrics.{DoubleMetric, Entity}
 import com.amazon.deequ.utils.FixtureSupport
 import com.amazon.deequ.utils.AssertionUtils.TryUtils
 import org.apache.spark.sql.{DataFrame, Row}
+import org.scalatest.Inside.inside
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -122,8 +123,16 @@ class AnalysisTest extends AnyWordSpec with Matchers with SparkContextSpec with 
 
       assert(resultMetrics.size == analysis.analyzers.size)
 
-      resultMetrics should contain(DoubleMetric(Entity.Column, "MaxLength", "att1",
-        Success(4.0)))
+      // Partially check the max length metric - don't verify the full column content
+      val maxLengthMetric = resultMetrics.head
+      inside (maxLengthMetric) { case DoubleMetric(entity, name, instance, value, fullColumn) =>
+        entity shouldBe Entity.Column
+        name shouldBe "MaxLength"
+        instance shouldBe "att1"
+        value shouldBe Success(4.0)
+        fullColumn.isDefined shouldBe true
+      }
+
       resultMetrics should contain(DoubleMetric(Entity.Column, "MinLength", "att1",
         Success(0.0)))
     }

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
@@ -21,6 +21,7 @@ import com.amazon.deequ.analyzers.runners.{NoSuchColumnException, WrongColumnTyp
 import com.amazon.deequ.metrics.{Distribution, DistributionValue, DoubleMetric, Entity}
 import com.amazon.deequ.utils.AssertionUtils.TryUtils
 import com.amazon.deequ.utils.FixtureSupport
+import org.apache.spark.sql.Column
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions.{col, udf}
 import org.apache.spark.sql.types._
@@ -50,10 +51,12 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
 
       assert(Completeness("someMissingColumn").preconditions.size == 2,
         "should check column name availability")
-      assert(Completeness("att1").calculate(dfMissing) == DoubleMetric(Entity.Column,
-        "Completeness", "att1", Success(0.5)))
-      assert(Completeness("att2").calculate(dfMissing) == DoubleMetric(Entity.Column,
-        "Completeness", "att2", Success(0.75)))
+      val result1 = Completeness("att1").calculate(dfMissing)
+      assert(result1 == DoubleMetric(Entity.Column,
+        "Completeness", "att1", Success(0.5), result1.fullColumn))
+      val result2 = Completeness("att2").calculate(dfMissing)
+      assert(result2 == DoubleMetric(Entity.Column,
+        "Completeness", "att2", Success(0.75), result2.fullColumn))
 
     }
 
@@ -82,7 +85,7 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
       val dfMissing = getDfMissing(sparkSession)
 
       val result = Completeness("att1", Some("item IN ('1', '2')")).calculate(dfMissing)
-      assert(result == DoubleMetric(Entity.Column, "Completeness", "att1", Success(1.0)))
+      assert(result == DoubleMetric(Entity.Column, "Completeness", "att1", Success(1.0), result.fullColumn))
     }
 
   }

--- a/src/test/scala/com/amazon/deequ/analyzers/CompletenessTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/CompletenessTest.scala
@@ -1,0 +1,41 @@
+/**
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.analyzers
+
+import com.amazon.deequ.SparkContextSpec
+import com.amazon.deequ.metrics.DoubleMetric
+import com.amazon.deequ.metrics.FullColumn
+import com.amazon.deequ.utils.FixtureSupport
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class CompletenessTest extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport {
+
+  "Completeness" should {
+    "return row-level results for columns" in withSparkSession { session =>
+
+      val data = getDfWithStringColumns(session)
+
+      val completenessCountry = Completeness("Address Line 3")
+      val state = completenessCountry.computeStateFrom(data)
+      val metric: DoubleMetric with FullColumn = completenessCountry.computeMetricFrom(state)
+
+      data.withColumn("new", metric.fullColumn.get).collect().map(_.getAs[Boolean]("new")) shouldBe
+        Seq(true, true, true, true, false, true, true, false)
+    }
+  }
+}

--- a/src/test/scala/com/amazon/deequ/analyzers/DistinctnessTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/DistinctnessTest.scala
@@ -51,8 +51,10 @@ class DistinctnessTest extends AnyWordSpec with Matchers with SparkContextSpec w
 
       val distinctnessValue = numNonNullDistinct.toDouble / numberOfNonNullItems
 
-      val distinctness = new Check(CheckLevel.Error, "d1").hasDistinctness(Seq("att1"), almostEquals(_, distinctnessValue))
-      val countDistinct = new Check(CheckLevel.Error, "d2").hasNumberOfDistinctValues("att1", _ == numDistinct)
+      val distinctness = new Check(CheckLevel.Error, "d1")
+        .hasDistinctness(Seq("att1"), almostEquals(_, distinctnessValue))
+      val countDistinct = new Check(CheckLevel.Error, "d2")
+        .hasNumberOfDistinctValues("att1", _ == numDistinct)
 
       val suite = new VerificationSuite().onData(data).addCheck(distinctness).addCheck(countDistinct)
       val result = suite.run()

--- a/src/test/scala/com/amazon/deequ/analyzers/DistinctnessTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/DistinctnessTest.scala
@@ -1,0 +1,87 @@
+/**
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+package com.amazon.deequ.analyzers
+
+import com.amazon.deequ.SparkContextSpec
+import com.amazon.deequ.VerificationSuite
+import com.amazon.deequ.checks.Check
+import com.amazon.deequ.checks.CheckLevel
+import com.amazon.deequ.checks.CheckStatus
+import com.amazon.deequ.constraints.Constraint
+import com.amazon.deequ.dataFrameWithColumn
+import com.amazon.deequ.metrics.Distribution
+import com.amazon.deequ.metrics.DoubleMetric
+import com.amazon.deequ.metrics.HistogramMetric
+import com.amazon.deequ.metrics.Metric
+import com.amazon.deequ.utils.FixtureSupport
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions.lit
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class DistinctnessTest extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport {
+
+  def almostEquals(a: Double, b: Double, e: Double): Boolean = {
+    (a-b).abs < e
+  }
+
+  def almostEquals(a: Double, b: Double): Boolean = almostEquals(a, b, 0.01)
+
+  "Distinctness and CountDistinct" should {
+    "have different behaviors with regard to nulls" in withSparkSession {session =>
+      val data = getDfWithDistinctValues(session).select("att1")
+
+      val numDistinct = data.distinct().count() // 4 including the null
+      val numNonNullDistinct = data.na.drop().distinct().count() // 3 excluding the null
+
+      val numberOfNonNullItems = data.na.drop().count() // 5
+
+      val distinctnessValue = numNonNullDistinct.toDouble / numberOfNonNullItems
+
+      val distinctness = new Check(CheckLevel.Error, "d1").hasDistinctness(Seq("att1"), almostEquals(_, distinctnessValue))
+      val countDistinct = new Check(CheckLevel.Error, "d2").hasNumberOfDistinctValues("att1", _ == numDistinct)
+
+      val suite = new VerificationSuite().onData(data).addCheck(distinctness).addCheck(countDistinct)
+      val result = suite.run()
+      assert(result.status == CheckStatus.Success)
+    }
+  }
+
+  "DistinctValueCount" should {
+    "return the number of distinct values in a column without doing a full count" in withSparkSession { session =>
+      val data = getDfWithDistinctValues(session)
+      val dvCount1 = new Check(CheckLevel.Error, "d1").hasNumberOfDistinctValues("att1", _ == 4.0)
+
+      val result = new VerificationSuite().onData(data).addCheck(dvCount1).run()
+      assert(result.status == CheckStatus.Success)
+
+      val absoluteFrequencies = Map(
+        "a" -> 2.0,
+        "b" -> 2.0,
+        "c" -> 1.0,
+        Histogram.NullFieldReplacement -> 1.0
+      )
+
+      // result contains metrics for an absolute, not relative, frequencies
+      result.metrics.foreach(pair => {
+        val metric = pair._2.asInstanceOf[HistogramMetric]
+        val distribution: Map[String, Double] = metric.value.get.values.map(v => v._1 -> v._2.ratio)
+        assert(distribution == absoluteFrequencies)
+      })
+    }
+  }
+
+}

--- a/src/test/scala/com/amazon/deequ/analyzers/MaxLengthTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/MaxLengthTest.scala
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+package com.amazon.deequ.analyzers
+
+import com.amazon.deequ.SparkContextSpec
+import com.amazon.deequ.metrics.DoubleMetric
+import com.amazon.deequ.metrics.FullColumn
+import com.amazon.deequ.utils.FixtureSupport
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class MaxLengthTest extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport {
+
+  "MaxLength" should {
+    "return row-level results for non-null columns" in withSparkSession { session =>
+
+      val data = getDfWithStringColumns(session)
+
+      val countryLength = MaxLength("Country") // It's "India" in every row
+      val state: Option[MaxState] = countryLength.computeStateFrom(data)
+      val metric: DoubleMetric with FullColumn = countryLength.computeMetricFrom(state)
+
+      data.withColumn("new", metric.fullColumn.get)
+        .collect().map(_.getAs[Double]("new")) shouldBe Seq(5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0)
+    }
+
+    "return row-level results for null columns" in withSparkSession { session =>
+
+      val data = getEmptyColumnDataDf(session)
+
+      val addressLength = MaxLength("att3") // It's null in two rows
+      val state: Option[MaxState] = addressLength.computeStateFrom(data)
+      val metric: DoubleMetric with FullColumn = addressLength.computeMetricFrom(state)
+
+      data.withColumn("new", metric.fullColumn.get)
+        .collect().map(_.getAs[Double]("new")) shouldBe Seq(1.0, 1.0, 0.0, 1.0, 0.0, 1.0)
+    }
+
+    "return row-level results for blank strings" in withSparkSession { session =>
+
+      val data = getEmptyColumnDataDf(session)
+
+      val addressLength = MaxLength("att1") // It's empty strings
+      val state: Option[MaxState] = addressLength.computeStateFrom(data)
+      val metric: DoubleMetric with FullColumn = addressLength.computeMetricFrom(state)
+
+      data.withColumn("new", metric.fullColumn.get)
+        .collect().map(_.getAs[Double]("new")) shouldBe Seq(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    }
+  }
+
+}

--- a/src/test/scala/com/amazon/deequ/analyzers/NullHandlingTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/NullHandlingTests.scala
@@ -62,7 +62,8 @@ class NullHandlingTests extends AnyWordSpec
       val data = dataWithNullColumns(session)
 
       Size().computeStateFrom(data) shouldBe Some(NumMatches(8))
-      Completeness("stringCol").computeStateFrom(data) shouldBe Some(NumMatchesAndCount(0, 8))
+      val completeness = Completeness("stringCol")
+      completeness.computeStateFrom(data) shouldBe Some(NumMatchesAndCount(0, 8, Some(completeness.criterion)))
 
       Mean("numericCol").computeStateFrom(data) shouldBe None
       StandardDeviation("numericCol").computeStateFrom(data) shouldBe None

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -60,6 +60,10 @@ class CheckTest extends AnyWordSpec with Matchers with SparkContextSpec with Fix
       assertEvaluatesTo(check1, context, CheckStatus.Success)
       assertEvaluatesTo(check2, context, CheckStatus.Error)
       assertEvaluatesTo(check3, context, CheckStatus.Warning)
+
+      assert(check1.getRowLevelConstraintColumnNames() == Seq("Completeness-att1", "Completeness-att1"))
+      assert(check2.getRowLevelConstraintColumnNames() == Seq("Completeness-att2"))
+      assert(check3.getRowLevelConstraintColumnNames() == Seq("Completeness-att2"))
     }
 
     "return the correct check status for combined completeness" in

--- a/src/test/scala/com/amazon/deequ/comparison/DataSynchronizationTest.scala
+++ b/src/test/scala/com/amazon/deequ/comparison/DataSynchronizationTest.scala
@@ -1,0 +1,395 @@
+/**
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.comparison
+
+import com.amazon.deequ.SparkContextSpec
+import org.scalatest.wordspec.AnyWordSpec
+
+class DataSynchronizationTest extends AnyWordSpec with SparkContextSpec {
+
+  "Data Synchronization Test" should {
+
+    "match == 0.66 when id is colKey and name is compCols" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (4, "Helena", "TX"),
+        (5, "Nick", "FL"),
+        (6, "Molly", "TX")))
+      val testDS1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (4, "Helena", "TX"),
+        (5, "Helena", "FL"),
+        (7, "Megan", "TX")))
+      val testDS2 = rdd2.toDF("id", "name", "state")
+
+      val ds1 = testDS1
+      val ds2 = testDS2
+      val colKeyMap = Map("id" -> "id")
+      val compCols = Map("name" -> "name")
+      val assertion: Double => Boolean = _ >= 0.60
+
+      val result = (DataSynchronization.columnMatch(ds1, ds2, colKeyMap, compCols, assertion))
+      assert(result.isInstanceOf[ComparisonSucceeded])
+    }
+
+    "match == 0.83 when id is colKey and state is compCols" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (4, "Helena", "TX"),
+        (5, "Nick", "FL"),
+        (6, "Molly", "TX")))
+      val testDS1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (4, "Helena", "TX"),
+        (5, "Helena", "FL"),
+        (7, "Megan", "TX")))
+      val testDS2 = rdd2.toDF("id", "name", "state")
+
+      val ds1 = testDS1
+      val ds2 = testDS2
+      val colKeyMap = Map("id" -> "id")
+      val compCols = Map("state" -> "state")
+      val assertion: Double => Boolean = _ >= 0.80
+
+      val result = (DataSynchronization.columnMatch(ds1, ds2, colKeyMap, compCols, assertion))
+      assert(result.isInstanceOf[ComparisonSucceeded])
+    }
+
+    "return false because col name isn't unique" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (4, "Helena", "TX"),
+        (5, "Nick", "FL"),
+        (6, "Molly", "TX")))
+      val testDS1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (4, "Helena", "TX"),
+        (5, "Helena", "FL"),
+        (7, "Megan", "TX")))
+      val testDS2 = rdd2.toDF("id", "name", "state")
+
+      val ds1 = testDS1
+      val ds2 = testDS2
+      val colKeyMap = Map("name" -> "name")
+      val compCols = Map("state" -> "state")
+      val assertion: Double => Boolean = _ >= 0.66
+
+      val result = (DataSynchronization.columnMatch(ds1, ds2, colKeyMap, compCols, assertion))
+      assert(result.isInstanceOf[ComparisonFailed])
+    }
+
+    "match >= 0.66 when id is unique col, rest compCols" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (4, "Helena", "TX"),
+        (5, "Nick", "FL"),
+        (6, "Molly", "TX")))
+      val testDS1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (4, "Helena", "TX"),
+        (5, "Helena", "FL"),
+        (7, "Megan", "TX")))
+      val testDS2 = rdd2.toDF("id", "name", "state")
+
+      val ds1 = testDS1
+      val ds2 = testDS2
+      val colKeyMap = Map("id" -> "id")
+      val compCols = Map("name" -> "name", "state" -> "state")
+      val assertion: Double => Boolean = _ >= 0.60
+
+      val result = (DataSynchronization.columnMatch(ds1, ds2, colKeyMap, compCols, assertion))
+      assert(result.isInstanceOf[ComparisonSucceeded])
+    }
+
+    "match >= 0.66 (same test as above only the data sets change)" in withSparkSession{ spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (4, "Helena", "TX"),
+        (5, "Nick", "FL"),
+        (6, "Molly", "TX")))
+      val testDS1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (4, "Helena", "TX"),
+        (5, "Helena", "FL"),
+        (7, "Megan", "TX")))
+      val testDS2 = rdd2.toDF("id", "name", "state")
+
+      val ds1 = testDS2
+      val ds2 = testDS1
+      val colKeyMap = Map("id" -> "id")
+      val compCols = Map("name" -> "name", "state" -> "state")
+      val assertion: Double => Boolean = _ >= 0.60
+
+      val result = (DataSynchronization.columnMatch(ds1, ds2, colKeyMap, compCols, assertion))
+      assert(result.isInstanceOf[ComparisonSucceeded])
+    }
+
+    "return false because the id col in ds1 isn't unique" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (4, "Helena", "TX"),
+        (5, "Helena", "FL"),
+        (7, "Megan", "TX")))
+      val testDS2 = rdd2.toDF("id", "name", "state")
+
+      val rdd3 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (1, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (4, "Helena", "TX"),
+        (5, "Helena", "FL"),
+        (9, "Nicholas", "CT"),
+        (7, "Megan", "TX")))
+      val testDS3 = rdd3.toDF("id", "name", "state")
+
+      val ds1 = testDS3
+      val ds2 = testDS2
+      val colKeyMap = Map("id" -> "id")
+      val compCols = Map("name" -> "name", "state" -> "state")
+      val assertion: Double => Boolean = _ >= 0.40
+
+      val result = (DataSynchronization.columnMatch(ds1, ds2, colKeyMap, compCols, assertion))
+      assert(result.isInstanceOf[ComparisonFailed])
+    }
+
+    "return false because the id col in ds2 isn't unique" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (4, "Helena", "TX"),
+        (5, "Nick", "FL"),
+        (6, "Molly", "TX")))
+      val testDS1 = rdd1.toDF("id", "name", "state")
+
+      val rdd3 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (1, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (4, "Helena", "TX"),
+        (5, "Helena", "FL"),
+        (9, "Nicholas", "CT"),
+        (7, "Megan", "TX")))
+      val testDS3 = rdd3.toDF("id", "name", "state")
+
+      val ds1 = testDS1
+      val ds2 = testDS3
+      val colKeyMap = Map("id" -> "id")
+      val compCols = Map("name" -> "name", "state" -> "state")
+      val assertion: Double => Boolean = _ >= 0.40
+
+      val result = (DataSynchronization.columnMatch(ds1, ds2, colKeyMap, compCols, assertion))
+      assert(result.isInstanceOf[ComparisonFailed])
+    }
+
+    "return false because col state isn't unique" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (4, "Helena", "TX"),
+        (5, "Nick", "FL"),
+        (6, "Molly", "TX")))
+      val testDS1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (4, "Helena", "TX"),
+        (5, "Helena", "FL"),
+        (7, "Megan", "TX")))
+      val testDS2 = rdd2.toDF("id", "name", "state")
+
+      val ds1 = testDS1
+      val ds2 = testDS2
+      val colKeyMap = Map("state" -> "state")
+      val compCols = Map("name" -> "name")
+      val assertion: Double => Boolean = _ >= 0.66
+
+      val result = (DataSynchronization.columnMatch(ds1, ds2, colKeyMap, compCols, assertion))
+      assert(result.isInstanceOf[ComparisonFailed])
+    }
+
+    "check all columns and return an assertion of .66" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (4, "Helena", "TX"),
+        (5, "Nick", "FL"),
+        (6, "Molly", "TX")))
+      val testDS1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (4, "Helena", "TX"),
+        (5, "Helena", "FL"),
+        (7, "Megan", "TX")))
+      val testDS2 = rdd2.toDF("id", "name", "state")
+
+      val ds1 = testDS1
+      val ds2 = testDS2
+      val colKeyMap = Map("id" -> "id")
+      val assertion: Double => Boolean = _ >= 0.66
+
+      val result = (DataSynchronization.columnMatch(ds1, ds2, colKeyMap, assertion))
+      assert(result.isInstanceOf[ComparisonSucceeded])
+    }
+
+    "return false because state column isn't unique" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (4, "Helena", "TX"),
+        (5, "Nick", "FL"),
+        (6, "Molly", "TX")))
+      val testDS1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (4, "Helena", "TX"),
+        (5, "Helena", "FL"),
+        (7, "Megan", "TX")))
+      val testDS2 = rdd2.toDF("id", "name", "state")
+
+      val ds1 = testDS1
+      val ds2 = testDS2
+      val colKeyMap = Map("state" -> "state")
+      val assertion: Double => Boolean = _ >= 0.66
+
+      val result = (DataSynchronization.columnMatch(ds1, ds2, colKeyMap, assertion))
+      assert(result.isInstanceOf[ComparisonFailed])
+    }
+
+    "check all columns" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (4, "Helena", "TX"),
+        (5, "Nick", "FL"),
+        (6, "Molly", "TX")))
+      val testDS1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (4, "Helena", "TX"),
+        (5, "Helena", "FL"),
+        (7, "Megan", "TX")))
+      val testDS2 = rdd2.toDF("id", "name", "state")
+
+      val ds1 = testDS1
+      val ds2 = testDS2
+      val colKeyMap = Map("id" -> "id")
+      val assertion: Double => Boolean = _ >= 0.66
+
+      val result = (DataSynchronization.columnMatch(ds1, ds2, colKeyMap, assertion))
+      assert(result.isInstanceOf[ComparisonSucceeded])
+    }
+    "cols exist but 0 matches" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (4, "Helena", "TX"),
+        (5, "Nick", "FL"),
+        (6, "Molly", "TX")))
+      val testDS1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (7, "Rahul", "CA"),
+        (8, "Tom", "MX"),
+        (9, "Tome", "NM"),
+        (10, "Kyra", "AZ"),
+        (11, "Jamie", "NB"),
+        (12, "Andrius", "ID")))
+      val testDS2 = rdd2.toDF("id", "name", "state")
+
+      val ds1 = testDS1
+      val ds2 = testDS2
+      val colKeyMap = Map("id" -> "id")
+      val assertion: Double => Boolean = _ >= 0
+
+      val result = (DataSynchronization.columnMatch(ds1, ds2, colKeyMap, assertion))
+      assert(result.isInstanceOf[ComparisonSucceeded])
+    }
+  }
+}

--- a/src/test/scala/com/amazon/deequ/comparison/ReferentialIntegrityTest.scala
+++ b/src/test/scala/com/amazon/deequ/comparison/ReferentialIntegrityTest.scala
@@ -1,0 +1,309 @@
+/**
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.comparison
+
+import com.amazon.deequ.SparkContextSpec
+import org.scalatest.wordspec.AnyWordSpec
+
+class ReferentialIntegrityTest extends AnyWordSpec with SparkContextSpec {
+
+  "Referential Integrity Test" should {
+    "id match equals 1.0" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (3, "Helena", "TX")))
+      val testDS1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (5, "Tyler", "FL"),
+        (6, "Megan", "TX")))
+      val testDS2 = rdd2.toDF("new_id", "name", "state")
+
+      val ds1 = testDS1
+      val col1 = "id"
+      val ds2 = testDS2
+      val col2 = "new_id"
+      val assertion: Double => Boolean = _ >= 1.0
+
+      val result = ReferentialIntegrity.subsetCheck(ds1, col1, ds2, col2, assertion)
+      assert(result.isInstanceOf[ComparisonSucceeded])
+    }
+
+    "id match equals 0.60" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (3, "Helena", "TX")))
+      val testDS1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (5, "Tyler", "FL"),
+        (6, "Megan", "TX")))
+      val testDS2 = rdd2.toDF("new_id", "name", "state")
+
+      val ds1 = testDS2
+      val col1 = "new_id"
+      val ds2 = testDS1
+      val col2 = "id"
+      val assertion: Double => Boolean = _ == 0.6
+
+      val result = ReferentialIntegrity.subsetCheck(ds1, col1, ds2, col2, assertion)
+      assert(result.isInstanceOf[ComparisonSucceeded])
+    }
+
+    "name match equals 1.0" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (3, "Helena", "TX")))
+      val testDS1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (5, "Tyler", "FL"),
+        (6, "Megan", "TX")))
+      val testDS2 = rdd2.toDF("new_id", "name", "state")
+
+      val ds1 = testDS1
+      val col1 = "name"
+      val ds2 = testDS2
+      val col2 = "name"
+      val assertion: Double => Boolean = _ >= 1.0
+
+      val result = ReferentialIntegrity.subsetCheck(ds1, col1, ds2, col2, assertion)
+      assert(result.isInstanceOf[ComparisonSucceeded])
+    }
+
+    "name match equals 0.60" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (3, "Helena", "TX")))
+      val testDS1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (5, "Tyler", "FL"),
+        (6, "Megan", "TX")))
+      val testDS2 = rdd2.toDF("id", "name", "state")
+
+      val ds1 = testDS2
+      val col1 = "name"
+      val ds2 = testDS1
+      val col2 = "name"
+      val assertion: Double => Boolean = _ == 0.6
+
+      val result = ReferentialIntegrity.subsetCheck(ds1, col1, ds2, col2, assertion)
+      assert(result.isInstanceOf[ComparisonSucceeded])
+    }
+
+    "state match equals 1.0" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (3, "Helena", "TX")))
+      val testDS1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (5, "Tyler", "FL"),
+        (6, "Megan", "TX")))
+      val testDS2 = rdd2.toDF("new_id", "name", "state")
+
+      val ds1 = testDS1
+      val col1 = "state"
+      val ds2 = testDS2
+      val col2 = "state"
+      val assertion: Double => Boolean = _ >= 1.0
+
+      val result = ReferentialIntegrity.subsetCheck(ds1, col1, ds2, col2, assertion)
+      assert(result.isInstanceOf[ComparisonSucceeded])
+    }
+
+    "state match equals to 0.80" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (3, "Helena", "TX")))
+      val testDS1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (5, "Tyler", "FL"),
+        (6, "Megan", "TX")))
+      val testDS2 = rdd2.toDF("new_id", "name", "state")
+
+      val ds1 = testDS2
+      val col1 = "state"
+      val ds2 = testDS1
+      val col2 = "state"
+      val assertion: Double => Boolean = _ >= 0.8
+
+      val result = ReferentialIntegrity.subsetCheck(ds1, col1, ds2, col2, assertion)
+      assert(result.isInstanceOf[ComparisonSucceeded])
+    }
+
+    "state match with name equals to 0.0" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (3, "Helena", "TX")))
+      val testDS1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (5, "Tyler", "FL"),
+        (6, "Megan", "TX")))
+      val testDS2 = rdd2.toDF("new_id", "name", "state")
+
+      val ds1 = testDS1
+      val col1 = "name"
+      val ds2 = testDS2
+      val col2 = "state"
+      val assertion: Double => Boolean = _ >= 0.0
+
+      val result = ReferentialIntegrity.subsetCheck(ds1, col1, ds2, col2, assertion)
+      assert(result.isInstanceOf[ComparisonSucceeded])
+    }
+
+    "ds1 doesn't contain col1 " in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (3, "Helena", "TX")))
+      val testDS1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (5, "Tyler", "FL"),
+        (6, "Megan", "TX")))
+      val testDS2 = rdd2.toDF("new_id", "name", "state")
+      val ds1 = testDS1
+      val col1 = "ids"
+      val ds2 = testDS2
+      val col2 = "new_id"
+      val assertion: Double => Boolean = _ == 0.66
+
+      val result = ReferentialIntegrity.subsetCheck(ds1, col1, ds2, col2, assertion)
+      assert(result.isInstanceOf[ComparisonFailed])
+    }
+
+    "ds2 doesn't contain col2" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (3, "Helena", "TX")))
+      val testDS1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (5, "Tyler", "FL"),
+        (6, "Megan", "TX")))
+      val testDS2 = rdd2.toDF("new_id", "name", "state")
+
+      val ds1 = testDS1
+      val col1 = "id"
+      val ds2 = testDS2
+      val col2 = "all-ids"
+      val assertion: Double => Boolean = _ == 0.66
+
+      val result = ReferentialIntegrity.subsetCheck(ds1, col1, ds2, col2, assertion)
+      assert(result.isInstanceOf[ComparisonFailed])
+    }
+
+    "More rows still 1.0" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (3, "Helena", "TX"),
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (5, "Tyler", "FL"),
+        (6, "Megan", "TX")))
+      val testDS1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (5, "Tyler", "FL"),
+        (6, "Megan", "TX")))
+      val testDS2 = rdd2.toDF("new_id", "name", "state")
+
+      val ds1 = testDS1
+      val col1 = "id"
+      val ds2 = testDS2
+      val col2 = "new_id"
+      val assertion: Double => Boolean = _ == 1.0
+
+      val result = ReferentialIntegrity.subsetCheck(ds1, col1, ds2, col2, assertion)
+      assert(result.isInstanceOf[ComparisonSucceeded])
+    }
+  }
+}

--- a/src/test/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunnerTest.scala
+++ b/src/test/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunnerTest.scala
@@ -282,9 +282,9 @@ object ConstraintSuggestionRunnerTest {
            |  com.amazon.deequ.VerificationSuite()
            |    .onData(df)
            |    .addCheck(
-           |      com.amazon.deequ.checks.Check(com.amazon.deequ.checks.CheckLevel.Error, "Test")
-           |        $constraint
-           |    )
+           |      com.amazon.deequ.checks.Check(
+           |        com.amazon.deequ.checks.CheckLevel.Error, "Test")
+           |        $constraint)
            |    .run()
            |}
          """.stripMargin.trim()

--- a/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
+++ b/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
@@ -155,6 +155,19 @@ trait FixtureSupport {
     ).toDF("item", "att1", "att2")
   }
 
+  def getDfCompleteAndInCompleteColumnsAndVarLengthStrings(sparkSession: SparkSession): DataFrame = {
+    import sparkSession.implicits._
+
+    Seq(
+      ("1", "a", "f"),
+      ("22", "b", "d"),
+      ("333", "a", null),
+      ("4444", "a", "f"),
+      ("55555", "b", null),
+      ("666666", "a", "f")
+    ).toDF("item", "att1", "att2")
+  }
+
   def getDfCompleteAndInCompleteColumnsDelta(sparkSession: SparkSession): DataFrame = {
     import sparkSession.implicits._
 
@@ -324,5 +337,21 @@ trait FixtureSupport {
       "ccc",
       "dddd"
     ).toDF("att1")
+  }
+
+  def getDfWithStringColumns(sparkSession: SparkSession): DataFrame = {
+    import sparkSession.implicits._
+
+    Seq(
+      ("India", "Xavier House, 2nd Floor", "St. Peter Colony, Perry Road", "Bandra (West)"),
+      ("India", "503 Godavari", "Sir Pochkhanwala Road", "Worli"),
+      ("India", "4/4 Seema Society", "N Dutta Road, Four Bungalows", "Andheri"),
+      ("India", "1001D Abhishek Apartments", "Juhu Versova Road", "Andheri"),
+      ("India", "95, Hill Road", null, null),
+      ("India", "90 Cuffe Parade", "Taj President Hotel", "Cuffe Parade"),
+      ("India", "4, Seven PM", "Sir Pochkhanwala Rd", "Worli"),
+      ("India", "1453 Sahar Road", null, null)
+    )
+      .toDF("Country", "Address Line 1", "Address Line 2", "Address Line 3")
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

While benchmarking Deequ, I noticed that our CountDistinct spec has a few irregularities compared to Distinctness and ShareableAnalyzers in general:

1. It is not a shareable analyzer, so it is forced to run on its own. This makes it less efficient.
2. It is replacing null values with a sentinel value, which Distinctness does not.
3. When computing the Histogram that it uses to derive the number of distinct values, Histogram performs an extraneous `count()` on the input dataframe. This is useful when the caller is interested in relative frequencies, but doesn't make sense when computing the number of distinct values.

This PR aims to solve the third issue.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
