### PR TITLE
[Experimental] Added a function to the Data Synchronization utility for annotating the dataframe with row level results

### DIFF
--- a/src/main/scala/com/amazon/deequ/comparison/ComparisonBase.scala
+++ b/src/main/scala/com/amazon/deequ/comparison/ComparisonBase.scala
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2022 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.comparison
+
+trait ComparisonBase {
+  val defaultOutcomeColumnName = "outcome"
+  val referenceColumnNamePrefix = "ref_col"
+}

--- a/src/main/scala/com/amazon/deequ/comparison/ReferentialIntegrity.scala
+++ b/src/main/scala/com/amazon/deequ/comparison/ReferentialIntegrity.scala
@@ -21,9 +21,7 @@ import org.apache.spark.sql.functions.{col, lit, when}
 
 import scala.util.Try
 
-object ReferentialIntegrity {
-  private val defaultOutcomeColumnName = "outcome"
-  private val referenceColumnNamePrefix = "ref_col"
+object ReferentialIntegrity extends ComparisonBase {
 
   /**
    * Checks to what extent a set of columns from a DataFrame is a subset of another set of columns


### PR DESCRIPTION
*Description of changes:*

- We hash the non key columns from both dataframes and store them as additional columns in each dataframe.
- We use the key columns map and the hash columns to join the data frames.
- We then check if the key columns and the hash column from the second dataframe are not null. If not null, then the row matches, otherwise it does not.
- Added tests to verify the behavior for non-nested and nested data.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
