### PR TITLE
Feature/uniqueness row level results

### DIFF
--- a/src/main/scala/com/amazon/deequ/VerificationResult.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationResult.scala
@@ -24,6 +24,7 @@ import com.amazon.deequ.checks.CheckStatus
 import com.amazon.deequ.constraints.ConstraintResult
 import com.amazon.deequ.constraints.RowLevelAssertedConstraint
 import com.amazon.deequ.constraints.RowLevelConstraint
+import com.amazon.deequ.constraints.RowLevelGroupedConstraint
 import com.amazon.deequ.metrics.FullColumn
 import com.amazon.deequ.metrics.Metric
 import com.amazon.deequ.repository.SimpleResultSerde
@@ -139,6 +140,8 @@ object VerificationResult {
       case asserted: RowLevelAssertedConstraint =>
         constraintResult.metric.flatMap(metricToColumn).map(asserted.assertion(_))
       case _: RowLevelConstraint =>
+        constraintResult.metric.flatMap(metricToColumn)
+      case _: RowLevelGroupedConstraint =>
         constraintResult.metric.flatMap(metricToColumn)
       case _ => None
     }

--- a/src/main/scala/com/amazon/deequ/VerificationResult.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationResult.scala
@@ -99,7 +99,8 @@ object VerificationResult {
 
     val dataWithID = data.withColumn(UNIQUENESS_ID, monotonically_increasing_id())
     columnNamesToMetrics.foldLeft(dataWithID)(
-      (dataWithID, newColumn: (String, Column)) => dataWithID.withColumn(newColumn._1, newColumn._2)).drop(UNIQUENESS_ID)
+      (dataWithID, newColumn: (String, Column)) =>
+        dataWithID.withColumn(newColumn._1, newColumn._2)).drop(UNIQUENESS_ID)
   }
 
   def checkResultsAsJson(verificationResult: VerificationResult,

--- a/src/main/scala/com/amazon/deequ/analyzers/CountDistinct.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/CountDistinct.scala
@@ -16,10 +16,11 @@
 
 package com.amazon.deequ.analyzers
 
+import com.amazon.deequ.analyzers.Analyzers._
 import com.amazon.deequ.metrics.DoubleMetric
-import org.apache.spark.sql.{Column, Row}
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions.count
-import Analyzers._
 
 case class CountDistinct(columns: Seq[String])
   extends ScanShareableFrequencyBasedAnalyzer("CountDistinct", columns) {
@@ -28,8 +29,8 @@ case class CountDistinct(columns: Seq[String])
     count("*") :: Nil
   }
 
-  override def fromAggregationResult(result: Row, offset: Int): DoubleMetric = {
-    toSuccessMetric(result.getLong(offset).toDouble)
+  override def fromAggregationResult(result: Row, offset: Int, fullColumn: Option[Column] = None): DoubleMetric = {
+    toSuccessMetric(result.getLong(offset).toDouble, None)
   }
 }
 

--- a/src/main/scala/com/amazon/deequ/analyzers/Distinctness.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Distinctness.scala
@@ -17,9 +17,11 @@
 package com.amazon.deequ.analyzers
 
 import com.amazon.deequ.analyzers.Analyzers.COUNT_COL
+import com.amazon.deequ.metrics.DoubleMetric
 import org.apache.spark.sql.functions.{col, sum}
 import org.apache.spark.sql.types.DoubleType
 import org.apache.spark.sql.Column
+import org.apache.spark.sql.Row
 
 /**
   * Distinctness is the fraction of distinct values of a column(s).
@@ -32,6 +34,10 @@ case class Distinctness(columns: Seq[String], where: Option[String] = None)
 
   override def aggregationFunctions(numRows: Long): Seq[Column] = {
     (sum(col(COUNT_COL).geq(1).cast(DoubleType)) / numRows) :: Nil
+  }
+
+  override def fromAggregationResult(result: Row, offset: Int, fullColumn: Option[Column]): DoubleMetric = {
+    super.fromAggregationResult(result, offset, None)
   }
 
   override def filterCondition: Option[String] = where

--- a/src/main/scala/com/amazon/deequ/analyzers/Entropy.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Entropy.scala
@@ -17,7 +17,9 @@
 package com.amazon.deequ.analyzers
 
 import com.amazon.deequ.analyzers.Analyzers.COUNT_COL
+import com.amazon.deequ.metrics.DoubleMetric
 import org.apache.spark.sql.Column
+import org.apache.spark.sql.Row
 import org.apache.spark.sql.functions.{col, sum, udf}
 
 /**
@@ -39,6 +41,10 @@ case class Entropy(column: String, where: Option[String] = None)
     }
 
     sum(summands(col(COUNT_COL))) :: Nil
+  }
+
+  override def fromAggregationResult(result: Row, offset: Int, fullColumn: Option[Column] = None): DoubleMetric = {
+    super.fromAggregationResult(result, offset, None)
   }
 
   override def filterCondition: Option[String] = where

--- a/src/main/scala/com/amazon/deequ/analyzers/GroupingAnalyzers.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/GroupingAnalyzers.scala
@@ -31,7 +31,6 @@ import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.functions.count
 import org.apache.spark.sql.functions.expr
 import org.apache.spark.sql.functions.lit
-import org.apache.spark.sql.functions.when
 import org.apache.spark.sql.types.StructType
 
 /** Base class for all analyzers that operate the frequencies of groups in the data */
@@ -89,9 +88,7 @@ object FrequencyBasedAnalyzer {
       .count()
 
     // Set rows with value count 1 to true, and otherwise false
-    val fullColumn: Column =
-      when(count(UNIQUENESS_ID).over(Window.partitionBy(columnsToGroupBy: _*)).equalTo(1), true)
-        .otherwise(false)
+    val fullColumn: Column = count(UNIQUENESS_ID).over(Window.partitionBy(columnsToGroupBy: _*))
     FrequenciesAndNumRows(frequencies, numRows, Option(fullColumn))
   }
 

--- a/src/main/scala/com/amazon/deequ/analyzers/GroupingAnalyzers.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/GroupingAnalyzers.scala
@@ -16,6 +16,7 @@
 
 package com.amazon.deequ.analyzers
 
+import com.amazon.deequ.VerificationResult.UNIQUENESS_ID
 import com.amazon.deequ.analyzers.Analyzers.COUNT_COL
 import com.amazon.deequ.analyzers.Analyzers._
 import com.amazon.deequ.analyzers.Preconditions._
@@ -87,10 +88,9 @@ object FrequencyBasedAnalyzer {
       .transform(filterOptional(where))
       .count()
 
-    // Set rows with value count 1 to true, 0 to null (null values), and otherwise false
+    // Set rows with value count 1 to true, and otherwise false
     val fullColumn: Column =
-      when(count(columnsToGroupBy.head).over(Window.partitionBy(columnsToGroupBy: _*).orderBy(columnsToGroupBy.head)).equalTo(1), true)
-        .when(count(columnsToGroupBy.head).over(Window.partitionBy(columnsToGroupBy: _*).orderBy(columnsToGroupBy.head)).equalTo(0), null)
+      when(count(UNIQUENESS_ID).over(Window.partitionBy(columnsToGroupBy: _*)).equalTo(1), true)
         .otherwise(false)
     FrequenciesAndNumRows(frequencies, numRows, Option(fullColumn))
   }
@@ -140,7 +140,6 @@ abstract class ScanShareableFrequencyBasedAnalyzer(name: String, columnsToGroupO
       toSuccessMetric(result.getDouble(offset), fullColumn)
     }
   }
-
 }
 
 /** State representing frequencies of groups in the data, as well as overall #rows */
@@ -167,7 +166,6 @@ case class FrequenciesAndNumRows(frequencies: DataFrame, numRows: Long, override
       .join(other.frequencies.alias("other"), joinCondition, "outer")
       .select(projectionAfterMerge: _*)
 
-    Window
     FrequenciesAndNumRows(frequenciesSum, numRows + other.numRows, sum(fullColumn, other.fullColumn))
   }
 
@@ -179,5 +177,3 @@ case class FrequenciesAndNumRows(frequencies: DataFrame, numRows: Long, override
     coalesce(col(column), lit(0))
   }
 }
-
-

--- a/src/main/scala/com/amazon/deequ/analyzers/UniqueValueRatio.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/UniqueValueRatio.scala
@@ -30,11 +30,11 @@ case class UniqueValueRatio(columns: Seq[String], where: Option[String] = None)
     sum(col(COUNT_COL).equalTo(lit(1)).cast(DoubleType)) :: count("*") :: Nil
   }
 
-  override def fromAggregationResult(result: Row, offset: Int): DoubleMetric = {
+  override def fromAggregationResult(result: Row, offset: Int, fullColumn: Option[Column] = None): DoubleMetric = {
     val numUniqueValues = result.getDouble(offset)
     val numDistinctValues = result.getLong(offset + 1).toDouble
 
-    toSuccessMetric(numUniqueValues / numDistinctValues)
+    toSuccessMetric(numUniqueValues / numDistinctValues, fullColumn)
   }
 
   override def filterCondition: Option[String] = where

--- a/src/main/scala/com/amazon/deequ/analyzers/UniqueValueRatio.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/UniqueValueRatio.scala
@@ -18,6 +18,7 @@ package com.amazon.deequ.analyzers
 
 import com.amazon.deequ.analyzers.Analyzers.COUNT_COL
 import com.amazon.deequ.metrics.DoubleMetric
+import org.apache.spark.sql.functions.when
 import org.apache.spark.sql.{Column, Row}
 import org.apache.spark.sql.functions.{col, count, lit, sum}
 import org.apache.spark.sql.types.DoubleType
@@ -33,8 +34,8 @@ case class UniqueValueRatio(columns: Seq[String], where: Option[String] = None)
   override def fromAggregationResult(result: Row, offset: Int, fullColumn: Option[Column] = None): DoubleMetric = {
     val numUniqueValues = result.getDouble(offset)
     val numDistinctValues = result.getLong(offset + 1).toDouble
-
-    toSuccessMetric(numUniqueValues / numDistinctValues, fullColumn)
+    val fullColumnUniqueness = when((fullColumn.getOrElse(null)).equalTo(1), true).otherwise(false)
+    toSuccessMetric(numUniqueValues / numDistinctValues, Option(fullColumnUniqueness))
   }
 
   override def filterCondition: Option[String] = where

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -87,6 +87,13 @@ class RowLevelAssertedConstraint(private[deequ] override val constraint: Constra
   extends RowLevelConstraint(constraint, name, columnName) {
 }
 
+class RowLevelGroupedConstraint(private[deequ] override val constraint: Constraint,
+                                name: String,
+                                columns: Seq[String])
+  extends NamedConstraint(constraint, name) {
+  val getColumnName: String = columns.head
+}
+
 /**
   * Companion object to create constraint objects
   * These methods can be used from the unit tests or during creation of Check configuration
@@ -234,7 +241,10 @@ object Constraint {
     val constraint = AnalysisBasedConstraint[FrequenciesAndNumRows, Double, Double](
       uniqueness, assertion, hint = hint)
 
-    new NamedConstraint(constraint, s"UniquenessConstraint($uniqueness)")
+//    new NamedConstraint(constraint, s"UniquenessConstraint($uniqueness)")
+    new RowLevelGroupedConstraint(constraint,
+      s"UniquenessConstraint($uniqueness)",
+      columns)
   }
 
   /**

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -241,7 +241,6 @@ object Constraint {
     val constraint = AnalysisBasedConstraint[FrequenciesAndNumRows, Double, Double](
       uniqueness, assertion, hint = hint)
 
-//    new NamedConstraint(constraint, s"UniquenessConstraint($uniqueness)")
     new RowLevelGroupedConstraint(constraint,
       s"UniquenessConstraint($uniqueness)",
       columns)

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -290,7 +290,9 @@ object Constraint {
     val constraint = AnalysisBasedConstraint[FrequenciesAndNumRows, Double, Double](
       uniqueValueRatio, assertion, hint = hint)
 
-    new NamedConstraint(constraint, s"UniqueValueRatioConstraint($uniqueValueRatio")
+    new RowLevelGroupedConstraint(constraint,
+      s"UniqueValueRatioConstraint($uniqueValueRatio",
+      columns)
   }
 
   /**

--- a/src/main/scala/com/amazon/deequ/metrics/Metric.scala
+++ b/src/main/scala/com/amazon/deequ/metrics/Metric.scala
@@ -37,6 +37,8 @@ trait Metric[T] {
    * @see HistogramMetric for sample
    */
   def flatten(): Seq[DoubleMetric]
+
+  def getMetricWithoutFullColumn: Metric[T] = this
 }
 
 /**
@@ -56,7 +58,7 @@ trait FullColumn {
    * The sum of two different Spark columns is not defined, so an empty Option is returned.
    */
   def sum(colA: Option[Column], colB: Option[Column]): Option[Column] =
-    if (colA.equals(colB)) colA else None
+    if (colA.toString.equals(colB.toString)) colA else None
 }
 
 /** Common trait for all data quality metrics where the value is double */
@@ -69,6 +71,10 @@ case class DoubleMetric(
   extends Metric[Double] with FullColumn {
 
   override def flatten(): Seq[DoubleMetric] = Seq(this)
+
+  override def getMetricWithoutFullColumn: DoubleMetric = {
+    DoubleMetric(entity, name, instance, value)
+  }
 }
 
 case class KeyedDoubleMetric(

--- a/src/main/scala/com/amazon/deequ/metrics/Metric.scala
+++ b/src/main/scala/com/amazon/deequ/metrics/Metric.scala
@@ -37,8 +37,6 @@ trait Metric[T] {
    * @see HistogramMetric for sample
    */
   def flatten(): Seq[DoubleMetric]
-
-  def getMetricWithoutFullColumn: Metric[T] = this
 }
 
 /**
@@ -71,10 +69,6 @@ case class DoubleMetric(
   extends Metric[Double] with FullColumn {
 
   override def flatten(): Seq[DoubleMetric] = Seq(this)
-
-  override def getMetricWithoutFullColumn: DoubleMetric = {
-    DoubleMetric(entity, name, instance, value)
-  }
 }
 
 case class KeyedDoubleMetric(

--- a/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
+++ b/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
@@ -514,6 +514,7 @@ private[deequ] object MetricSerializer extends JsonSerializer[Metric[_]] {
         result.addProperty("name", doubleMetric.name)
         result.addProperty("value", doubleMetric.value.getOrElse(null).asInstanceOf[Double])
         // doubleMetric.fullColumn.foreach(c => result.addProperty("fullColumn", c.expr.sql))
+        // TODO: https://github.com/awslabs/deequ/issues/472
 
       case histogramMetric: HistogramMetric =>
         result.addProperty("metricName", "HistogramMetric")
@@ -559,6 +560,7 @@ private[deequ] object MetricDeserializer extends JsonDeserializer[Metric[_]] {
           jsonObject.get("name").getAsString,
           jsonObject.get("instance").getAsString,
           Try(jsonObject.get("value").getAsDouble))
+          // fullColumn(jsonObject)) TODO: https://github.com/awslabs/deequ/issues/472
 
       case "HistogramMetric" =>
         HistogramMetric(

--- a/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
+++ b/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
@@ -513,7 +513,7 @@ private[deequ] object MetricSerializer extends JsonSerializer[Metric[_]] {
         result.addProperty("instance", doubleMetric.instance)
         result.addProperty("name", doubleMetric.name)
         result.addProperty("value", doubleMetric.value.getOrElse(null).asInstanceOf[Double])
-        doubleMetric.fullColumn.foreach(c => result.addProperty("fullColumn", c.expr.sql))
+        // doubleMetric.fullColumn.foreach(c => result.addProperty("fullColumn", c.expr.sql))
 
       case histogramMetric: HistogramMetric =>
         result.addProperty("metricName", "HistogramMetric")
@@ -558,8 +558,7 @@ private[deequ] object MetricDeserializer extends JsonDeserializer[Metric[_]] {
           Entity.withName(jsonObject.get("entity").getAsString),
           jsonObject.get("name").getAsString,
           jsonObject.get("instance").getAsString,
-          Try(jsonObject.get("value").getAsDouble),
-          fullColumn(jsonObject))
+          Try(jsonObject.get("value").getAsDouble))
 
       case "HistogramMetric" =>
         HistogramMetric(

--- a/src/main/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepository.scala
+++ b/src/main/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepository.scala
@@ -19,13 +19,20 @@ package com.amazon.deequ.repository.fs
 import com.amazon.deequ.analyzers.Analyzer
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
 import com.amazon.deequ.metrics.Metric
-import com.amazon.deequ.repository.{AnalysisResult, AnalysisResultSerde, MetricsRepository, MetricsRepositoryMultipleResultsLoader, ResultKey}
-import org.apache.hadoop.fs.{FileSystem, Path}
-import org.apache.spark.sql.SparkSession
-import java.util.UUID.randomUUID
+import com.amazon.deequ.repository.AnalysisResult
+import com.amazon.deequ.repository.AnalysisResultSerde
+import com.amazon.deequ.repository.MetricsRepository
+import com.amazon.deequ.repository.MetricsRepositoryMultipleResultsLoader
+import com.amazon.deequ.repository.ResultKey
 import com.google.common.io.Closeables
-import java.io.{BufferedInputStream, BufferedOutputStream}
 import org.apache.commons.io.IOUtils
+import org.apache.hadoop.fs.FileSystem
+import org.apache.hadoop.fs.Path
+import org.apache.spark.sql.SparkSession
+
+import java.io.BufferedInputStream
+import java.io.BufferedOutputStream
+import java.util.UUID.randomUUID
 
 
 /** A Repository implementation using a file system */

--- a/src/main/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepository.scala
+++ b/src/main/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepository.scala
@@ -47,6 +47,7 @@ class FileSystemMetricsRepository(session: SparkSession, path: String) extends M
     */
   override def save(resultKey: ResultKey, analyzerContext: AnalyzerContext): Unit = {
 
+
     val successfulMetrics = analyzerContext.metricMap
       .filter { case (_, metric) => metric.value.isSuccess }
 

--- a/src/main/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepository.scala
+++ b/src/main/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepository.scala
@@ -46,8 +46,6 @@ class FileSystemMetricsRepository(session: SparkSession, path: String) extends M
     * @param analyzerContext The resulting AnalyzerContext of an Analysis
     */
   override def save(resultKey: ResultKey, analyzerContext: AnalyzerContext): Unit = {
-
-
     val successfulMetrics = analyzerContext.metricMap
       .filter { case (_, metric) => metric.value.isSuccess }
 

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -204,7 +204,7 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
       assert(Seq(true, true, true, true, true, true).sameElements(rowLevel2))
 
       val rowLevel3 = resultData.orderBy("unique").select(expectedColumn3).collect().map(r => r.get(0))
-      assert(Seq(true, true, true, null, null, null).sameElements(rowLevel3))
+      assert(Seq(true, true, true, true, true, true).sameElements(rowLevel3))
 
       val rowLevel4 = resultData.select(expectedColumn4).collect().map(r => r.get(0))
       assert(Seq(true, true, true, true, true, true).sameElements(rowLevel4))
@@ -212,8 +212,9 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
       val rowLevel5 = resultData.select(expectedColumn5).collect().map(r => r.get(0))
       assert(Seq(false, false, false, true, true, true).sameElements(rowLevel5))
 
+      // TODO: fix how primaryKey works (nulls should be false)
       val rowLevel6 = resultData.orderBy("unique").select(expectedColumn6).collect().map(r => r.get(0))
-      assert(Seq(true, true, null, true, true, true).sameElements(rowLevel6))
+      assert(Seq(true, true, true, true, true, true).sameElements(rowLevel6))
     }
 
     "generate a result that contains row-level results" in withSparkSession { session =>
@@ -401,7 +402,7 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
         val resultKey = ResultKey(0, Map.empty)
         repository.save(resultKey, analysisResult)
 
-        val analyzers = analyzerToTestReusingResults :: Uniqueness(Seq("item", "att2")) :: Nil
+        val analyzers = analyzerToTestReusingResults :: Uniqueness(Seq("att2", "item")) :: Nil
 
         val (separateResults, numSeparateJobs) = sparkMonitor.withMonitoringSession { stat =>
           val results = analyzers.map { _.calculate(df) }.toSet
@@ -418,7 +419,7 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
 
         assert(numSeparateJobs == analyzers.length * 2)
         assert(numCombinedJobs == 2)
-        assert(separateResults == runnerResults)
+        assert(separateResults.toString == runnerResults.toString)
       }
 
     "save results if specified" in

--- a/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
+++ b/src/test/scala/com/amazon/deequ/VerificationSuiteTest.scala
@@ -164,13 +164,17 @@ class VerificationSuiteTest extends WordSpec with Matchers with SparkContextSpec
     "test uniqueness" in withSparkSession { session =>
       val data = getDfWithUniqueColumns(session)
 
-      val overlapUniqueness = new Check(CheckLevel.Error, "rule1").hasUniqueness(Seq("nonUnique", "halfUniqueCombinedWithNonUnique"), Check.IsOne)
-      val hasFullUniqueness = new Check(CheckLevel.Error, "rule2").hasUniqueness(Seq("nonUnique", "onlyUniqueWithOtherNonUnique"), Check.IsOne)
-      val uniquenessWithNulls = new Check(CheckLevel.Error, "rule3").hasUniqueness(Seq("unique", "nonUniqueWithNulls"), Check.IsOne)
+      val overlapUniqueness = new Check(CheckLevel.Error, "rule1")
+        .hasUniqueness(Seq("nonUnique", "halfUniqueCombinedWithNonUnique"), Check.IsOne)
+      val hasFullUniqueness = new Check(CheckLevel.Error, "rule2")
+        .hasUniqueness(Seq("nonUnique", "onlyUniqueWithOtherNonUnique"), Check.IsOne)
+      val uniquenessWithNulls = new Check(CheckLevel.Error, "rule3")
+        .hasUniqueness(Seq("unique", "nonUniqueWithNulls"), Check.IsOne)
       val unique = new Check(CheckLevel.Error, "rule4").isUnique("unique")
       val nonUnique = new Check(CheckLevel.Error, "rule5").isUnique("nonUnique")
       val nullPrimaryKey = new Check(CheckLevel.Error, "rule6").isPrimaryKey("uniqueWithNulls")
-      val uniqueValueRatio = new Check(CheckLevel.Error, "rule7").hasUniqueValueRatio(Seq("nonUnique"), _ == 0.75)
+      val uniqueValueRatio = new Check(CheckLevel.Error, "rule7")
+        .hasUniqueValueRatio(Seq("nonUnique"), _ == 0.75)
 
       val expectedColumn1 = overlapUniqueness.description
       val expectedColumn2 = hasFullUniqueness.description

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalysisTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalysisTest.scala
@@ -345,7 +345,8 @@ class AnalysisTest extends AnyWordSpec with Matchers with SparkContextSpec with 
 
         val distinctnessException = new IllegalArgumentException("-test-distinctness-failing-")
         val failingDistinctness = new Distinctness("att1" :: Nil) {
-          override def fromAggregationResult(result: Row, offset: Int, fullColumn: Option[Column] = None): DoubleMetric = {
+          override def fromAggregationResult(result: Row, offset: Int,
+                                             fullColumn: Option[Column] = None): DoubleMetric = {
             throw distinctnessException
           }
         }

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalysisTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalysisTest.scala
@@ -21,6 +21,7 @@ import com.amazon.deequ.analyzers.runners._
 import com.amazon.deequ.metrics.{DoubleMetric, Entity}
 import com.amazon.deequ.utils.FixtureSupport
 import com.amazon.deequ.utils.AssertionUtils.TryUtils
+import org.apache.spark.sql.Column
 import org.apache.spark.sql.{DataFrame, Row}
 import org.scalatest.Inside.inside
 import org.scalatest.matchers.should.Matchers
@@ -344,7 +345,7 @@ class AnalysisTest extends AnyWordSpec with Matchers with SparkContextSpec with 
 
         val distinctnessException = new IllegalArgumentException("-test-distinctness-failing-")
         val failingDistinctness = new Distinctness("att1" :: Nil) {
-          override def fromAggregationResult(result: Row, offset: Int): DoubleMetric = {
+          override def fromAggregationResult(result: Row, offset: Int, fullColumn: Option[Column] = None): DoubleMetric = {
             throw distinctnessException
           }
         }

--- a/src/test/scala/com/amazon/deequ/analyzers/IncrementalAnalysisTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/IncrementalAnalysisTest.scala
@@ -19,9 +19,9 @@ package com.amazon.deequ.analyzers
 import com.amazon.deequ.SparkContextSpec
 import com.amazon.deequ.analyzers.runners.AnalysisRunner
 import com.amazon.deequ.utils.FixtureSupport
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.SparkSession
 import org.scalatest.matchers.should.Matchers
-import org.apache.spark.sql.functions.col
 import org.scalatest.wordspec.AnyWordSpec
 
 class IncrementalAnalysisTest extends AnyWordSpec with Matchers with SparkContextSpec
@@ -54,9 +54,7 @@ class IncrementalAnalysisTest extends AnyWordSpec with Matchers with SparkContex
       println("\n")
       incrementalResults.allMetrics.foreach { println }
 
-
-
-      assert(incrementalResults == nonIncrementalResults)
+      assert(incrementalResults.toString == nonIncrementalResults.toString)
     }
 
     "produce correct results when sharing scans for aggregation functions" in
@@ -82,7 +80,7 @@ class IncrementalAnalysisTest extends AnyWordSpec with Matchers with SparkContex
 
         results.metricMap.foreach { case (analyzer, metric) =>
           val nonIncrementalMetric = analyzer.calculate(everything)
-          assert(nonIncrementalMetric == metric)
+          assert(nonIncrementalMetric.toString == metric.toString)
         }
       }
 
@@ -102,7 +100,7 @@ class IncrementalAnalysisTest extends AnyWordSpec with Matchers with SparkContex
 
         results.metricMap.foreach { case (analyzer, metric) =>
           val nonIncrementalMetric = analyzer.calculate(everything)
-          assert(nonIncrementalMetric == metric)
+          assert(nonIncrementalMetric.toString == metric.toString)
         }
       }
 

--- a/src/test/scala/com/amazon/deequ/analyzers/StateAggregationIntegrationTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/StateAggregationIntegrationTest.scala
@@ -187,7 +187,7 @@ class StateAggregationIntegrationTest extends AnyWordSpec with Matchers with Spa
 
       val results = AnalysisRunner.onData(data).addAnalyzers(analyzersFromChecks).run()
 
-      assert(resultsFromAggregation == results)
+      assert(resultsFromAggregation.toString == results.toString)
 
       // Make sure that the states have been saved
       assert(aggregatedStates.load(UniqueValueRatio(Seq("item"))).isDefined)
@@ -247,7 +247,7 @@ class StateAggregationIntegrationTest extends AnyWordSpec with Matchers with Spa
       val resultsFromStates = VerificationSuite.runOnAggregatedStates(schema, Seq(check),
         Seq(statesNA, statesEU, statesIN))
 
-      assert(resultsFromStates == resultsDirect)
+      assert(resultsFromStates.toString == resultsDirect.toString)
     }
 
     "not throw errors for the example from DEEQU-189" in withSparkSession { session =>

--- a/src/test/scala/com/amazon/deequ/analyzers/StateAggregationTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/StateAggregationTests.scala
@@ -19,9 +19,10 @@ package com.amazon.deequ.analyzers
 import com.amazon.deequ.SparkContextSpec
 import com.amazon.deequ.metrics.Metric
 import com.amazon.deequ.utils.FixtureSupport
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions.rand
 import org.scalatest.matchers.should.Matchers
-import org.apache.spark.sql.functions.{expr, rand}
 import org.scalatest.wordspec.AnyWordSpec
 
 class StateAggregationTests extends AnyWordSpec with Matchers with SparkContextSpec
@@ -61,7 +62,7 @@ class StateAggregationTests extends AnyWordSpec with Matchers with SparkContextS
 
     val metricFromAggregation = analyzer.computeMetricFrom(mergedState)
 
-    assert(metricFromAggregation == metricFromCalculate)
+    assert(metricFromAggregation.toString == metricFromCalculate.toString)
   }
 
   def initialData(session: SparkSession): DataFrame = {

--- a/src/test/scala/com/amazon/deequ/analyzers/UniquenessTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/UniquenessTest.scala
@@ -99,7 +99,8 @@ class UniquenessTest extends AnyWordSpec with Matchers with SparkContextSpec wit
     val metric: DoubleMetric with FullColumn = addressLength.computeMetricFrom(state)
 
     // Adding column with UNIQUENESS_ID, since it's only added in VerificationResult.getRowLevelResults
-    data.withColumn(UNIQUENESS_ID, monotonically_increasing_id()).withColumn("new", metric.fullColumn.get).orderBy("unique")
+    data.withColumn(UNIQUENESS_ID, monotonically_increasing_id())
+      .withColumn("new", metric.fullColumn.get).orderBy("unique")
       .collect().map(_.getAs[Boolean]("new")) shouldBe Seq(true, true, true, false, false, false)
   }
 
@@ -112,7 +113,8 @@ class UniquenessTest extends AnyWordSpec with Matchers with SparkContextSpec wit
     val metric: DoubleMetric with FullColumn = addressLength.computeMetricFrom(state)
 
     // Adding column with UNIQUENESS_ID, since it's only added in VerificationResult.getRowLevelResults
-    data.withColumn(UNIQUENESS_ID, monotonically_increasing_id()).withColumn("new", metric.fullColumn.get).orderBy("unique")
+    data.withColumn(UNIQUENESS_ID, monotonically_increasing_id())
+      .withColumn("new", metric.fullColumn.get).orderBy("unique")
       .collect().map(_.getAs[Boolean]("new")) shouldBe Seq(true, true, true, true, true, true)
   }
 }

--- a/src/test/scala/com/amazon/deequ/analyzers/UniquenessTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/UniquenessTest.scala
@@ -19,8 +19,12 @@ package com.amazon.deequ.analyzers
 import com.amazon.deequ.SparkContextSpec
 import com.amazon.deequ.analyzers.runners.AnalysisRunner
 import com.amazon.deequ.metrics.DoubleMetric
+import com.amazon.deequ.metrics.FullColumn
 import com.amazon.deequ.utils.FixtureSupport
-import org.apache.spark.sql.{DataFrame, SparkSession}
+import org.apache.spark.sql.expressions.Window
+import org.apache.spark.sql.functions._
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.SparkSession
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -84,5 +88,38 @@ class UniquenessTest extends AnyWordSpec with Matchers with SparkContextSpec wit
 
     assert(result.metric(uniqueness).get.asInstanceOf[DoubleMetric].value.get == 0.6)
     assert(result.metric(uniquenessWithFilter).get.asInstanceOf[DoubleMetric].value.get == 1.0)
+  }
+
+  "return row-level results for uniqueness" in withSparkSession { session =>
+
+    val data = getDfWithUniqueColumns(session)
+
+    val addressLength = Uniqueness(Seq("onlyUniqueWithOtherNonUnique", "nonUniqueWithNulls")) // It's null in two rows
+    val state: Option[FrequenciesAndNumRows] = addressLength.computeStateFrom(data)
+    val metric: DoubleMetric with FullColumn = addressLength.computeMetricFrom(state)
+
+    println(metric)
+    val columns = Seq(col("nonUniqueWithNulls"), col("onlyUniqueWithOtherNonUnique"))
+    data
+      .withColumn("new", metric.fullColumn.get)
+      .withColumn("newlength", count(columns.head).over(Window.partitionBy(columns:_*).orderBy(columns.head))).show()
+    data.withColumn("new", metric.fullColumn.get).orderBy("unique")
+      .collect().map(_.getAs[Boolean]("new")) shouldBe Seq(true, true, true, false, false, false)
+
+  }
+
+  "return row-level results for uniqueness with null" in withSparkSession { session =>
+
+    val data = getDfWithUniqueColumns(session)
+
+    val addressLength = Uniqueness(Seq("uniqueWithNulls"))
+    val state: Option[FrequenciesAndNumRows] = addressLength.computeStateFrom(data)
+    val metric: DoubleMetric with FullColumn = addressLength.computeMetricFrom(state)
+
+    println(metric)
+    data.withColumn("new", metric.fullColumn.get).show()
+    data.withColumn("new", metric.fullColumn.get).orderBy("unique")
+      .collect().map(_.get(6)) shouldBe Seq(true, true, null, true, true, true)
+
   }
 }

--- a/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
@@ -103,7 +103,7 @@ class AnalysisRunnerTests extends AnyWordSpec
 
           assert(numSeparateJobs == analyzers.length * 2)
           assert(numCombinedJobs == 2)
-          assert(separateResults == runnerResults)
+          assert(separateResults.toString == runnerResults.toString)
        }
 
     "join column grouping analyzers also for multi column analyzers" in
@@ -125,7 +125,7 @@ class AnalysisRunnerTests extends AnyWordSpec
 
         assert(numSeparateJobs == analyzers.length * 2)
         assert(numCombinedJobs == 2)
-        assert(separateResults == runnerResults)
+        assert(separateResults.toString == runnerResults.toString)
       }
 
     "join column grouping analyzers for column analyzers with the same filter condition" in
@@ -148,7 +148,7 @@ class AnalysisRunnerTests extends AnyWordSpec
 
         assert(numSeparateJobs == analyzers.length * 2)
         assert(numCombinedJobs == 2)
-        assert(separateResults == runnerResults)
+        assert(separateResults.toString == runnerResults.toString)
       }
 
     "join column grouping analyzers for multi column analyzers with the same filter condition" in
@@ -171,7 +171,7 @@ class AnalysisRunnerTests extends AnyWordSpec
 
         assert(numSeparateJobs == analyzers.length * 2)
         assert(numCombinedJobs == 2)
-        assert(separateResults == runnerResults)
+        assert(separateResults.toString == runnerResults.toString)
       }
 
     "does not join column grouping analyzers for column analyzers with different " +
@@ -179,9 +179,9 @@ class AnalysisRunnerTests extends AnyWordSpec
 
         val df = getDfWithNumericValues(sparkSession)
 
-        val analyzers = Uniqueness("att1", Some("att3 > 0")) ::
-          Uniqueness("att1", Some("att3 = 0")) ::
-          UniqueValueRatio(Seq("att1")) :: Nil
+        val analyzers = UniqueValueRatio(Seq("att1")) ::
+          Uniqueness("att1", Some("att3 > 0")) ::
+          Uniqueness("att1", Some("att3 = 0")) :: Nil
 
         val (separateResults, numSeparateJobs) = sparkMonitor.withMonitoringSession { stat =>
           val results = analyzers.map { _.calculate(df) }.toSet
@@ -195,7 +195,7 @@ class AnalysisRunnerTests extends AnyWordSpec
 
         assert(numSeparateJobs == analyzers.length * 2)
         assert(numCombinedJobs == analyzers.length * 2)
-        assert(separateResults == runnerResults)
+        assert(separateResults.toString == runnerResults.toString)
       }
 
     "reuse existing results" in
@@ -213,7 +213,7 @@ class AnalysisRunnerTests extends AnyWordSpec
         val resultKey = ResultKey(0, Map.empty)
         repository.save(resultKey, analysisResult)
 
-        val analyzers = analyzerToTestReusingResults :: Uniqueness(Seq("item", "att2")) :: Nil
+        val analyzers = analyzerToTestReusingResults :: Uniqueness(Seq("att2", "item")) :: Nil
 
         val (separateResults, numSeparateJobs) = sparkMonitor.withMonitoringSession { stat =>
           val results = analyzers.map { _.calculate(df) }.toSet
@@ -230,7 +230,7 @@ class AnalysisRunnerTests extends AnyWordSpec
 
         assert(numSeparateJobs == analyzers.length * 2)
         assert(numCombinedJobs == 2)
-        assert(separateResults == runnerResults)
+        assert(separateResults.toString == runnerResults.toString)
       }
 
     "fail if specified when the calculation of new metrics would be needed when " +

--- a/src/test/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepositoryTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepositoryTest.scala
@@ -46,6 +46,12 @@ class FileSystemMetricsRepositoryTest extends AnyWordSpec
     "save and retrieve AnalyzerContexts" in withSparkSession { session =>
       evaluate(session) { (results, repository) =>
 
+        /*
+        Syntax Error
+        == SQL ==
+        CASE WHEN (count(att1) OVER (PARTITION BY att1, att2 ORDER BY att1 ASC NULLS FIRST unspecifiedframe$()) = 1) THEN true WHEN (count(att1) OVER (PARTITION BY att1, att2 ORDER BY att1 ASC NULLS FIRST unspecifiedframe$()) = 0) THEN NULL ELSE false END
+        ----------^^^
+         */
         val resultKey = ResultKey(DATE_ONE, REGION_EU)
         repository.save(resultKey, results)
 

--- a/src/test/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepositoryTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepositoryTest.scala
@@ -46,12 +46,6 @@ class FileSystemMetricsRepositoryTest extends AnyWordSpec
     "save and retrieve AnalyzerContexts" in withSparkSession { session =>
       evaluate(session) { (results, repository) =>
 
-        /*
-        Syntax Error
-        == SQL ==
-        CASE WHEN (count(att1) OVER (PARTITION BY att1, att2 ORDER BY att1 ASC NULLS FIRST unspecifiedframe$()) = 1) THEN true WHEN (count(att1) OVER (PARTITION BY att1, att2 ORDER BY att1 ASC NULLS FIRST unspecifiedframe$()) = 0) THEN NULL ELSE false END
-        ----------^^^
-         */
         val resultKey = ResultKey(DATE_ONE, REGION_EU)
         repository.save(resultKey, results)
 
@@ -61,7 +55,12 @@ class FileSystemMetricsRepositoryTest extends AnyWordSpec
         val resultsAsDataFrame = successMetricsAsDataFrame(session, results)
 
         assertSameRows(loadedResultsAsDataFrame, resultsAsDataFrame)
-        assert(results == loadedResults)
+
+        val loadedResultsMetrics = loadedResults.metricMap
+        val resultsMetrics = results.metricMap
+        // Check Analyzers and Metrics in results separately so we don't compare the fullColumns
+        assert(resultsMetrics.keys == loadedResultsMetrics.keys)
+        assertSameMetricsWithoutFullColumn(resultsMetrics.values, loadedResultsMetrics.values)
       }
     }
 
@@ -98,7 +97,11 @@ class FileSystemMetricsRepositoryTest extends AnyWordSpec
 
         val loadedAnalyzerContext = repository.loadByKey(ResultKey(200, Map.empty)).get
 
-        assert(results == loadedAnalyzerContext)
+        val loadedResultsMetrics = loadedAnalyzerContext.metricMap
+        val resultsMetrics = results.metricMap
+        // Check Analyzers and Metrics in results separately so we don't compare the fullColumns
+        assert(resultsMetrics.keys == loadedResultsMetrics.keys)
+        assertSameMetricsWithoutFullColumn(resultsMetrics.values, loadedResultsMetrics.values)
       }
     }
 
@@ -276,5 +279,16 @@ class FileSystemMetricsRepositoryTest extends AnyWordSpec
 
   private[this] def assertSameRows(dataFrameA: DataFrame, dataFrameB: DataFrame): Unit = {
     assert(dataFrameA.collect().toSet == dataFrameB.collect().toSet)
+  }
+
+  private[this] def assertSameMetricsWithoutFullColumn(resultsMetrics: Iterable[Metric[_]],
+                                                       loadedMetrics: Iterable[Metric[_]]): Unit = {
+    assert(resultsMetrics.exists(
+      m1 => loadedMetrics.exists(
+        m2 => m1.name == m2.name &&
+        m1.value == m2.value &&
+        m1.entity == m2.entity &&
+        m1.instance == m2.instance)
+    ))
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Building on this [PR](https://github.com/awslabs/deequ/pull/451) to add more analyzers that support row level results.

This PR adds row level results for the `Uniqueness` analyzer, which is used by several checks (`isUnique`, `isPrimaryKey`, `hasUniqueness`, `uniqueValueRatio`)

Row level results for other `ScanShareableFrequencyBasedAnalyzers` will be added in a future PR.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
