### PR TITLE
Updated Referential Integrity to support multiple columns

### DIFF
--- a/src/test/scala/com/amazon/deequ/comparison/ReferentialIntegrityTest.scala
+++ b/src/test/scala/com/amazon/deequ/comparison/ReferentialIntegrityTest.scala
@@ -19,9 +19,118 @@ package com.amazon.deequ.comparison
 import com.amazon.deequ.SparkContextSpec
 import org.scalatest.wordspec.AnyWordSpec
 
-class ReferentialIntegrityTest extends AnyWordSpec with SparkContextSpec {
+private[comparison] case class State(stateName: String, stateAbbr: String)
+private[comparison] case class DatasetRow(id: Int, state: State)
 
+class ReferentialIntegrityTest extends AnyWordSpec with SparkContextSpec {
   "Referential Integrity Test" should {
+    "primary column not being in primary throws error" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (3, "Helena", "TX")))
+      val ds1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (5, "Tyler", "FL"),
+        (6, "Megan", "TX")))
+      val ds2 = rdd2.toDF("new_id", "name", "state")
+
+      val col1 = "name_foo"
+      val col2 = "name"
+      val assertion: Double => Boolean = _ >= 1.0
+
+      val result = ReferentialIntegrity.subsetCheck(ds1, Seq(col1), ds2, Seq(col2), assertion)
+      assert(result.isInstanceOf[ComparisonFailed])
+      assert(result.asInstanceOf[ComparisonFailed].errorMessage.contains(s"does not exist in primary data frame"))
+    }
+
+    "primary columns not being in primary throws error" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (3, "Helena", "TX")))
+      val ds1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (5, "Tyler", "FL"),
+        (6, "Megan", "TX")))
+      val ds2 = rdd2.toDF("new_id", "name", "state")
+
+      val cols = Seq("name_foo", "state_foo")
+      val assertion: Double => Boolean = _ >= 1.0
+
+      val result = ReferentialIntegrity.subsetCheck(ds1, cols, ds2, cols, assertion)
+      assert(result.isInstanceOf[ComparisonFailed])
+      assert(result.asInstanceOf[ComparisonFailed].errorMessage.contains(s"do not exist in primary data frame"))
+    }
+
+    "reference column not being in reference throws error" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (3, "Helena", "TX")))
+      val ds1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (5, "Tyler", "FL"),
+        (6, "Megan", "TX")))
+      val ds2 = rdd2.toDF("new_id", "name", "state")
+
+      val col1 = "name"
+      val col2 = "name_foo"
+      val assertion: Double => Boolean = _ >= 1.0
+
+      val result = ReferentialIntegrity.subsetCheck(ds1, Seq(col1), ds2, Seq(col2), assertion)
+      assert(result.isInstanceOf[ComparisonFailed])
+      assert(result.asInstanceOf[ComparisonFailed].errorMessage.contains(s"does not exist in reference data frame"))
+    }
+
+    "reference columns not being in primary throws error" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (3, "Helena", "TX")))
+      val ds1 = rdd1.toDF("id", "name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "John", "NY"),
+        (2, "Javier", "WI"),
+        (3, "Helena", "TX"),
+        (5, "Tyler", "FL"),
+        (6, "Megan", "TX")))
+      val ds2 = rdd2.toDF("new_id", "name", "state")
+
+      val cols1 = Seq("name", "state")
+      val cols2 = Seq("name_foo", "state_foo")
+      val assertion: Double => Boolean = _ >= 1.0
+
+      val result = ReferentialIntegrity.subsetCheck(ds1, cols1, ds2, cols2, assertion)
+      assert(result.isInstanceOf[ComparisonFailed])
+      assert(result.asInstanceOf[ComparisonFailed].errorMessage.contains(s"do not exist in reference data frame"))
+    }
+
     "id match equals 1.0" in withSparkSession { spark =>
       import spark.implicits._
 
@@ -30,7 +139,7 @@ class ReferentialIntegrityTest extends AnyWordSpec with SparkContextSpec {
         (2, "Javier", "WI"),
         (3, "Helena", "TX"),
         (3, "Helena", "TX")))
-      val testDS1 = rdd1.toDF("id", "name", "state")
+      val ds1 = rdd1.toDF("id", "name", "state")
 
       val rdd2 = spark.sparkContext.parallelize(Seq(
         (1, "John", "NY"),
@@ -38,15 +147,13 @@ class ReferentialIntegrityTest extends AnyWordSpec with SparkContextSpec {
         (3, "Helena", "TX"),
         (5, "Tyler", "FL"),
         (6, "Megan", "TX")))
-      val testDS2 = rdd2.toDF("new_id", "name", "state")
+      val ds2 = rdd2.toDF("new_id", "name", "state")
 
-      val ds1 = testDS1
       val col1 = "id"
-      val ds2 = testDS2
       val col2 = "new_id"
       val assertion: Double => Boolean = _ >= 1.0
 
-      val result = ReferentialIntegrity.subsetCheck(ds1, col1, ds2, col2, assertion)
+      val result = ReferentialIntegrity.subsetCheck(ds1, Seq(col1), ds2, Seq(col2), assertion)
       assert(result.isInstanceOf[ComparisonSucceeded])
     }
 
@@ -58,7 +165,7 @@ class ReferentialIntegrityTest extends AnyWordSpec with SparkContextSpec {
         (2, "Javier", "WI"),
         (3, "Helena", "TX"),
         (3, "Helena", "TX")))
-      val testDS1 = rdd1.toDF("id", "name", "state")
+      val ds1 = rdd1.toDF("id", "name", "state")
 
       val rdd2 = spark.sparkContext.parallelize(Seq(
         (1, "John", "NY"),
@@ -66,15 +173,13 @@ class ReferentialIntegrityTest extends AnyWordSpec with SparkContextSpec {
         (3, "Helena", "TX"),
         (5, "Tyler", "FL"),
         (6, "Megan", "TX")))
-      val testDS2 = rdd2.toDF("new_id", "name", "state")
+      val ds2 = rdd2.toDF("new_id", "name", "state")
 
-      val ds1 = testDS2
       val col1 = "new_id"
-      val ds2 = testDS1
       val col2 = "id"
       val assertion: Double => Boolean = _ == 0.6
 
-      val result = ReferentialIntegrity.subsetCheck(ds1, col1, ds2, col2, assertion)
+      val result = ReferentialIntegrity.subsetCheck(ds2, Seq(col1), ds1, Seq(col2), assertion)
       assert(result.isInstanceOf[ComparisonSucceeded])
     }
 
@@ -86,7 +191,7 @@ class ReferentialIntegrityTest extends AnyWordSpec with SparkContextSpec {
         (2, "Javier", "WI"),
         (3, "Helena", "TX"),
         (3, "Helena", "TX")))
-      val testDS1 = rdd1.toDF("id", "name", "state")
+      val ds1 = rdd1.toDF("id", "name", "state")
 
       val rdd2 = spark.sparkContext.parallelize(Seq(
         (1, "John", "NY"),
@@ -94,15 +199,13 @@ class ReferentialIntegrityTest extends AnyWordSpec with SparkContextSpec {
         (3, "Helena", "TX"),
         (5, "Tyler", "FL"),
         (6, "Megan", "TX")))
-      val testDS2 = rdd2.toDF("new_id", "name", "state")
+      val ds2 = rdd2.toDF("new_id", "name", "state")
 
-      val ds1 = testDS1
       val col1 = "name"
-      val ds2 = testDS2
       val col2 = "name"
       val assertion: Double => Boolean = _ >= 1.0
 
-      val result = ReferentialIntegrity.subsetCheck(ds1, col1, ds2, col2, assertion)
+      val result = ReferentialIntegrity.subsetCheck(ds1, Seq(col1), ds2, Seq(col2), assertion)
       assert(result.isInstanceOf[ComparisonSucceeded])
     }
 
@@ -114,7 +217,7 @@ class ReferentialIntegrityTest extends AnyWordSpec with SparkContextSpec {
         (2, "Javier", "WI"),
         (3, "Helena", "TX"),
         (3, "Helena", "TX")))
-      val testDS1 = rdd1.toDF("id", "name", "state")
+      val ds1 = rdd1.toDF("id", "name", "state")
 
       val rdd2 = spark.sparkContext.parallelize(Seq(
         (1, "John", "NY"),
@@ -122,15 +225,13 @@ class ReferentialIntegrityTest extends AnyWordSpec with SparkContextSpec {
         (3, "Helena", "TX"),
         (5, "Tyler", "FL"),
         (6, "Megan", "TX")))
-      val testDS2 = rdd2.toDF("id", "name", "state")
+      val ds2 = rdd2.toDF("id", "name", "state")
 
-      val ds1 = testDS2
       val col1 = "name"
-      val ds2 = testDS1
       val col2 = "name"
       val assertion: Double => Boolean = _ == 0.6
 
-      val result = ReferentialIntegrity.subsetCheck(ds1, col1, ds2, col2, assertion)
+      val result = ReferentialIntegrity.subsetCheck(ds2, Seq(col1), ds1, Seq(col2), assertion)
       assert(result.isInstanceOf[ComparisonSucceeded])
     }
 
@@ -142,7 +243,7 @@ class ReferentialIntegrityTest extends AnyWordSpec with SparkContextSpec {
         (2, "Javier", "WI"),
         (3, "Helena", "TX"),
         (3, "Helena", "TX")))
-      val testDS1 = rdd1.toDF("id", "name", "state")
+      val ds1 = rdd1.toDF("id", "name", "state")
 
       val rdd2 = spark.sparkContext.parallelize(Seq(
         (1, "John", "NY"),
@@ -150,15 +251,13 @@ class ReferentialIntegrityTest extends AnyWordSpec with SparkContextSpec {
         (3, "Helena", "TX"),
         (5, "Tyler", "FL"),
         (6, "Megan", "TX")))
-      val testDS2 = rdd2.toDF("new_id", "name", "state")
+      val ds2 = rdd2.toDF("new_id", "name", "state")
 
-      val ds1 = testDS1
       val col1 = "state"
-      val ds2 = testDS2
       val col2 = "state"
       val assertion: Double => Boolean = _ >= 1.0
 
-      val result = ReferentialIntegrity.subsetCheck(ds1, col1, ds2, col2, assertion)
+      val result = ReferentialIntegrity.subsetCheck(ds1, Seq(col1), ds2, Seq(col2), assertion)
       assert(result.isInstanceOf[ComparisonSucceeded])
     }
 
@@ -170,7 +269,7 @@ class ReferentialIntegrityTest extends AnyWordSpec with SparkContextSpec {
         (2, "Javier", "WI"),
         (3, "Helena", "TX"),
         (3, "Helena", "TX")))
-      val testDS1 = rdd1.toDF("id", "name", "state")
+      val ds1 = rdd1.toDF("id", "name", "state")
 
       val rdd2 = spark.sparkContext.parallelize(Seq(
         (1, "John", "NY"),
@@ -178,15 +277,13 @@ class ReferentialIntegrityTest extends AnyWordSpec with SparkContextSpec {
         (3, "Helena", "TX"),
         (5, "Tyler", "FL"),
         (6, "Megan", "TX")))
-      val testDS2 = rdd2.toDF("new_id", "name", "state")
+      val ds2 = rdd2.toDF("new_id", "name", "state")
 
-      val ds1 = testDS2
       val col1 = "state"
-      val ds2 = testDS1
       val col2 = "state"
       val assertion: Double => Boolean = _ >= 0.8
 
-      val result = ReferentialIntegrity.subsetCheck(ds1, col1, ds2, col2, assertion)
+      val result = ReferentialIntegrity.subsetCheck(ds1, Seq(col1), ds2, Seq(col2), assertion)
       assert(result.isInstanceOf[ComparisonSucceeded])
     }
 
@@ -198,7 +295,7 @@ class ReferentialIntegrityTest extends AnyWordSpec with SparkContextSpec {
         (2, "Javier", "WI"),
         (3, "Helena", "TX"),
         (3, "Helena", "TX")))
-      val testDS1 = rdd1.toDF("id", "name", "state")
+      val ds1 = rdd1.toDF("id", "name", "state")
 
       val rdd2 = spark.sparkContext.parallelize(Seq(
         (1, "John", "NY"),
@@ -206,15 +303,13 @@ class ReferentialIntegrityTest extends AnyWordSpec with SparkContextSpec {
         (3, "Helena", "TX"),
         (5, "Tyler", "FL"),
         (6, "Megan", "TX")))
-      val testDS2 = rdd2.toDF("new_id", "name", "state")
+      val ds2 = rdd2.toDF("new_id", "name", "state")
 
-      val ds1 = testDS1
       val col1 = "name"
-      val ds2 = testDS2
       val col2 = "state"
       val assertion: Double => Boolean = _ >= 0.0
 
-      val result = ReferentialIntegrity.subsetCheck(ds1, col1, ds2, col2, assertion)
+      val result = ReferentialIntegrity.subsetCheck(ds1, Seq(col1), ds2, Seq(col2), assertion)
       assert(result.isInstanceOf[ComparisonSucceeded])
     }
 
@@ -226,7 +321,7 @@ class ReferentialIntegrityTest extends AnyWordSpec with SparkContextSpec {
         (2, "Javier", "WI"),
         (3, "Helena", "TX"),
         (3, "Helena", "TX")))
-      val testDS1 = rdd1.toDF("id", "name", "state")
+      val ds1 = rdd1.toDF("id", "name", "state")
 
       val rdd2 = spark.sparkContext.parallelize(Seq(
         (1, "John", "NY"),
@@ -234,14 +329,13 @@ class ReferentialIntegrityTest extends AnyWordSpec with SparkContextSpec {
         (3, "Helena", "TX"),
         (5, "Tyler", "FL"),
         (6, "Megan", "TX")))
-      val testDS2 = rdd2.toDF("new_id", "name", "state")
-      val ds1 = testDS1
+      val ds2 = rdd2.toDF("new_id", "name", "state")
+
       val col1 = "ids"
-      val ds2 = testDS2
       val col2 = "new_id"
       val assertion: Double => Boolean = _ == 0.66
 
-      val result = ReferentialIntegrity.subsetCheck(ds1, col1, ds2, col2, assertion)
+      val result = ReferentialIntegrity.subsetCheck(ds1, Seq(col1), ds2, Seq(col2), assertion)
       assert(result.isInstanceOf[ComparisonFailed])
     }
 
@@ -253,7 +347,7 @@ class ReferentialIntegrityTest extends AnyWordSpec with SparkContextSpec {
         (2, "Javier", "WI"),
         (3, "Helena", "TX"),
         (3, "Helena", "TX")))
-      val testDS1 = rdd1.toDF("id", "name", "state")
+      val ds1 = rdd1.toDF("id", "name", "state")
 
       val rdd2 = spark.sparkContext.parallelize(Seq(
         (1, "John", "NY"),
@@ -261,15 +355,13 @@ class ReferentialIntegrityTest extends AnyWordSpec with SparkContextSpec {
         (3, "Helena", "TX"),
         (5, "Tyler", "FL"),
         (6, "Megan", "TX")))
-      val testDS2 = rdd2.toDF("new_id", "name", "state")
+      val ds2 = rdd2.toDF("new_id", "name", "state")
 
-      val ds1 = testDS1
       val col1 = "id"
-      val ds2 = testDS2
       val col2 = "all-ids"
       val assertion: Double => Boolean = _ == 0.66
 
-      val result = ReferentialIntegrity.subsetCheck(ds1, col1, ds2, col2, assertion)
+      val result = ReferentialIntegrity.subsetCheck(ds1, Seq(col1), ds2, Seq(col2), assertion)
       assert(result.isInstanceOf[ComparisonFailed])
     }
 
@@ -286,7 +378,7 @@ class ReferentialIntegrityTest extends AnyWordSpec with SparkContextSpec {
         (3, "Helena", "TX"),
         (5, "Tyler", "FL"),
         (6, "Megan", "TX")))
-      val testDS1 = rdd1.toDF("id", "name", "state")
+      val ds1 = rdd1.toDF("id", "name", "state")
 
       val rdd2 = spark.sparkContext.parallelize(Seq(
         (1, "John", "NY"),
@@ -294,15 +386,91 @@ class ReferentialIntegrityTest extends AnyWordSpec with SparkContextSpec {
         (3, "Helena", "TX"),
         (5, "Tyler", "FL"),
         (6, "Megan", "TX")))
-      val testDS2 = rdd2.toDF("new_id", "name", "state")
+      val ds2 = rdd2.toDF("new_id", "name", "state")
 
-      val ds1 = testDS1
       val col1 = "id"
-      val ds2 = testDS2
       val col2 = "new_id"
       val assertion: Double => Boolean = _ == 1.0
 
-      val result = ReferentialIntegrity.subsetCheck(ds1, col1, ds2, col2, assertion)
+      val result = ReferentialIntegrity.subsetCheck(ds1, Seq(col1), ds2, Seq(col2), assertion)
+      assert(result.isInstanceOf[ComparisonSucceeded])
+    }
+
+    "Multiple columns" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "New York", "NY"),
+        (2, "Wisconsin", "WI"),
+        (3, "Texas", "TX"),
+        (4, "Canada", "CA"))) // Incorrect row
+      val ds1 = rdd1.toDF("id", "state name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "New York", "NY"),
+        (2, "Wisconsin", "WI"),
+        (3, "Texas", "TX"),
+        (4, "California", "CA"))) // Reference has correct row
+      val ds2 = rdd2.toDF("id", "state name", "state")
+
+      val cols = Seq("state name", "state")
+      val assertion: Double => Boolean = _ == 0.75
+
+      val result = ReferentialIntegrity.subsetCheck(ds1, cols, ds2, cols, assertion)
+      assert(result.isInstanceOf[ComparisonSucceeded])
+    }
+
+    "Multiple non-nested columns with dots in the column names" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(Seq(
+        (1, "New York", "NY"),
+        (2, "Wisconsin", "WI"),
+        (3, "Texas", "TX"),
+        (4, "Canada", "CA"))) // Incorrect row
+      val ds1 = rdd1.toDF("id", "state.name", "state")
+
+      val rdd2 = spark.sparkContext.parallelize(Seq(
+        (1, "New York", "NY"),
+        (2, "Wisconsin", "WI"),
+        (3, "Texas", "TX"),
+        (4, "California", "CA"))) // Reference has correct row
+      val ds2 = rdd2.toDF("id", "state.name", "state")
+
+      val cols = Seq("`state.name`", "state")
+      val assertion: Double => Boolean = _ == 0.75
+
+      val result = ReferentialIntegrity.subsetCheck(ds1, cols, ds2, cols, assertion)
+      assert(result.isInstanceOf[ComparisonSucceeded])
+    }
+
+    "Multiple nested columns" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val rdd1 = spark.sparkContext.parallelize(
+        Seq(
+          DatasetRow(1, State("New York", "NY")),
+          DatasetRow(1, State("Wisconsin", "WI")),
+          DatasetRow(1, State("Texas", "TX")),
+          DatasetRow(1, State("Canada", "CA")) // Incorrect row
+        )
+      )
+      val ds1 = rdd1.toDF
+
+      val rdd2 = spark.sparkContext.parallelize(
+        Seq(
+          DatasetRow(1, State("New York", "NY")),
+          DatasetRow(1, State("Wisconsin", "WI")),
+          DatasetRow(1, State("Texas", "TX")),
+          DatasetRow(1, State("California", "CA")) // Reference has correct row
+        )
+      )
+      val ds2 = rdd2.toDF
+
+      val cols = Seq("state.stateName", "state.stateAbbr")
+      val assertion: Double => Boolean = _ == 0.75
+
+      val result = ReferentialIntegrity.subsetCheck(ds1, cols, ds2, cols, assertion)
       assert(result.isInstanceOf[ComparisonSucceeded])
     }
   }


### PR DESCRIPTION
*Description of changes:*

- The change involves updating the API to accept a list of columns for both the primary and reference dataframes.
- This is still an experimental utility, hence we are changing the API.
- Added tests to verify the updated behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
