### PR TITLE
Alternative aggregate functions to calculate histogram values.

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/Histogram.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Histogram.scala
@@ -138,15 +138,6 @@ object Histogram {
   val count_function = "count"
   val sum_function = "sum"
 
-
-  def createAggregateFunction(function: String, aggregateColumn: String): AggregateFunction = {
-    function match {
-      case Histogram.count_function => Count
-      case Histogram.sum_function => Sum(aggregateColumn)
-      case _ => throw new IllegalArgumentException("Wrong aggregate function name: " + function)
-    }
-  }
-
   sealed trait AggregateFunction {
     def query(column: String, data: DataFrame): DataFrame
 
@@ -196,40 +187,6 @@ object Histogram {
 
     override def function(): String = sum_function
   }
-
-//  case class Min(aggColumn: String) extends AggregateFunction {
-//    override def query(column: String, data: DataFrame): DataFrame = {
-//      data
-//        .select(col(column).cast(StringType), col(aggColumn).cast(LongType))
-//        .na.fill(Histogram.NullFieldReplacement)
-//        .groupBy(column)
-//        .min(aggColumn)
-//        .withColumnRenamed("count", Analyzers.COUNT_COL)
-//    }
-//
-//    override def aggregateColumn(): Option[String] = {
-//      Some(aggColumn)
-//    }
-//
-//    override def function(): String = min
-//  }
-//
-//  case class Max(aggColumn: String) extends AggregateFunction {
-//    override def query(column: String, data: DataFrame): DataFrame = {
-//      data
-//        .select(col(column).cast(StringType), col(aggColumn).cast(LongType))
-//        .na.fill(Histogram.NullFieldReplacement)
-//        .groupBy(column)
-//        .max(aggColumn)
-//        .withColumnRenamed("count", Analyzers.COUNT_COL)
-//    }
-//
-//    override def aggregateColumn(): Option[String] = {
-//      Some(aggColumn)
-//    }
-//
-//    override def function(): String = max
-//  }
 }
 
 

--- a/src/main/scala/com/amazon/deequ/analyzers/Histogram.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Histogram.scala
@@ -189,9 +189,6 @@ object Histogram {
   }
 }
 
-
-
-
 object OrderByAbsoluteCount extends Ordering[Row] {
   override def compare(x: Row, y: Row): Int = {
     x.getLong(1).compareTo(y.getLong(1))

--- a/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
+++ b/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
@@ -302,9 +302,9 @@ private[deequ] object AnalyzerSerializer
         result.addProperty(ANALYZER_NAME_FIELD, "Histogram")
         result.addProperty(COLUMN_FIELD, histogram.column)
         result.addProperty("maxDetailBins", histogram.maxDetailBins)
-        result.addProperty("aggregateFunction", histogram.aggregateFunction)
-        if (histogram.aggregateColumn.isDefined) {
-          result.addProperty("aggregateColumn", histogram.aggregateColumn.get)
+        if (histogram.aggregateFunction != Histogram.Count) {
+          result.addProperty("aggregateFunction", histogram.aggregateFunction.function())
+          result.addProperty("aggregateColumn", histogram.aggregateFunction.aggregateColumn().get)
         }
 
       case _ : Histogram =>
@@ -441,8 +441,9 @@ private[deequ] object AnalyzerDeserializer
           json.get(COLUMN_FIELD).getAsString,
           None,
           json.get("maxDetailBins").getAsInt,
-          aggregateFunction = getOptionalStringParam(json, "aggregateFunction").getOrElse(Histogram.Count),
-          aggregateColumn = getOptionalStringParam(json, "aggregateColumn"))
+          aggregateFunction = Histogram.createAggregateFunction(
+            getOptionalStringParam(json, "aggregateFunction").getOrElse(Histogram.count_function),
+            getOptionalStringParam(json, "aggregateColumn").getOrElse("")))
 
       case "DataType" =>
         DataType(

--- a/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
+++ b/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
@@ -30,6 +30,7 @@ import scala.collection._
 import scala.collection.JavaConverters._
 import java.util.{ArrayList => JArrayList, HashMap => JHashMap, List => JList, Map => JMap}
 import JsonSerializationConstants._
+import com.amazon.deequ.analyzers.Histogram.{AggregateFunction, Count => HistogramCount, Sum => HistogramSum}
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions.expr
 
@@ -302,6 +303,8 @@ private[deequ] object AnalyzerSerializer
         result.addProperty(ANALYZER_NAME_FIELD, "Histogram")
         result.addProperty(COLUMN_FIELD, histogram.column)
         result.addProperty("maxDetailBins", histogram.maxDetailBins)
+        // Count is initial and default implementation for Histogram
+        // We don't include fields below in json to preserve json backward compatibility.
         if (histogram.aggregateFunction != Histogram.Count) {
           result.addProperty("aggregateFunction", histogram.aggregateFunction.function())
           result.addProperty("aggregateColumn", histogram.aggregateFunction.aggregateColumn().get)
@@ -441,7 +444,7 @@ private[deequ] object AnalyzerDeserializer
           json.get(COLUMN_FIELD).getAsString,
           None,
           json.get("maxDetailBins").getAsInt,
-          aggregateFunction = Histogram.createAggregateFunction(
+          aggregateFunction = createAggregateFunction(
             getOptionalStringParam(json, "aggregateFunction").getOrElse(Histogram.count_function),
             getOptionalStringParam(json, "aggregateColumn").getOrElse("")))
 
@@ -504,6 +507,14 @@ private[deequ] object AnalyzerDeserializer
       Option(jsonObject.get(field).getAsString)
     } else {
       None
+    }
+  }
+
+  private[this] def createAggregateFunction(function: String, aggregateColumn: String): AggregateFunction = {
+    function match {
+      case Histogram.count_function => HistogramCount
+      case Histogram.sum_function => HistogramSum(aggregateColumn)
+      case _ => throw new IllegalArgumentException("Wrong aggregate function name: " + function)
     }
   }
 }

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
@@ -33,7 +33,6 @@ import org.scalatest.wordspec.AnyWordSpec
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
-import scala.collection.immutable.Set
 import scala.util.Failure
 import scala.util.Success
 

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
@@ -263,8 +263,7 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
 
     "compute correct sum metrics " in withSparkSession { sparkSession =>
       val dfFull = getDateDf(sparkSession)
-      val histogram = Histogram("product", aggregateColumn = Some("units"),
-        aggregateFunction = Histogram.Sum).calculate(dfFull)
+      val histogram = Histogram("product", aggregateFunction = Histogram.Sum("units")).calculate(dfFull)
       assert(histogram.value.isSuccess)
 
       histogram.value.get match {
@@ -273,8 +272,11 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
           assert(hv.values.size == 3)
           assert(hv.values.keys == Set("Furniture", "Cosmetics", "Electronics"))
           assert(hv("Furniture").absolute == 55)
+          assert(hv("Furniture").ratio == 55.0 / (55 + 20 + 60))
           assert(hv("Cosmetics").absolute == 20)
+          assert(hv("Cosmetics").ratio == 20.0 / (55 + 20 + 60))
           assert(hv("Electronics").absolute == 60)
+          assert(hv("Electronics").ratio == 60.0 / (55 + 20 + 60))
 
       }
     }

--- a/src/test/scala/com/amazon/deequ/analyzers/runners/AnalyzerContextTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/runners/AnalyzerContextTest.scala
@@ -86,13 +86,13 @@ class AnalyzerContextTest extends AnyWordSpec
               |{"entity":"Column","instance":"item","name":"Distinctness","value":1.0},
               |{"entity":"Column","instance":"att1","name":"Completeness","value":1.0},
               |{"entity":"Multicolumn","instance":"att1,att2","name":"Uniqueness","value":0.25},
+              |{"entity":"Dataset","instance":"*","name":"Size (where: att2 == 'd')","value":1.0},
+              |{"entity":"Dataset","instance":"*","name":"Size","value":4.0},
               |{"entity":"Column","instance":"att1","name":"Histogram.bins","value":2.0},
               |{"entity":"Column","instance":"att1","name":"Histogram.abs.a","value":3.0},
               |{"entity":"Column","instance":"att1","name":"Histogram.ratio.a","value":0.75},
               |{"entity":"Column","instance":"att1","name":"Histogram.abs.b","value":1.0},
-              |{"entity":"Column","instance":"att1","name":"Histogram.ratio.b","value":0.25},
-              |{"entity":"Dataset","instance":"*","name":"Size (where: att2 == 'd')","value":1.0},
-              |{"entity":"Dataset","instance":"*","name":"Size","value":4.0}
+              |{"entity":"Column","instance":"att1","name":"Histogram.ratio.b","value":0.25}
               |]"""
               .stripMargin.replaceAll("\n", "")
 

--- a/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
@@ -58,7 +58,7 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
       Histogram("ColumnA") ->
         HistogramMetric("ColumnA", Success(Distribution(
           Map("some" -> DistributionValue(10, 0.5)), 10))),
-      Histogram("ColumnA", None) ->
+      Histogram ("ColumnA", None) ->
         HistogramMetric("ColumnA", Success(Distribution(
           Map("some" -> DistributionValue(10, 0.5), "other" -> DistributionValue(0, 0)), 10))),
       Histogram("ColumnA", None, 5) ->
@@ -87,7 +87,7 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
     ))
 
     val dateTime = LocalDate.of(2017, 10, 14).atTime(10, 10, 10)
-      .toEpochSecond(ZoneOffset.UTC)
+        .toEpochSecond(ZoneOffset.UTC)
     val resultKeyOne = ResultKey(dateTime, Map("Region" -> "EU"))
     val resultKeyTwo = ResultKey(dateTime, Map("Region" -> "NA"))
 
@@ -131,12 +131,12 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
       Map(
         Size() -> DoubleMetric(Entity.Column, "Size", "*", Success(5.0)),
         Completeness("ColumnA") ->
-          DoubleMetric(Entity.Column, "Completeness", "ColumnA", Failure(sampleException))
+            DoubleMetric(Entity.Column, "Completeness", "ColumnA", Failure(sampleException))
       )
     )
 
     val dateTime = LocalDate.of(2017, 10, 14).atTime(10, 10, 10)
-      .toEpochSecond(ZoneOffset.UTC)
+        .toEpochSecond(ZoneOffset.UTC)
     val resultKeyOne = ResultKey(dateTime, Map("Region" -> "EU"))
     val resultKeyTwo = ResultKey(dateTime, Map("Region" -> "NA"))
 
@@ -145,7 +145,7 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
     val analysisResultTwo = AnalysisResult(resultKeyTwo, analyzerContextWithMixedValues)
 
     assertCorrectlyConvertsAnalysisResults(Seq(analysisResultOne, analysisResultTwo),
-      shouldFail = true)
+        shouldFail = true)
   }
 
   "serialization of ApproxQuantile" should "correctly restore it" in {


### PR DESCRIPTION
*Issue #, if available:*
NA. Kind of close to #381 

*Description of changes:*
- Histogram analyzer changes
  -  Provide a way to calculate histogram values using different aggregate functions (sum).
  - Add aggregateColumn - a column castable to Long. Aggregate function is applied to this column
- Histogram serialization changes
  - Add aggregateFunction property ("count" is default in case of missing property)
  - Add aggregateColumn property

In addition to
``` 
select(col(column).cast(StringType)).groupBy(column).count()
```
provide a way get histogram values
```
select(col(column).cast(StringType), col(aggregateColumn.get).cast(LongType)).groupBy(column).sum(aggregateColumn.get)
```

WIP. Please take a look at the changes. I'll add more tests, docs and validation logic if you think that these changes make sense.

Thanks.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
