### PR TITLE
Bugfix: Small perf optimization for constraints using histogram

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/Histogram.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Histogram.scala
@@ -42,7 +42,8 @@ case class Histogram(
     column: String,
     binningUdf: Option[UserDefinedFunction] = None,
     maxDetailBins: Integer = Histogram.MaximumAllowedDetailBins,
-    where: Option[String] = None)
+    where: Option[String] = None,
+    computeFrequenciesAsRatio: Boolean = true)
   extends Analyzer[FrequenciesAndNumRows, HistogramMetric]
   with FilterableAnalyzer {
 
@@ -56,7 +57,11 @@ case class Histogram(
   override def computeStateFrom(data: DataFrame): Option[FrequenciesAndNumRows] = {
 
     // TODO figure out a way to pass this in if its known before hand
-    val totalCount = data.count()
+    val totalCount = if (computeFrequenciesAsRatio) {
+      data.count()
+    } else {
+      1
+    }
 
     val frequencies = data
       .transform(filterOptional(where))

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -357,7 +357,7 @@ case class Check(
     : CheckWithLastConstraintFilterable = {
 
     addFilterableConstraint { filter =>
-      histogramBinConstraint(column, assertion, binningUdf, maxBins, filter, hint) }
+      histogramBinConstraint(column, assertion, binningUdf, maxBins, filter, hint, computeFrequenciesAsRatio = false) }
   }
 
   /**

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -158,10 +158,11 @@ object Constraint {
       binningUdf: Option[UserDefinedFunction] = None,
       maxBins: Integer = Histogram.MaximumAllowedDetailBins,
       where: Option[String] = None,
-      hint: Option[String] = None)
+      hint: Option[String] = None,
+      computeFrequenciesAsRatio: Boolean = true)
     : Constraint = {
 
-    val histogram = Histogram(column, binningUdf, maxBins, where)
+    val histogram = Histogram(column, binningUdf, maxBins, where, computeFrequenciesAsRatio)
 
     val constraint = AnalysisBasedConstraint[FrequenciesAndNumRows, Distribution, Long](
       histogram, assertion, Some(_.numberOfBins), hint)

--- a/src/test/scala/com/amazon/deequ/analyzers/DistinctnessTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/DistinctnessTest.scala
@@ -1,0 +1,76 @@
+/**
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+package com.amazon.deequ.analyzers
+
+import com.amazon.deequ.SparkContextSpec
+import com.amazon.deequ.VerificationSuite
+import com.amazon.deequ.checks.Check
+import com.amazon.deequ.checks.CheckLevel
+import com.amazon.deequ.checks.CheckStatus
+import com.amazon.deequ.constraints.Constraint
+import com.amazon.deequ.dataFrameWithColumn
+import com.amazon.deequ.metrics.Distribution
+import com.amazon.deequ.metrics.DoubleMetric
+import com.amazon.deequ.metrics.HistogramMetric
+import com.amazon.deequ.metrics.Metric
+import com.amazon.deequ.utils.FixtureSupport
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions.lit
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class DistinctnessTest extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport {
+
+  def almostEquals(a: Double, b: Double, e: Double): Boolean = {
+    (a-b).abs < e
+  }
+
+  def almostEquals(a: Double, b: Double): Boolean = almostEquals(a, b, 0.01)
+
+  "Distinctness" should {
+    "return the ratio of distinct values in a column" in withSparkSession {session =>
+      val data = getDfWithDistinctValues(session)
+      val distinctAtt1 = new Check(CheckLevel.Error, "d1").hasDistinctness(Seq("att1"), almostEquals(_, 0.6))
+      val distinctAtt2 = new Check(CheckLevel.Error, "d2").hasDistinctness(Seq("att2"), almostEquals(_, 0.5))
+
+      val suite = new VerificationSuite().onData(data).addCheck(distinctAtt1).addCheck(distinctAtt2)
+      val result = suite.run()
+      assert(result.status == CheckStatus.Success)
+
+      val metrics = result.metrics
+      metrics.foreach(m => {
+        val metric: Metric[_] = m._2
+        metric match {
+          case d: DoubleMetric => assert(d.value.get == 0.6 | d.value.get == 0.5)
+          case _ => fail("Metric is not a Double")
+        }
+      })
+    }
+  }
+
+  "DistinctValueCount" should {
+    "return the number of distinct values in a column without doing a full count" in withSparkSession { session =>
+      val data = getDfWithDistinctValues(session)
+      val dvCount1 = new Check(CheckLevel.Error, "d1").hasNumberOfDistinctValues("att1", _ == 4.0)
+      val dvCount2 = new Check(CheckLevel.Error, "d2").hasNumberOfDistinctValues("att2", _ == 3.0)
+
+      val suite = new VerificationSuite().onData(data).addCheck(dvCount1).addCheck(dvCount2)
+      val result = suite.run()
+      assert(result.status == CheckStatus.Success)
+    }
+  }
+
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

While benchmarking Deequ, I noticed that our CountDistinct spec has a few irregularities compared to Distinctness and ShareableAnalyzers in general:

1. It is not a shareable analyzer, so it is forced to run on its own. This makes it less efficient.
2. It is replacing null values with a sentinel value, which Distinctness does not.
3. When computing the Histogram that it uses to derive the number of distinct values, Histogram performs an extraneous `count()` on the input dataframe. This is useful when the caller is interested in relative frequencies, but doesn't make sense when computing the number of distinct values.

This PR aims to solve the third issue.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
