### PR TITLE
Improve message wording for dataset comparison

### DIFF
--- a/src/main/scala/com/amazon/deequ/comparison/DataSynchronization.scala
+++ b/src/main/scala/com/amazon/deequ/comparison/DataSynchronization.scala
@@ -94,7 +94,8 @@ object DataSynchronization extends ComparisonBase {
                   ds2: DataFrame,
                   colKeyMap: Map[String, String],
                   assertion: Double => Boolean): ComparisonResult = {
-    if (areKeyColumnsValid(ds1, ds2, colKeyMap)) {
+    val columnErrors = areKeyColumnsValid(ds1, ds2, colKeyMap)
+    if (columnErrors.isEmpty) {
       val colsDS1 = ds1.columns.filterNot(x => colKeyMap.keys.toSeq.contains(x)).sorted
       val colsDS2 = ds2.columns.filterNot(x => colKeyMap.values.toSeq.contains(x)).sorted
 
@@ -105,7 +106,7 @@ object DataSynchronization extends ComparisonBase {
         finalAssertion(ds1, ds2, mergedMaps, assertion)
       }
     } else {
-      ComparisonFailed("Provided key map not suitable for given data frames.")
+      ComparisonFailed(columnErrors.get)
     }
   }
 
@@ -129,11 +130,12 @@ object DataSynchronization extends ComparisonBase {
                   colKeyMap: Map[String, String],
                   compCols: Map[String, String],
                   assertion: Double => Boolean): ComparisonResult = {
-    if (areKeyColumnsValid(ds1, ds2, colKeyMap)) {
+    val columnErrors = areKeyColumnsValid(ds1, ds2, colKeyMap)
+    if (columnErrors.isEmpty) {
       val mergedMaps = colKeyMap ++ compCols
       finalAssertion(ds1, ds2, mergedMaps, assertion)
     } else {
-      ComparisonFailed("Provided key map not suitable for given data frames.")
+      ComparisonFailed(columnErrors.get)
     }
   }
 
@@ -142,7 +144,8 @@ object DataSynchronization extends ComparisonBase {
                           colKeyMap: Map[String, String],
                           optionalCompCols: Option[Map[String, String]] = None,
                           optionalOutcomeColumnName: Option[String] = None): Either[ComparisonFailed, DataFrame] = {
-    if (areKeyColumnsValid(ds1, ds2, colKeyMap)) {
+    val columnErrors = areKeyColumnsValid(ds1, ds2, colKeyMap)
+    if (columnErrors.isEmpty) {
       val compColsEither: Either[ComparisonFailed, Map[String, String]] = if (optionalCompCols.isDefined) {
         optionalCompCols.get match {
           case compCols if compCols.isEmpty => Left(ComparisonFailed("Empty column comparison map provided."))
@@ -168,19 +171,34 @@ object DataSynchronization extends ComparisonBase {
         }
       }
     } else {
-      Left(ComparisonFailed("Provided key map not suitable for given data frames."))
+      Left(ComparisonFailed(columnErrors.get))
     }
   }
 
   private def areKeyColumnsValid(ds1: DataFrame,
                                  ds2: DataFrame,
-                                 colKeyMap: Map[String, String]): Boolean = {
+                                 colKeyMap: Map[String, String]): Option[String] = {
     // We verify that the key columns provided form a valid primary/composite key.
     // To achieve this, we group the dataframes and compare their count with the original count.
     // If the key columns provided are valid, then the two counts should match.
-    val ds1Unique = ds1.groupBy(colKeyMap.keys.toSeq.map(col): _*).count()
-    val ds2Unique = ds2.groupBy(colKeyMap.values.toSeq.map(col): _*).count()
-    (ds1Unique.count() == ds1.count()) && (ds2Unique.count() == ds2.count())
+    val ds1Cols = colKeyMap.keys.toSeq
+    val ds2Cols = colKeyMap.values.toSeq
+    val ds1Unique = ds1.groupBy(ds1Cols.map(col): _*).count()
+    val ds2Unique = ds2.groupBy(ds2Cols.map(col): _*).count()
+
+    val ds1Count = ds1.count()
+    val ds2Count = ds2.count()
+    val ds1UniqueCount = ds1Unique.count()
+    val ds2UniqueCount = ds2Unique.count()
+
+    if (ds1UniqueCount == ds1Count && ds2UniqueCount == ds2Count) {
+      None
+    } else {
+      Some(s"The selected dataset columns are not comparable using the specified keys. " +
+        s"Dataframe 1 has $ds1UniqueCount unique combinations and $ds1Count rows," +
+        s" and " +
+        s"Dataframe 2 has $ds2UniqueCount unique combinations and $ds2Count rows.")
+    }
   }
 
   private def finalAssertion(ds1: DataFrame,

--- a/src/test/scala/com/amazon/deequ/comparison/DataSynchronizationTest.scala
+++ b/src/test/scala/com/amazon/deequ/comparison/DataSynchronizationTest.scala
@@ -213,7 +213,11 @@ class DataSynchronizationTest extends AnyWordSpec with SparkContextSpec {
       val assertion: Double => Boolean = _ >= 0.40
 
       val result = (DataSynchronization.columnMatch(ds1, ds2, colKeyMap, compCols, assertion))
-      assert(result.isInstanceOf[ComparisonFailed])
+      assert(result.asInstanceOf[ComparisonFailed].errorMessage == "The selected dataset columns are not comparable " +
+        "using the specified keys. " +
+        s"Dataframe 1 has 6 unique combinations and 7 rows," +
+        s" and " +
+        s"Dataframe 2 has 6 unique combinations and 6 rows.")
     }
 
     "return false because the id col in ds2 isn't unique" in withSparkSession { spark =>
@@ -513,7 +517,7 @@ class DataSynchronizationTest extends AnyWordSpec with SparkContextSpec {
       val outcomeColName = "outcome"
       val result = DataSynchronization.columnMatchRowLevel(ds1, ds2, colKeyMap, Some(compCols), Some(outcomeColName))
       assert(result.isLeft)
-      assert(result.left.get.errorMessage.contains("Provided key map not suitable for given data frames"))
+      assert(result.left.get.errorMessage.contains("The selected dataset columns are not comparable"))
     }
 
     "fails to annotate row level results when column key map is not provided " +


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The error thrown by this rule when the datasets are not comparable is not verbose enough, leading to confusion about the reasons why the comparison did not happen.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
