### PR TITLE
Feature: Length Row Level Results

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.amazon.deequ</groupId>
     <artifactId>deequ</artifactId>
-    <version>2.0.1-spark-3.1</version>
+    <version>2.0.3-spark-3.3</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.amazon.deequ</groupId>
     <artifactId>deequ</artifactId>
-    <version>2.0.3-spark-3.3</version>
+    <version>2.0.1-spark-3.1</version>
 
     <properties>
         <maven.compiler.source>1.8</maven.compiler.source>

--- a/src/main/scala/com/amazon/deequ/VerificationResult.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationResult.scala
@@ -18,17 +18,18 @@ package com.amazon.deequ
 
 import com.amazon.deequ.analyzers.Analyzer
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
-import com.amazon.deequ.checks.{Check, CheckResult, CheckStatus}
-import com.amazon.deequ.constraints.AnalysisBasedConstraint
+import com.amazon.deequ.checks.Check
+import com.amazon.deequ.checks.CheckResult
+import com.amazon.deequ.checks.CheckStatus
 import com.amazon.deequ.constraints.ConstraintResult
-import com.amazon.deequ.constraints.NamedConstraint
 import com.amazon.deequ.constraints.RowLevelAssertedConstraint
 import com.amazon.deequ.constraints.RowLevelConstraint
 import com.amazon.deequ.metrics.FullColumn
 import com.amazon.deequ.metrics.Metric
 import com.amazon.deequ.repository.SimpleResultSerde
 import org.apache.spark.sql.Column
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.SparkSession
 
 /**
   * The result returned from the VerificationSuite

--- a/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
@@ -17,16 +17,22 @@
 package com.amazon.deequ.analyzers
 
 import com.amazon.deequ.analyzers.Analyzers._
-import com.amazon.deequ.metrics.{DoubleMetric, Entity, Metric}
-import org.apache.spark.sql.functions._
-import org.apache.spark.sql.types._
-import org.apache.spark.sql.{Column, DataFrame, Row, SparkSession}
 import com.amazon.deequ.analyzers.runners._
 import com.amazon.deequ.metrics.FullColumn
 import com.amazon.deequ.utilities.ColumnUtil.removeEscapeColumn
+import com.amazon.deequ.metrics.DoubleMetric
+import com.amazon.deequ.metrics.Entity
+import com.amazon.deequ.metrics.Metric
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.types._
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.SparkSession
 
 import scala.language.existentials
-import scala.util.{Failure, Success}
+import scala.util.Failure
+import scala.util.Success
 
 /**
   * A state (sufficient statistic) computed from data, from which we can compute a metric.
@@ -449,6 +455,12 @@ private[deequ] object Analyzers {
     if (columns.size == 1) Entity.Column else Entity.Mutlicolumn
   }
 
+  def conditionalSelectionForLength(selection: Column, where: Option[String], replaceWith: Double): Column = {
+    val conditionColumn = where.map { expression => expr(expression) }
+    conditionColumn
+      .map { condition => when(condition, replaceWith).otherwise(selection) }
+      .getOrElse(selection)
+  }
   def conditionalSelection(selection: String, where: Option[String]): Column = {
     conditionalSelection(col(selection), where)
   }

--- a/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
@@ -255,6 +255,12 @@ case class NumMatchesAndCount(numMatches: Long, count: Long, override val fullCo
   }
 }
 
+case class AnalyzerOptions(convertNull: Boolean) {
+  def getConvertNull(): Boolean = {
+    convertNull
+  }
+}
+
 /** Base class for analyzers that compute ratios of matching predicates */
 abstract class PredicateMatchingAnalyzer(
     name: String,

--- a/src/main/scala/com/amazon/deequ/analyzers/MaxLength.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/MaxLength.scala
@@ -26,7 +26,7 @@ import org.apache.spark.sql.functions.max
 import org.apache.spark.sql.types.DoubleType
 import org.apache.spark.sql.types.StructType
 
-case class MaxLength(column: String, where: Option[String] = None, convertNull: Boolean = false)
+case class MaxLength(column: String, where: Option[String] = None, analyzerOptions: Option[AnalyzerOptions] = None)
   extends StandardScanShareableAnalyzer[MaxState]("MaxLength", column)
   with FilterableAnalyzer {
 
@@ -35,6 +35,9 @@ case class MaxLength(column: String, where: Option[String] = None, convertNull: 
   }
 
   override def fromAggregationResult(result: Row, offset: Int): Option[MaxState] = {
+    val convertNull: Boolean = analyzerOptions
+      .map { options => options.getConvertNull() }
+      .getOrElse(false)
     ifNoNullsIn(result, offset) { _ =>
       MaxState(result.getDouble(offset), Some(criterion(convertNull)))
     }

--- a/src/main/scala/com/amazon/deequ/analyzers/MinLength.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/MinLength.scala
@@ -27,7 +27,7 @@ import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.Row
 
-case class MinLength(column: String, where: Option[String] = None, convertNull: Boolean = false)
+case class MinLength(column: String, where: Option[String] = None, analyzerOptions: Option[AnalyzerOptions] = None)
   extends StandardScanShareableAnalyzer[MinState]("MinLength", column)
   with FilterableAnalyzer {
 
@@ -36,6 +36,9 @@ case class MinLength(column: String, where: Option[String] = None, convertNull: 
   }
 
   override def fromAggregationResult(result: Row, offset: Int): Option[MinState] = {
+    val convertNull: Boolean = analyzerOptions
+      .map { options => options.getConvertNull() }
+      .getOrElse(false)
     ifNoNullsIn(result, offset) { _ =>
       MinState(result.getDouble(offset), Some(criterion(convertNull)))
     }

--- a/src/main/scala/com/amazon/deequ/analyzers/MinLength.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/MinLength.scala
@@ -18,6 +18,7 @@ package com.amazon.deequ.analyzers
 
 import com.amazon.deequ.analyzers.Analyzers._
 import com.amazon.deequ.analyzers.Preconditions.{hasColumn, isString}
+import com.google.common.annotations.VisibleForTesting
 import org.apache.spark.sql.functions.{length, min}
 import org.apache.spark.sql.types.{DoubleType, StructType}
 import org.apache.spark.sql.{Column, Row}
@@ -32,7 +33,7 @@ case class MinLength(column: String, where: Option[String] = None)
 
   override def fromAggregationResult(result: Row, offset: Int): Option[MinState] = {
     ifNoNullsIn(result, offset) { _ =>
-      MinState(result.getDouble(offset))
+      MinState(result.getDouble(offset), Some(criterion))
     }
   }
 
@@ -41,4 +42,7 @@ case class MinLength(column: String, where: Option[String] = None)
   }
 
   override def filterCondition: Option[String] = where
+
+  @VisibleForTesting
+  private[deequ] def criterion: Column = length(conditionalSelection(column, where)).cast(DoubleType)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Minimum.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Minimum.scala
@@ -21,11 +21,13 @@ import org.apache.spark.sql.{Column, Row}
 import org.apache.spark.sql.functions.min
 import org.apache.spark.sql.types.{DoubleType, StructType}
 import Analyzers._
+import com.amazon.deequ.metrics.FullColumn
 
-case class MinState(minValue: Double) extends DoubleValuedState[MinState] {
+case class MinState(minValue: Double, override val fullColumn: Option[Column] = None)
+  extends DoubleValuedState[MinState] with FullColumn {
 
   override def sum(other: MinState): MinState = {
-    MinState(math.min(minValue, other.minValue))
+    MinState(math.min(minValue, other.minValue), sum(fullColumn, other.fullColumn))
   }
 
   override def metricValue(): Double = {

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -16,16 +16,17 @@
 
 package com.amazon.deequ.checks
 
+import com.amazon.deequ.analyzers.AnalyzerOptions
 import com.amazon.deequ.anomalydetection.{AnomalyDetectionStrategy, AnomalyDetector, DataPoint}
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
-import com.amazon.deequ.analyzers.{Analyzer, Histogram, Patterns, State, KLLParameters}
+import com.amazon.deequ.analyzers.{Analyzer, Histogram, KLLParameters, Patterns, State}
 import com.amazon.deequ.constraints.Constraint._
 import com.amazon.deequ.constraints._
 import com.amazon.deequ.metrics.{BucketDistribution, Distribution, Metric}
 import com.amazon.deequ.repository.MetricsRepository
 import org.apache.spark.sql.expressions.UserDefinedFunction
 import com.amazon.deequ.anomalydetection.HistoryUtils
-import com.amazon.deequ.checks.ColumnCondition.{isEachNotNull, isAnyNotNull}
+import com.amazon.deequ.checks.ColumnCondition.{isAnyNotNull, isEachNotNull}
 
 import scala.util.matching.Regex
 
@@ -517,10 +518,10 @@ case class Check(
       column: String,
       assertion: Double => Boolean,
       hint: Option[String] = None,
-      convertNull: Boolean = false)
+      analyzerOptions: Option[AnalyzerOptions] = None)
     : CheckWithLastConstraintFilterable = {
 
-    addFilterableConstraint { filter => minLengthConstraint(column, assertion, filter, hint, convertNull) }
+    addFilterableConstraint { filter => minLengthConstraint(column, assertion, filter, hint, analyzerOptions) }
   }
 
   /**
@@ -535,10 +536,10 @@ case class Check(
       column: String,
       assertion: Double => Boolean,
       hint: Option[String] = None,
-      convertNull: Boolean = false)
+      analyzerOptions: Option[AnalyzerOptions] = None)
     : CheckWithLastConstraintFilterable = {
 
-    addFilterableConstraint { filter => maxLengthConstraint(column, assertion, filter, hint, convertNull) }
+    addFilterableConstraint { filter => maxLengthConstraint(column, assertion, filter, hint, analyzerOptions) }
   }
 
   /**

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -516,10 +516,11 @@ case class Check(
   def hasMinLength(
       column: String,
       assertion: Double => Boolean,
-      hint: Option[String] = None)
+      hint: Option[String] = None,
+      convertNull: Boolean = false)
     : CheckWithLastConstraintFilterable = {
 
-    addFilterableConstraint { filter => minLengthConstraint(column, assertion, filter, hint) }
+    addFilterableConstraint { filter => minLengthConstraint(column, assertion, filter, hint, convertNull) }
   }
 
   /**
@@ -533,10 +534,11 @@ case class Check(
   def hasMaxLength(
       column: String,
       assertion: Double => Boolean,
-      hint: Option[String] = None)
+      hint: Option[String] = None,
+      convertNull: Boolean = false)
     : CheckWithLastConstraintFilterable = {
 
-    addFilterableConstraint { filter => maxLengthConstraint(column, assertion, filter, hint) }
+    addFilterableConstraint { filter => maxLengthConstraint(column, assertion, filter, hint, convertNull) }
   }
 
   /**

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -427,10 +427,10 @@ object Constraint {
       assertion: Double => Boolean,
       where: Option[String] = None,
       hint: Option[String] = None,
-      convertNull: Boolean = false)
+      analyzerOptions: Option[AnalyzerOptions] = None)
     : Constraint = {
 
-    val maxLength = MaxLength(column, where, convertNull)
+    val maxLength = MaxLength(column, where, analyzerOptions)
 
     val constraint = AnalysisBasedConstraint[MaxState, Double, Double](maxLength, assertion,
       hint = hint)
@@ -456,10 +456,10 @@ object Constraint {
       assertion: Double => Boolean,
       where: Option[String] = None,
       hint: Option[String] = None,
-      convertNull: Boolean = false)
+      analyzerOptions: Option[AnalyzerOptions] = None)
     : Constraint = {
 
-    val minLength = MinLength(column, where, convertNull)
+    val minLength = MinLength(column, where, analyzerOptions)
 
     val constraint = AnalysisBasedConstraint[MinState, Double, Double](minLength, assertion,
       hint = hint)

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -426,10 +426,11 @@ object Constraint {
       column: String,
       assertion: Double => Boolean,
       where: Option[String] = None,
-      hint: Option[String] = None)
+      hint: Option[String] = None,
+      convertNull: Boolean = false)
     : Constraint = {
 
-    val maxLength = MaxLength(column, where)
+    val maxLength = MaxLength(column, where, convertNull)
 
     val constraint = AnalysisBasedConstraint[MaxState, Double, Double](maxLength, assertion,
       hint = hint)
@@ -454,10 +455,11 @@ object Constraint {
       column: String,
       assertion: Double => Boolean,
       where: Option[String] = None,
-      hint: Option[String] = None)
+      hint: Option[String] = None,
+      convertNull: Boolean = false)
     : Constraint = {
 
-    val minLength = MinLength(column, where)
+    val minLength = MinLength(column, where, convertNull)
 
     val constraint = AnalysisBasedConstraint[MinState, Double, Double](minLength, assertion,
       hint = hint)

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -462,7 +462,13 @@ object Constraint {
     val constraint = AnalysisBasedConstraint[MinState, Double, Double](minLength, assertion,
       hint = hint)
 
-    new NamedConstraint(constraint, s"MinLengthConstraint($minLength)")
+    val sparkAssertion = org.apache.spark.sql.functions.udf(assertion)
+
+    new RowLevelAssertedConstraint(
+      constraint,
+      s"MinLengthConstraint($minLength)",
+      s"ColumnLength-$column",
+      sparkAssertion)
   }
 
   /**

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -26,9 +26,9 @@ import com.amazon.deequ.constraints.Constraint
 import com.amazon.deequ.io.DfsUtils
 import com.amazon.deequ.metrics.DoubleMetric
 import com.amazon.deequ.metrics.Entity
-import com.amazon.deequ.repository.memory.InMemoryMetricsRepository
 import com.amazon.deequ.repository.MetricsRepository
 import com.amazon.deequ.repository.ResultKey
+import com.amazon.deequ.repository.memory.InMemoryMetricsRepository
 import com.amazon.deequ.utils.CollectionUtils.SeqExtensions
 import com.amazon.deequ.utils.FixtureSupport
 import com.amazon.deequ.utils.TempFileUtils
@@ -167,8 +167,10 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
       val isComplete = new Check(CheckLevel.Error, "rule1").isComplete("att1")
       val completeness = new Check(CheckLevel.Error, "rule2").hasCompleteness("att2", _ > 0.7)
       val isPrimaryKey = new Check(CheckLevel.Error, "rule3").isPrimaryKey("item")
-      val minLength = new Check(CheckLevel.Error, "rule4").hasMinLength("item", _ <= 3)
-      val maxLength = new Check(CheckLevel.Error, "rule5").hasMaxLength("item", _ > 1)
+      val minLength = new Check(CheckLevel.Error, "rule4")
+        .hasMinLength("item", _ <= 3, convertNull = true)
+      val maxLength = new Check(CheckLevel.Error, "rule5")
+        .hasMaxLength("item", _ > 1, convertNull = true)
       val expectedColumn1 = isComplete.description
       val expectedColumn2 = completeness.description
       val expectedColumn3 = minLength.description
@@ -199,10 +201,10 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
       val rowLevel2 = resultData.select(expectedColumn2).collect().map(r => r.getBoolean(0))
       assert(Seq(true, true, false, true, false, true).sameElements(rowLevel2))
 
-      val rowLevel3 = resultData.select(expectedColumn3).collect().map(r => r.getAs[Boolean](0))
+      val rowLevel3 = resultData.select(expectedColumn3).collect().map(r => r.getBoolean(0))
       assert(Seq(true, true, true, false, false, false).sameElements(rowLevel3))
 
-      val rowLevel4 = resultData.select(expectedColumn4).collect().map(r => r.getAs[Boolean](0))
+      val rowLevel4 = resultData.select(expectedColumn4).collect().map(r => r.getBoolean(0))
       assert(Seq(false, true, true, true, true, true).sameElements(rowLevel4))
     }
 
@@ -211,8 +213,10 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
 
       val minLength = new Check(CheckLevel.Error, "rule1").hasMinLength("item", _ <= 3)
       val maxLength = new Check(CheckLevel.Error, "rule2").hasMaxLength("item", _ > 1)
-      val isLengthMin = new Check(CheckLevel.Error, "rule3").hasMinLength("att1", _ <= 1)
-      val isLengthMax = new Check(CheckLevel.Error, "rule4").hasMaxLength("att1", _ >= 1)
+      val isLengthMin = new Check(CheckLevel.Error, "rule3")
+        .hasMinLength("att2", _ <= 1, convertNull = true)
+      val isLengthMax = new Check(CheckLevel.Error, "rule4")
+        .hasMaxLength("att2", _ >= 1, convertNull = true)
       val expectedColumn1 = minLength.description
       val expectedColumn2 = maxLength.description
       val expectedColumn3 = isLengthMin.description
@@ -242,11 +246,11 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
       val rowLevel2 = resultData.select(expectedColumn2).collect().map(r => r.getBoolean(0))
       assert(Seq(false, true, true, true, true, true).sameElements(rowLevel2))
 
-      val rowLevel3 = resultData.select(expectedColumn3).collect().map(r => r.getAs[Boolean](0))
-      assert(Seq(true, true, true, true, true, true).sameElements(rowLevel3))
+      val rowLevel3 = resultData.select(expectedColumn3).collect().map(r => r.getBoolean(0))
+      assert(Seq(true, true, false, true, false, true).sameElements(rowLevel3))
 
-      val rowLevel4 = resultData.select(expectedColumn4).collect().map(r => r.getAs[Boolean](0))
-      assert(Seq(true, true, true, true, true, true).sameElements(rowLevel4))
+      val rowLevel4 = resultData.select(expectedColumn4).collect().map(r => r.getBoolean(0))
+      assert(Seq(true, true, false, true, false, true).sameElements(rowLevel4))
     }
 
     "accept analysis config for mandatory analysis" in withSparkSession { sparkSession =>

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -168,9 +168,9 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
       val completeness = new Check(CheckLevel.Error, "rule2").hasCompleteness("att2", _ > 0.7)
       val isPrimaryKey = new Check(CheckLevel.Error, "rule3").isPrimaryKey("item")
       val minLength = new Check(CheckLevel.Error, "rule4")
-        .hasMinLength("item", _ <= 3, convertNull = true)
+        .hasMinLength("item", _ <= 3, analyzerOptions = Option(AnalyzerOptions(convertNull = true)))
       val maxLength = new Check(CheckLevel.Error, "rule5")
-        .hasMaxLength("item", _ > 1, convertNull = true)
+        .hasMaxLength("item", _ > 1, analyzerOptions = Option(AnalyzerOptions(convertNull = true)))
       val expectedColumn1 = isComplete.description
       val expectedColumn2 = completeness.description
       val expectedColumn3 = minLength.description
@@ -214,9 +214,9 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
       val minLength = new Check(CheckLevel.Error, "rule1").hasMinLength("item", _ <= 3)
       val maxLength = new Check(CheckLevel.Error, "rule2").hasMaxLength("item", _ > 1)
       val isLengthMin = new Check(CheckLevel.Error, "rule3")
-        .hasMinLength("att2", _ <= 1, convertNull = true)
+        .hasMinLength("att2", _ <= 1, analyzerOptions = Option(AnalyzerOptions(convertNull = true)))
       val isLengthMax = new Check(CheckLevel.Error, "rule4")
-        .hasMaxLength("att2", _ >= 1, convertNull = true)
+        .hasMaxLength("att2", _ >= 1, analyzerOptions = Option(AnalyzerOptions(convertNull = true)))
       val expectedColumn1 = minLength.description
       val expectedColumn2 = maxLength.description
       val expectedColumn3 = isLengthMin.description

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalysisTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalysisTest.scala
@@ -158,8 +158,14 @@ class AnalysisTest extends AnyWordSpec with Matchers with SparkContextSpec with 
         fullColumn.isDefined shouldBe true
       }
 
-      resultMetrics should contain(DoubleMetric(Entity.Column, "MinLength", "att1",
-        Success(0.0)))
+      val minLengthMetric = resultMetrics.tail.head
+      inside (minLengthMetric) { case DoubleMetric(entity, name, instance, value, fullColumn) =>
+        entity shouldBe Entity.Column
+        name shouldBe "MinLength"
+        instance shouldBe "att1"
+        value shouldBe Success(0.0)
+        fullColumn.isDefined shouldBe true
+      }
     }
 
     "return the proper exception for non existing columns" in withSparkSession { sparkSession =>

--- a/src/test/scala/com/amazon/deequ/analyzers/MaxLengthTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/MaxLengthTest.scala
@@ -53,7 +53,7 @@ class MaxLengthTest extends AnyWordSpec with Matchers with SparkContextSpec with
 
       val data = getEmptyColumnDataDf(session)
 
-      val addressLength = MaxLength("att3", convertNull = true) // It's null in two rows
+      val addressLength = MaxLength("att3", analyzerOptions = Option(AnalyzerOptions(true))) // It's null in two rows
       val state: Option[MaxState] = addressLength.computeStateFrom(data)
       val metric: DoubleMetric with FullColumn = addressLength.computeMetricFrom(state)
 

--- a/src/test/scala/com/amazon/deequ/analyzers/MinLengthTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/MinLengthTest.scala
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2023 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+
+package com.amazon.deequ.analyzers
+
+import com.amazon.deequ.SparkContextSpec
+import com.amazon.deequ.metrics.DoubleMetric
+import com.amazon.deequ.metrics.FullColumn
+import com.amazon.deequ.utils.FixtureSupport
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class MinLengthTest extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport {
+
+  "MinLength" should {
+    "return row-level results for non-null columns" in withSparkSession { session =>
+
+      val data = getDfWithStringColumns(session)
+
+      val countryLength = MinLength("Country") // It's "India" in every row
+      val state: Option[MinState] = countryLength.computeStateFrom(data)
+      val metric: DoubleMetric with FullColumn = countryLength.computeMetricFrom(state)
+
+      data.withColumn("new", metric.fullColumn.get)
+        .collect().map(_.getAs[Double]("new")) shouldBe Seq(5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0, 5.0)
+    }
+
+    "return row-level results for null columns" in withSparkSession { session =>
+
+      val data = getEmptyColumnDataDf(session)
+
+      val addressLength = MinLength("att3") // It's null in two rows
+      val state: Option[MinState] = addressLength.computeStateFrom(data)
+      val metric: DoubleMetric with FullColumn = addressLength.computeMetricFrom(state)
+
+      data.withColumn("new", metric.fullColumn.get)
+        .collect().map(_.getAs[Double]("new")) shouldBe Seq(1.0, 1.0, 0.0, 1.0, 0.0, 1.0)
+    }
+
+    "return row-level results for blank strings" in withSparkSession { session =>
+
+      val data = getEmptyColumnDataDf(session)
+
+      val addressLength = MinLength("att1") // It's empty strings
+      val state: Option[MinState] = addressLength.computeStateFrom(data)
+      val metric: DoubleMetric with FullColumn = addressLength.computeMetricFrom(state)
+
+      data.withColumn("new", metric.fullColumn.get)
+        .collect().map(_.getAs[Double]("new")) shouldBe Seq(0.0, 0.0, 0.0, 0.0, 0.0, 0.0)
+    }
+  }
+
+}

--- a/src/test/scala/com/amazon/deequ/analyzers/MinLengthTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/MinLengthTest.scala
@@ -55,7 +55,7 @@ class MinLengthTest extends AnyWordSpec with Matchers with SparkContextSpec with
 
       val data = getEmptyColumnDataDf(session)
 
-      val addressLength = MinLength("att3", convertNull = true) // It's null in two rows
+      val addressLength = MinLength("att3", analyzerOptions = Option(AnalyzerOptions(true))) // It's null in two rows
       val state: Option[MinState] = addressLength.computeStateFrom(data)
       val metric: DoubleMetric with FullColumn = addressLength.computeMetricFrom(state)
 

--- a/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
@@ -228,10 +228,6 @@ class SimpleResultSerdeTest extends WordSpec with Matchers with SparkContextSpec
           |"instance":"att2","name":"Completeness","value":1.0},
           |{"dataset_date":1507975810,"entity":"Column","region":"EU",
           |"instance":"att1","name":"Completeness","value":1.0},
-          |{"dataset_date":1507975810,"entity":"Column","region":"EU",
-          |"instance":"att1","name":"MinLength","value":1.0},
-          |{"dataset_date":1507975810,"entity":"Column","region":"EU",
-          |"instance":"att1","name":"MaxLength","value":1.0},
           |{"dataset_date":1507975810,"entity":"Mutlicolumn","region":"EU",
           |"instance":"att1,att2","name":"MutualInformation","value":0.5623351446188083},
           |{"dataset_date":1507975810,"entity":"Dataset","region":"EU",
@@ -240,6 +236,10 @@ class SimpleResultSerdeTest extends WordSpec with Matchers with SparkContextSpec
           |"instance":"att1","name":"Uniqueness","value":0.25},
           |{"dataset_date":1507975810,"entity":"Column","region":"EU",
           |"instance":"att1","name":"Distinctness","value":0.5},
+          |{"dataset_date":1507975810,"entity":"Column","region":"EU",
+          |"instance":"att1","name":"MinLength","value":1.0},
+          |{"dataset_date":1507975810,"entity":"Column","region":"EU",
+          |"instance":"att1","name":"MaxLength","value":1.0},
           |{"dataset_date":1507975810,"entity":"Column","region":"EU",
           |"instance":"att2","name":"Uniqueness","value":0.25}]"""
             .stripMargin.replaceAll("\n", "")


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Building on this [PR](https://github.com/awslabs/deequ/pull/451) to add more analyzers that support row level results.

This PR address this for `MinLength`, as `MaxLength` was completed in the PR mentioned above.

In addition, this PR adds an `AnalzyerOptions` case class that gives an option to convert null values to result to failing the check. This option is not set by default, which means that for a `MinLength` analyzer, the check would succeed even if null values were present.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
