### PR TITLE
Bugfix/escape columnname

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
@@ -204,7 +204,6 @@ abstract class StandardScanShareableAnalyzer[S <: DoubleValuedState[_]](
     entity: Entity.Value = Entity.Column)
   extends ScanShareableAnalyzer[S, DoubleMetric] {
 
-  // Thrown here
   override def computeMetricFrom(state: Option[S]): DoubleMetric = {
     state match {
       case Some(theState) =>
@@ -218,7 +217,6 @@ abstract class StandardScanShareableAnalyzer[S <: DoubleValuedState[_]](
     }
   }
 
-  // Thrown here
   override private[deequ] def toFailureMetric(exception: Exception): DoubleMetric = {
     metricFromFailure(exception, name, instance, entity)
   }

--- a/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.types._
 import org.apache.spark.sql.{Column, DataFrame, Row, SparkSession}
 import com.amazon.deequ.analyzers.runners._
 import com.amazon.deequ.metrics.FullColumn
+import com.amazon.deequ.utilities.ColumnUtil.removeEscapeColumn
 
 import scala.language.existentials
 import scala.util.{Failure, Success}
@@ -308,23 +309,6 @@ object Preconditions {
       }
     }
   }
-
-  def removeEscapeColumn(column: String): String = {
-    if (column.endsWith("`")) {
-      column.substring(1, column.length - 1)
-    } else {
-      column
-    }
-  }
-
-  def escapeColumn(column: String): String = {
-    if (column.contains(".")) {
-      "`" + column + "`"
-    } else {
-      column
-    }
-  }
-
   def hasColumn(column: String, schema: StructType): Boolean = {
     val escapedColumn = removeEscapeColumn(column)
     if (caseSensitive) {

--- a/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
@@ -299,7 +299,6 @@ object AnalysisRunner {
     frequenciesAndNumRows.numRows -> results
   }
 
-  // Main method that needs looking into
   private[this] def runScanningAnalyzers(
       data: DataFrame,
       analyzers: Seq[Analyzer[State[_], Metric[_]]],

--- a/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
@@ -299,6 +299,7 @@ object AnalysisRunner {
     frequenciesAndNumRows.numRows -> results
   }
 
+  // Main method that needs looking into
   private[this] def runScanningAnalyzers(
       data: DataFrame,
       analyzers: Seq[Analyzer[State[_], Metric[_]]],
@@ -322,9 +323,7 @@ object AnalysisRunner {
         val offsets = shareableAnalyzers.scanLeft(0) { case (current, analyzer) =>
           current + analyzer.aggregationFunctions().length
         }
-
         val results = data.agg(aggregations.head, aggregations.tail: _*).collect().head
-
         shareableAnalyzers.zip(offsets).map { case (analyzer, offset) =>
           analyzer ->
             successOrFailureMetricFrom(analyzer, results, offset, aggregateWith, saveStatesTo)
@@ -334,12 +333,10 @@ object AnalysisRunner {
         case error: Exception =>
           shareableAnalyzers.map { analyzer => analyzer -> analyzer.toFailureMetric(error) }
       }
-
       AnalyzerContext(metricsByAnalyzer.toMap[Analyzer[_, Metric[_]], Metric[_]])
     } else {
       AnalyzerContext.empty
     }
-
     /* Run non-shareable analyzers separately */
     val otherMetrics = others
       .map { analyzer => analyzer -> analyzer.calculate(data, aggregateWith, saveStatesTo) }

--- a/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
+++ b/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
@@ -17,8 +17,6 @@
 package com.amazon.deequ.profiles
 
 import com.amazon.deequ.analyzers.DataTypeInstances._
-import com.amazon.deequ.analyzers.Preconditions.escapeColumn
-import com.amazon.deequ.analyzers.Preconditions.removeEscapeColumn
 import com.amazon.deequ.analyzers._
 import com.amazon.deequ.analyzers.runners.AnalysisRunBuilder
 import com.amazon.deequ.analyzers.runners.AnalysisRunner
@@ -27,6 +25,8 @@ import com.amazon.deequ.analyzers.runners.ReusingNotPossibleResultsMissingExcept
 import com.amazon.deequ.metrics._
 import com.amazon.deequ.repository.MetricsRepository
 import com.amazon.deequ.repository.ResultKey
+import com.amazon.deequ.utilities.ColumnUtil.escapeColumn
+import com.amazon.deequ.utilities.ColumnUtil.removeEscapeColumn
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.types.BooleanType
 import org.apache.spark.sql.types.DecimalType

--- a/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
+++ b/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
@@ -477,7 +477,7 @@ object ColumnProfiler {
         case _ => castedData
       }
     }
-  castedData
+    castedData
   }
 
 

--- a/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
+++ b/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
@@ -231,9 +231,7 @@ object ColumnProfiler {
 
     schema.fields
       .filter { field => restrictToColumns.isEmpty || restrictToColumns.get.contains(field.name) }
-      .map { field => {
-        escapeColumn(field.name)
-      }
+      .map { field => { escapeColumn(field.name) }
     }
   }
 

--- a/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
+++ b/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
@@ -16,16 +16,31 @@
 
 package com.amazon.deequ.profiles
 
-import scala.util.Success
-
 import com.amazon.deequ.analyzers.DataTypeInstances._
+import com.amazon.deequ.analyzers.Preconditions.escapeColumn
+import com.amazon.deequ.analyzers.Preconditions.removeEscapeColumn
 import com.amazon.deequ.analyzers._
-import com.amazon.deequ.analyzers.runners.{AnalysisRunBuilder, AnalysisRunner, AnalyzerContext, ReusingNotPossibleResultsMissingException}
+import com.amazon.deequ.analyzers.runners.AnalysisRunBuilder
+import com.amazon.deequ.analyzers.runners.AnalysisRunner
+import com.amazon.deequ.analyzers.runners.AnalyzerContext
+import com.amazon.deequ.analyzers.runners.ReusingNotPossibleResultsMissingException
 import com.amazon.deequ.metrics._
-import com.amazon.deequ.repository.{MetricsRepository, ResultKey}
-
+import com.amazon.deequ.repository.MetricsRepository
+import com.amazon.deequ.repository.ResultKey
 import org.apache.spark.sql.DataFrame
-import org.apache.spark.sql.types.{BooleanType, DecimalType, DoubleType, FloatType, IntegerType, LongType, ShortType, StringType, StructType, TimestampType, DataType => SparkDataType}
+import org.apache.spark.sql.types.BooleanType
+import org.apache.spark.sql.types.DecimalType
+import org.apache.spark.sql.types.DoubleType
+import org.apache.spark.sql.types.FloatType
+import org.apache.spark.sql.types.IntegerType
+import org.apache.spark.sql.types.LongType
+import org.apache.spark.sql.types.ShortType
+import org.apache.spark.sql.types.StringType
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.types.TimestampType
+import org.apache.spark.sql.types.{DataType => SparkDataType}
+
+import scala.util.Success
 
 private[deequ] case class GenericColumnStatistics(
     numRecords: Long,
@@ -216,7 +231,10 @@ object ColumnProfiler {
 
     schema.fields
       .filter { field => restrictToColumns.isEmpty || restrictToColumns.get.contains(field.name) }
-      .map { field => field.name }
+      .map { field => {
+        escapeColumn(field.name)
+      }
+    }
   }
 
   private[this] def getAnalyzersForGenericStats(
@@ -225,11 +243,13 @@ object ColumnProfiler {
       predefinedTypes: Map[String, DataTypeInstances.Value])
     : Seq[Analyzer[_, Metric[_]]] = {
 
+
     schema.fields
-      .filter { field => relevantColumns.contains(field.name) }
+      .filter { field => relevantColumns
+        .contains( escapeColumn(field.name)) }
       .flatMap { field =>
 
-        val name = field.name
+        val name: String = escapeColumn(field.name)
 
         if (field.dataType == StringType && !predefinedTypes.contains(name)) {
           Seq(Completeness(name), ApproxCountDistinct(name), DataType(name))
@@ -366,9 +386,11 @@ object ColumnProfiler {
       toType: SparkDataType)
     : DataFrame = {
 
+    val originalName = removeEscapeColumn(name)
+
     data.withColumn(s"${name}___CASTED", data(name).cast(toType))
-      .drop(name)
-      .withColumnRenamed(s"${name}___CASTED", name)
+      .drop(originalName)
+      .withColumnRenamed(s"${name}___CASTED", originalName)
   }
 
   private[this] def extractGenericStatistics(
@@ -382,7 +404,6 @@ object ColumnProfiler {
       .collect { case (_: Size, metric: DoubleMetric) => metric.value.get }
       .head
       .toLong
-
 
     val inferredTypes = results.metricMap
       .filterNot{
@@ -450,15 +471,13 @@ object ColumnProfiler {
     var castedData = originalData
 
     columns.foreach { name =>
-
       castedData = genericStatistics.typeOf(name) match {
         case Integral => castColumn(castedData, name, LongType)
         case Fractional => castColumn(castedData, name, DoubleType)
         case _ => castedData
       }
     }
-
-    castedData
+  castedData
   }
 
 

--- a/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunner.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunner.scala
@@ -233,7 +233,7 @@ class ConstraintSuggestionRunner {
 
     schema.fields
       .filter { field => restrictToColumns.isEmpty || restrictToColumns.get.contains(field.name) }
-      .map { field => {escapeColumn(field.name)}
+      .map { field => {escapeColumn(field.name) }
       }
   }
 

--- a/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunner.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunner.scala
@@ -16,6 +16,7 @@
 
 package com.amazon.deequ.suggestions
 
+import com.amazon.deequ.analyzers.Preconditions.escapeColumn
 import com.amazon.deequ.analyzers.{DataTypeInstances, KLLParameters}
 import com.amazon.deequ.{VerificationResult, VerificationSuite}
 import com.amazon.deequ.checks.{Check, CheckLevel}
@@ -232,7 +233,8 @@ class ConstraintSuggestionRunner {
 
     schema.fields
       .filter { field => restrictToColumns.isEmpty || restrictToColumns.get.contains(field.name) }
-      .map { field => field.name }
+      .map { field => {escapeColumn(field.name)}
+      }
   }
 
   private[this] def saveColumnProfilesJsonToFileSystemIfNecessary(

--- a/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunner.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunner.scala
@@ -16,7 +16,6 @@
 
 package com.amazon.deequ.suggestions
 
-import com.amazon.deequ.analyzers.Preconditions.escapeColumn
 import com.amazon.deequ.analyzers.{DataTypeInstances, KLLParameters}
 import com.amazon.deequ.{VerificationResult, VerificationSuite}
 import com.amazon.deequ.checks.{Check, CheckLevel}
@@ -24,6 +23,7 @@ import com.amazon.deequ.io.DfsUtils
 import com.amazon.deequ.profiles.{ColumnProfile, ColumnProfilerRunner, ColumnProfiles}
 import com.amazon.deequ.repository.{MetricsRepository, ResultKey}
 import com.amazon.deequ.suggestions.rules._
+import com.amazon.deequ.utilities.ColumnUtil.escapeColumn
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SparkSession}

--- a/src/main/scala/com/amazon/deequ/utilities/ColumnUtil.scala
+++ b/src/main/scala/com/amazon/deequ/utilities/ColumnUtil.scala
@@ -19,7 +19,7 @@ package com.amazon.deequ.utilities
 object ColumnUtil {
 
   def removeEscapeColumn(column: String): String = {
-    if (column.endsWith("`")) {
+    if (column.startsWith("`") && column.endsWith("`")) {
       column.substring(1, column.length - 1)
     } else {
       column

--- a/src/main/scala/com/amazon/deequ/utilities/ColumnUtil.scala
+++ b/src/main/scala/com/amazon/deequ/utilities/ColumnUtil.scala
@@ -1,0 +1,37 @@
+/**
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.utilities
+
+object ColumnUtil {
+
+  def removeEscapeColumn(column: String): String = {
+    if (column.endsWith("`")) {
+      column.substring(1, column.length - 1)
+    } else {
+      column
+    }
+  }
+
+  def escapeColumn(column: String): String = {
+    if (column.contains(".")) {
+      "`" + column + "`"
+    } else {
+      column
+    }
+  }
+
+}

--- a/src/test/scala/com/amazon/deequ/SuggestionAndVerificationIntegrationTest.scala
+++ b/src/test/scala/com/amazon/deequ/SuggestionAndVerificationIntegrationTest.scala
@@ -1,0 +1,70 @@
+/**
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ
+
+import com.amazon.deequ.analyzers.Preconditions.escapeColumn
+import com.amazon.deequ.checks.Check
+import com.amazon.deequ.checks.CheckLevel
+import com.amazon.deequ.checks.CheckStatus
+import com.amazon.deequ.constraints.Constraint
+import com.amazon.deequ.suggestions.ConstraintSuggestionRunner
+import com.amazon.deequ.suggestions.Rules
+import com.amazon.deequ.suggestions.rules.UniqueIfApproximatelyUniqueRule
+import com.amazon.deequ.utils.FixtureSupport
+import org.apache.spark.sql.DataFrame
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
+
+class SuggestionAndVerificationIntegrationTest extends WordSpec with Matchers with SparkContextSpec
+  with FixtureSupport {
+
+  "SuggestionAndVerificationIntegration" should {
+    "Succeed for all constraints suggested for the data with . in column name" in
+      withSparkSession { session =>
+
+        def assertStatusFor(data: DataFrame, checks: Check*)
+                           (expectedStatus: CheckStatus.Value)
+        : Unit = {
+          val verificationSuiteStatus =
+            VerificationSuite().onData(data).addChecks(checks).run().status
+          assert(verificationSuiteStatus == expectedStatus)
+        }
+
+        val data = getDfWithPeriodInName(session)
+
+        val results = ConstraintSuggestionRunner()
+          .onData(data)
+          .addConstraintRules(Rules.DEFAULT)
+          .addConstraintRule(UniqueIfApproximatelyUniqueRule())
+          .run()
+
+        val columns = data.columns.map { c =>
+          escapeColumn(c)
+        }
+
+        val constraints: Seq[Constraint] = columns.flatMap { column =>
+          results.constraintSuggestions
+            .getOrElse(column, Seq())
+            .map(suggestion => suggestion.constraint)
+        }
+
+        val checksToSucceed = Check(CheckLevel.Error, "group-1", constraints)
+
+        assertStatusFor(data, checksToSucceed)(CheckStatus.Success)
+      }
+  }
+}

--- a/src/test/scala/com/amazon/deequ/SuggestionAndVerificationIntegrationTest.scala
+++ b/src/test/scala/com/amazon/deequ/SuggestionAndVerificationIntegrationTest.scala
@@ -16,7 +16,6 @@
 
 package com.amazon.deequ
 
-import com.amazon.deequ.analyzers.Preconditions.escapeColumn
 import com.amazon.deequ.checks.Check
 import com.amazon.deequ.checks.CheckLevel
 import com.amazon.deequ.checks.CheckStatus
@@ -24,6 +23,7 @@ import com.amazon.deequ.constraints.Constraint
 import com.amazon.deequ.suggestions.ConstraintSuggestionRunner
 import com.amazon.deequ.suggestions.Rules
 import com.amazon.deequ.suggestions.rules.UniqueIfApproximatelyUniqueRule
+import com.amazon.deequ.utilities.ColumnUtil.escapeColumn
 import com.amazon.deequ.utils.FixtureSupport
 import org.apache.spark.sql.DataFrame
 import org.scalatest.Matchers

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -104,11 +104,11 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
         val df = getDfCompleteAndInCompleteColumnsWithPeriod(sparkSession)
 
         val checkToSucceed = Check(CheckLevel.Error, "group-1")
-          .isComplete("att1")
-          .hasCompleteness("att1", _ == 1.0)
+          .isComplete("`att.1`")
+          .hasCompleteness("`att.1`", _ == 1.0)
 
         val checkToErrorOut = Check(CheckLevel.Error, "group-2-E")
-          .hasCompleteness("att2", _ > 0.8)
+          .hasCompleteness("`att.2`", _ > 0.8)
 
         val checkToWarn = Check(CheckLevel.Warning, "group-2-W")
           .hasCompleteness("`item.one`", _ < 0.8)

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -19,18 +19,23 @@ package com.amazon.deequ
 import com.amazon.deequ.analyzers._
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
 import com.amazon.deequ.anomalydetection.AbsoluteChangeStrategy
-import com.amazon.deequ.checks.{Check, CheckLevel, CheckStatus}
+import com.amazon.deequ.checks.Check
+import com.amazon.deequ.checks.CheckLevel
+import com.amazon.deequ.checks.CheckStatus
 import com.amazon.deequ.constraints.Constraint
-import com.amazon.deequ.constraints.RowLevelConstraint
 import com.amazon.deequ.io.DfsUtils
-import com.amazon.deequ.metrics.{DoubleMetric, Entity}
+import com.amazon.deequ.metrics.DoubleMetric
+import com.amazon.deequ.metrics.Entity
 import com.amazon.deequ.repository.memory.InMemoryMetricsRepository
-import com.amazon.deequ.repository.{MetricsRepository, ResultKey}
+import com.amazon.deequ.repository.MetricsRepository
+import com.amazon.deequ.repository.ResultKey
 import com.amazon.deequ.utils.CollectionUtils.SeqExtensions
-import com.amazon.deequ.utils.{FixtureSupport, TempFileUtils}
+import com.amazon.deequ.utils.FixtureSupport
+import com.amazon.deequ.utils.TempFileUtils
 import org.apache.spark.sql.DataFrame
 import org.scalamock.scalatest.MockFactory
-import org.scalatest.{Matchers, WordSpec}
+import org.scalatest.Matchers
+import org.scalatest.WordSpec
 
 
 
@@ -61,6 +66,52 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
 
         val checkToWarn = Check(CheckLevel.Warning, "group-2-W")
           .hasCompleteness("item", _ < 0.8)
+
+
+        assertStatusFor(df, checkToSucceed)(CheckStatus.Success)
+        assertStatusFor(df, checkToErrorOut)(CheckStatus.Error)
+        assertStatusFor(df, checkToWarn)(CheckStatus.Warning)
+
+
+        Seq(checkToSucceed, checkToErrorOut).forEachOrder { checks =>
+          assertStatusFor(df, checks: _*)(CheckStatus.Error)
+        }
+
+        Seq(checkToSucceed, checkToWarn).forEachOrder { checks =>
+          assertStatusFor(df, checks: _*)(CheckStatus.Warning)
+        }
+
+        Seq(checkToWarn, checkToErrorOut).forEachOrder { checks =>
+          assertStatusFor(df, checks: _*)(CheckStatus.Error)
+        }
+
+        Seq(checkToSucceed, checkToWarn, checkToErrorOut).forEachOrder { checks =>
+          assertStatusFor(df, checks: _*)(CheckStatus.Error)
+        }
+      }
+
+    "return the correct verification status regardless of the order of checks with period" in
+      withSparkSession { sparkSession =>
+
+        def assertStatusFor(data: DataFrame, checks: Check*)
+                           (expectedStatus: CheckStatus.Value)
+        : Unit = {
+          val verificationSuiteStatus =
+            VerificationSuite().onData(data).addChecks(checks).run().status
+          assert(verificationSuiteStatus == expectedStatus)
+        }
+
+        val df = getDfCompleteAndInCompleteColumnsWithPeriod(sparkSession)
+
+        val checkToSucceed = Check(CheckLevel.Error, "group-1")
+          .isComplete("att1")
+          .hasCompleteness("att1", _ == 1.0)
+
+        val checkToErrorOut = Check(CheckLevel.Error, "group-2-E")
+          .hasCompleteness("att2", _ > 0.8)
+
+        val checkToWarn = Check(CheckLevel.Warning, "group-2-W")
+          .hasCompleteness("`item.one`", _ < 0.8)
 
 
         assertStatusFor(df, checkToSucceed)(CheckStatus.Success)

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -89,6 +89,31 @@ class CheckTest extends AnyWordSpec with Matchers with SparkContextSpec with Fix
         assertEvaluatesTo(check3, context, CheckStatus.Warning)
     }
 
+    "return the correct check status for combined completeness with . in column name" in
+      withSparkSession { sparkSession =>
+
+        val check1 = Check(CheckLevel.Error, "group-1")
+          .areComplete(Seq("`item.one`", "`att.1`")) // 1.0
+          .haveCompleteness(Seq("`item.one`", "`att.1`"), _ == 1.0) // 1.0
+
+        val check2 = Check(CheckLevel.Error, "group-2-E")
+          .haveCompleteness(Seq("`item.one`", "`att.1`", "`att.2`"), _ > 0.8) // 0.75
+
+        val check3 = Check(CheckLevel.Warning, "group-2-W")
+          .haveCompleteness(Seq("`item.one`", "`att.1`", "`att.2`"), _ > 0.8) // 0.75
+
+        val context = runChecks(getDfCompleteAndInCompleteColumnsWithPeriod(sparkSession),
+          check1, check2, check3)
+
+        context.metricMap.foreach {
+          println
+        }
+
+        assertEvaluatesTo(check1, context, CheckStatus.Success)
+        assertEvaluatesTo(check2, context, CheckStatus.Error)
+        assertEvaluatesTo(check3, context, CheckStatus.Warning)
+      }
+
     "return the correct check status for any completeness" in
       withSparkSession { sparkSession =>
 

--- a/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
+++ b/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
@@ -16,8 +16,10 @@
 
 package com.amazon.deequ.utils
 
-import org.apache.spark.sql.types.{DoubleType, LongType, MapType, StringType, StructType}
-import org.apache.spark.sql.{DataFrame, Row, SparkSession}
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.SparkSession
 
 import scala.util.Random
 
@@ -353,5 +355,29 @@ trait FixtureSupport {
       ("India", "1453 Sahar Road", null, null)
     )
       .toDF("Country", "Address Line 1", "Address Line 2", "Address Line 3")
+  }
+
+  def getDfWithPeriodInName(sparkSession: SparkSession): DataFrame = {
+    import sparkSession.implicits._
+
+    Seq(
+      ("1", "a", "c"),
+      ("2", "a", "c"),
+      ("3", "a", "c"),
+      ("4", "b", "d")
+    ).toDF("item.one", "att1", "att2")
+  }
+
+  def getDfCompleteAndInCompleteColumnsWithPeriod(sparkSession: SparkSession): DataFrame = {
+    import sparkSession.implicits._
+
+    Seq(
+      ("1", "a", "f"),
+      ("2", "b", "d"),
+      ("3", "a", null),
+      ("4", "a", "f"),
+      ("5", "b", null),
+      ("6", "a", "f")
+    ).toDF("item.one", "att.1", "att.2")
   }
 }


### PR DESCRIPTION
*Issue #, if available:* [#274](https://github.com/awslabs/deequ/issues/274)

*Description of changes:*

When there is a . in the column name, Spark recognizes that as trying to get the field nested in a column. This is an issue for those testing with common data sets like Iris, resulting in the following error: 
`org.apache.spark.sql.AnalysisException: Column 'sepal.width' does not exist. Did you mean one of the following? [petal.length, petal.width, sepal.length, sepal.width, variety]`

This PR addresses the issue by using helper methods that add and remove backticks "`" in the appropriate instances when going through the data.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
