### PR TITLE
Add population stability index (PSI) to distance methods

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/Distance.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Distance.scala
@@ -21,7 +21,7 @@ import org.apache.spark.mllib.stat.Statistics
 import org.apache.spark.mllib.stat.test.ChiSqTestResult
 import scala.math._
 import scala.annotation.tailrec
-import com.amazon.deequ.metrics.{BucketValue}
+import com.amazon.deequ.metrics.BucketValue
 
 object Distance {
     // Chi-square constants
@@ -337,13 +337,13 @@ object Distance {
     val expectedSum : Long = expected.map(e => e.count).sum
 
     // Calculate percentage per bucket
-    val actualPercent: List[Double] = actual.map( b => (b.count / actualSum.toDouble))
-    val expectedPercent: List[Double] = expected.map( b => (b.count / expectedSum.toDouble))
-
-    val zippedSamples : List[(Double, Double)] = actualPercent.zip(expectedPercent)
+    val actualPercent: List[Double] = actual.map(b => (b.count / actualSum.toDouble))
+    val expectedPercent: List[Double] = expected.map(b => (b.count / expectedSum.toDouble))
 
     // Apply PSI formula PSI = (P - Q) * ln(P/Q)
-    zippedSamples.map(e => (e._1-e._2) * log(e._1 / e._2)).sum
+    actualPercent.zip(expectedPercent).map{
+      case (actual, expected) => (actual - expected) * log(actual / expected)
+    }.sum
   }
 
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Distance.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Distance.scala
@@ -317,12 +317,13 @@ object Distance {
 
   /** Calculate Population Stability Index from two distributions defined as buckets
     *
-    * PSI is a measure of the degree to which the distribution of a population has shifted over time or between two different samples of a population in a single number.
-    * https://xai.arya.ai/wiki/population-stability-index-psi
+    * PSI is a measure of the degree to which the distribution of a population has shifted over time or between
+    * two different samples of a population in a single number. https://xai.arya.ai/wiki/population-stability-index-psi
     *
     * @param actual                      the actual distribution as a list of buckets
     * @param expected                    the expected distribution as a list of buckets
-    * @return Double                     a value closer to 0 means the distributions are stable, common thresholds are 0.1, 0.2
+    * @return Double                     a value closer to 0 means the distributions are stable,
+    *                                    common thresholds are 0.1, 0.2
     */
 
   def populationStabilityIndex(actual: List[BucketValue],
@@ -339,10 +340,10 @@ object Distance {
     val actualPercent: List[Double] = actual.map( b => (b.count / actualSum.toDouble))
     val expectedPercent: List[Double] = expected.map( b => (b.count / expectedSum.toDouble))
 
-    val zippedSamples : List[(Double,Double)] = actualPercent.zip(expectedPercent)
+    val zippedSamples : List[(Double, Double)] = actualPercent.zip(expectedPercent)
 
     // Apply PSI formula PSI = (P - Q) * ln(P/Q)
-    zippedSamples.map(e => (e._1-e._2) * log(e._1/e._2)).sum
+    zippedSamples.map(e => (e._1-e._2) * log(e._1 / e._2)).sum
   }
 
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Distance.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Distance.scala
@@ -19,7 +19,7 @@ package com.amazon.deequ.analyzers
 import org.apache.spark.mllib.linalg._
 import org.apache.spark.mllib.stat.Statistics
 import org.apache.spark.mllib.stat.test.ChiSqTestResult
-import scala.math._
+import scala.math.log
 import scala.annotation.tailrec
 import com.amazon.deequ.metrics.BucketValue
 

--- a/src/main/scala/com/amazon/deequ/analyzers/Distance.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Distance.scala
@@ -15,11 +15,13 @@
  */
 
 package com.amazon.deequ.analyzers
+
 import org.apache.spark.mllib.linalg._
 import org.apache.spark.mllib.stat.Statistics
 import org.apache.spark.mllib.stat.test.ChiSqTestResult
-
+import scala.math._
 import scala.annotation.tailrec
+import com.amazon.deequ.metrics.{BucketValue}
 
 object Distance {
     // Chi-square constants
@@ -311,4 +313,36 @@ object Distance {
        linfRobust
      }
    }
+
+
+  /** Calculate Population Stability Index from two distributions defined as buckets
+    *
+    * PSI is a measure of the degree to which the distribution of a population has shifted over time or between two different samples of a population in a single number.
+    * https://xai.arya.ai/wiki/population-stability-index-psi
+    *
+    * @param actual                      the actual distribution as a list of buckets
+    * @param expected                    the expected distribution as a list of buckets
+    * @return Double                     a value closer to 0 means the distributions are stable, common thresholds are 0.1, 0.2
+    */
+
+  def populationStabilityIndex(actual: List[BucketValue],
+                               expected: List[BucketValue]): Double = {
+
+    // Number of buckets has to be identical for actual and expected
+    assert(actual.length==expected.length)
+
+    // Calculate sums
+    val actualSum : Long = actual.map(e => e.count).sum
+    val expectedSum : Long = expected.map(e => e.count).sum
+
+    // Calculate percentage per bucket
+    val actualPercent: List[Double] = actual.map( b => (b.count / actualSum.toDouble))
+    val expectedPercent: List[Double] = expected.map( b => (b.count / expectedSum.toDouble))
+
+    val zippedSamples : List[(Double,Double)] = actualPercent.zip(expectedPercent)
+
+    // Apply PSI formula PSI = (P - Q) * ln(P/Q)
+    zippedSamples.map(e => (e._1-e._2) * log(e._1/e._2)).sum
+  }
+
 }

--- a/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
+++ b/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
@@ -19,8 +19,10 @@ package com.amazon.deequ.KLL
 import com.amazon.deequ.SparkContextSpec
 import com.amazon.deequ.analyzers.Distance.{ChisquareMethod, LInfinityMethod}
 import com.amazon.deequ.analyzers.{Distance, QuantileNonSample}
+import com.amazon.deequ.metrics.BucketValue
 import com.amazon.deequ.utils.FixtureSupport
 import org.scalatest.WordSpec
+import com.amazon.deequ.metrics.{BucketValue}
 
 class KLLDistanceTest extends WordSpec with SparkContextSpec
   with FixtureSupport{
@@ -28,7 +30,7 @@ class KLLDistanceTest extends WordSpec with SparkContextSpec
   "KLL distance calculator should compute correct linf_simple" in {
     val sample1 = new QuantileNonSample[Double](4, 0.64)
     val sample2 = new QuantileNonSample[Double](4, 0.64)
-    sample1.reconstruct(4, 0.64, Array(Array(1, 2, 3, 4)))
+    sample1.reconstruct(4, 0.64, Array(Array(1, 2, 3, 4, 4, 4, 4, 4, 4)))
     sample2.reconstruct(4, 0.64, Array(Array(2, 3, 4, 5)))
     val distance = Distance.numericalDistance(sample1, sample2, correctForLowNumberOfSamples = true)
     assert(distance == 0.25)
@@ -179,5 +181,22 @@ class KLLDistanceTest extends WordSpec with SparkContextSpec
     val distance = Distance.categoricalDistance(
       sample, baseline, correctForLowNumberOfSamples = true, method = ChisquareMethod())
     assert(distance.isNaN)
+  }
+
+  "Population Stability Index (PSI) test with deciles " in {
+
+    val expected: List[BucketValue] = List(BucketValue(1.0, 1.05, 428), BucketValue(1.05, 1.1, 425), BucketValue(1.1, 1.15, 414),
+      BucketValue(1.15, 1.2, 427), BucketValue(1.2, 1.25, 440), BucketValue(1.25, 1.3, 447),
+      BucketValue(1.3, 1.35, 380), BucketValue(1.35, 1.4, 386), BucketValue(1.4, 1.45, 444),
+      BucketValue(1.45, 1.5, 386))
+
+    val actual: List[BucketValue] = List(BucketValue(1.0, 1.05, 426), BucketValue(1.05, 1.1, 437), BucketValue(1.1, 1.15, 429),
+      BucketValue(1.15, 1.2, 391), BucketValue(1.2, 1.25, 469), BucketValue(1.25, 1.3, 433),
+      BucketValue(1.3, 1.35, 360), BucketValue(1.35, 1.4, 443), BucketValue(1.4, 1.45, 371),
+      BucketValue(1.45, 1.5, 418))
+
+    val distance = Distance.populationStabilityIndex(actual, expected)
+    assert(distance == 0.007406694184014186)
+
   }
 }

--- a/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
+++ b/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
@@ -30,7 +30,7 @@ class KLLDistanceTest extends WordSpec with SparkContextSpec
   "KLL distance calculator should compute correct linf_simple" in {
     val sample1 = new QuantileNonSample[Double](4, 0.64)
     val sample2 = new QuantileNonSample[Double](4, 0.64)
-    sample1.reconstruct(4, 0.64, Array(Array(1, 2, 3, 4, 4, 4, 4, 4, 4)))
+    sample1.reconstruct(4, 0.64, Array(Array(1, 2, 3, 4)))
     sample2.reconstruct(4, 0.64, Array(Array(2, 3, 4, 5)))
     val distance = Distance.numericalDistance(sample1, sample2, correctForLowNumberOfSamples = true)
     assert(distance == 0.25)

--- a/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
+++ b/src/test/scala/com/amazon/deequ/KLL/KLLDistanceTest.scala
@@ -185,15 +185,15 @@ class KLLDistanceTest extends WordSpec with SparkContextSpec
 
   "Population Stability Index (PSI) test with deciles " in {
 
-    val expected: List[BucketValue] = List(BucketValue(1.0, 1.05, 428), BucketValue(1.05, 1.1, 425), BucketValue(1.1, 1.15, 414),
-      BucketValue(1.15, 1.2, 427), BucketValue(1.2, 1.25, 440), BucketValue(1.25, 1.3, 447),
-      BucketValue(1.3, 1.35, 380), BucketValue(1.35, 1.4, 386), BucketValue(1.4, 1.45, 444),
-      BucketValue(1.45, 1.5, 386))
+    val expected: List[BucketValue] = List(BucketValue(1.0, 1.05, 428), BucketValue(1.05, 1.1, 425),
+      BucketValue(1.1, 1.15, 414), BucketValue(1.15, 1.2, 427), BucketValue(1.2, 1.25, 440),
+      BucketValue(1.25, 1.3, 447), BucketValue(1.3, 1.35, 380), BucketValue(1.35, 1.4, 386),
+      BucketValue(1.4, 1.45, 444), BucketValue(1.45, 1.5, 386))
 
-    val actual: List[BucketValue] = List(BucketValue(1.0, 1.05, 426), BucketValue(1.05, 1.1, 437), BucketValue(1.1, 1.15, 429),
-      BucketValue(1.15, 1.2, 391), BucketValue(1.2, 1.25, 469), BucketValue(1.25, 1.3, 433),
-      BucketValue(1.3, 1.35, 360), BucketValue(1.35, 1.4, 443), BucketValue(1.4, 1.45, 371),
-      BucketValue(1.45, 1.5, 418))
+    val actual: List[BucketValue] = List(BucketValue(1.0, 1.05, 426), BucketValue(1.05, 1.1, 437),
+      BucketValue(1.1, 1.15, 429), BucketValue(1.15, 1.2, 391), BucketValue(1.2, 1.25, 469),
+      BucketValue(1.25, 1.3, 433), BucketValue(1.3, 1.35, 360), BucketValue(1.35, 1.4, 443),
+      BucketValue(1.4, 1.45, 371), BucketValue(1.45, 1.5, 418))
 
     val distance = Distance.populationStabilityIndex(actual, expected)
     assert(distance == 0.007406694184014186)


### PR DESCRIPTION
Adds the population stability index (PSI) to distance methods for numerical features.

Population stability index (PSI) is a statistical measure with a basis in information theory that quantifies the difference between one probability distribution from a reference probability distribution.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
