### PR TITLE
Updated the Categorical range constraint suggestions to use a new class called ConstraintSuggestionWithValue

### DIFF
--- a/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestion.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestion.scala
@@ -22,14 +22,33 @@ import com.amazon.deequ.profiles.ColumnProfile
 import com.amazon.deequ.suggestions.rules.ConstraintRule
 import com.google.gson.{GsonBuilder, JsonArray, JsonObject}
 
-case class ConstraintSuggestion(
+sealed trait ConstraintSuggestion {
+    val constraint: Constraint
+    val columnName: String
+    val currentValue: String
+    val description: String
+    val suggestingRule: ConstraintRule[ColumnProfile]
+    val codeForConstraint: String
+}
+
+case class CommonConstraintSuggestion(
     constraint: Constraint,
     columnName: String,
     currentValue: String,
     description: String,
     suggestingRule: ConstraintRule[ColumnProfile],
     codeForConstraint: String
-)
+) extends ConstraintSuggestion
+
+case class ConstraintSuggestionWithValue[T](
+    constraint: Constraint,
+    columnName: String,
+    currentValue: String,
+    description: String,
+    suggestingRule: ConstraintRule[ColumnProfile],
+    codeForConstraint: String,
+    value: T
+) extends ConstraintSuggestion
 
 object ConstraintSuggestions {
 

--- a/src/main/scala/com/amazon/deequ/suggestions/rules/CompleteIfCompleteRule.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/rules/CompleteIfCompleteRule.scala
@@ -19,6 +19,7 @@ package com.amazon.deequ.suggestions.rules
 import com.amazon.deequ.checks.Check
 import com.amazon.deequ.constraints.Constraint.completenessConstraint
 import com.amazon.deequ.profiles.ColumnProfile
+import com.amazon.deequ.suggestions.CommonConstraintSuggestion
 import com.amazon.deequ.suggestions.ConstraintSuggestion
 
 /** If a column is complete in the sample, we suggest a NOT NULL constraint */
@@ -32,7 +33,7 @@ case class CompleteIfCompleteRule() extends ConstraintRule[ColumnProfile] {
 
     val constraint = completenessConstraint(profile.column, Check.IsOne)
 
-    ConstraintSuggestion(
+    CommonConstraintSuggestion(
       constraint,
       profile.column,
       "Completeness: " + profile.completeness.toString,

--- a/src/main/scala/com/amazon/deequ/suggestions/rules/ConstraintRule.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/rules/ConstraintRule.scala
@@ -17,7 +17,7 @@
 package com.amazon.deequ.suggestions.rules
 
 import com.amazon.deequ.profiles.ColumnProfile
-import com.amazon.deequ.suggestions._
+import com.amazon.deequ.suggestions.ConstraintSuggestion
 
 /** Abstract base class for all constraint suggestion rules */
 abstract class ConstraintRule[P <: ColumnProfile] {

--- a/src/main/scala/com/amazon/deequ/suggestions/rules/HasMax.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/rules/HasMax.scala
@@ -16,12 +16,11 @@
 
 package com.amazon.deequ.suggestions.rules
 
-import com.amazon.deequ.checks.Check
 import com.amazon.deequ.constraints.Constraint.maxConstraint
 import com.amazon.deequ.profiles.ColumnProfile
 import com.amazon.deequ.profiles.NumericColumnProfile
+import com.amazon.deequ.suggestions.CommonConstraintSuggestion
 import com.amazon.deequ.suggestions.ConstraintSuggestion
-import com.amazon.deequ.checks
 
 /** If we see only non-negative numbers in a column, we suggest a corresponding
   * constraint
@@ -41,7 +40,7 @@ case class HasMax() extends ConstraintRule[ColumnProfile] {
     val description = s"'${profile.column}' <= $maximum"
     val constraint = maxConstraint(profile.column, _ == maximum)
 
-    ConstraintSuggestion(
+    CommonConstraintSuggestion(
       constraint,
       profile.column,
       s"Maximum: $maximum",

--- a/src/main/scala/com/amazon/deequ/suggestions/rules/HasMaxLength.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/rules/HasMaxLength.scala
@@ -16,10 +16,10 @@
 
 package com.amazon.deequ.suggestions.rules
 
-import com.amazon.deequ.checks.Check
 import com.amazon.deequ.constraints.Constraint.maxLengthConstraint
 import com.amazon.deequ.profiles.ColumnProfile
 import com.amazon.deequ.profiles.StringColumnProfile
+import com.amazon.deequ.suggestions.CommonConstraintSuggestion
 import com.amazon.deequ.suggestions.ConstraintSuggestion
 
 case class HasMaxLength() extends ConstraintRule[ColumnProfile] {
@@ -35,7 +35,7 @@ case class HasMaxLength() extends ConstraintRule[ColumnProfile] {
 
     val constraint = maxLengthConstraint(profile.column, _ <= maxLength)
 
-    ConstraintSuggestion(
+    CommonConstraintSuggestion(
       constraint,
       profile.column,
       "MaxLength: " + profile.completeness.toString,

--- a/src/main/scala/com/amazon/deequ/suggestions/rules/HasMean.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/rules/HasMean.scala
@@ -16,12 +16,11 @@
 
 package com.amazon.deequ.suggestions.rules
 
-import com.amazon.deequ.checks.Check
 import com.amazon.deequ.constraints.Constraint.meanConstraint
 import com.amazon.deequ.profiles.ColumnProfile
 import com.amazon.deequ.profiles.NumericColumnProfile
+import com.amazon.deequ.suggestions.CommonConstraintSuggestion
 import com.amazon.deequ.suggestions.ConstraintSuggestion
-import com.amazon.deequ.checks
 
 /** If we see only non-negative numbers in a column, we suggest a corresponding
   * constraint
@@ -41,7 +40,7 @@ case class HasMean() extends ConstraintRule[ColumnProfile] {
     val description = s"'${profile.column}' <= $mean"
     val constraint = meanConstraint(profile.column, _ == mean)
 
-    ConstraintSuggestion(
+    CommonConstraintSuggestion(
       constraint,
       profile.column,
       s"Mean: $mean",

--- a/src/main/scala/com/amazon/deequ/suggestions/rules/HasMin.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/rules/HasMin.scala
@@ -16,10 +16,10 @@
 
 package com.amazon.deequ.suggestions.rules
 
-import com.amazon.deequ.checks.Check
 import com.amazon.deequ.constraints.Constraint.minConstraint
 import com.amazon.deequ.profiles.ColumnProfile
 import com.amazon.deequ.profiles.NumericColumnProfile
+import com.amazon.deequ.suggestions.CommonConstraintSuggestion
 import com.amazon.deequ.suggestions.ConstraintSuggestion
 
 /** If we see only non-negative numbers in a column, we suggest a corresponding
@@ -40,7 +40,7 @@ case class HasMin() extends ConstraintRule[ColumnProfile] {
     val description = s"'${profile.column}' >= $minimum"
     val constraint = minConstraint(profile.column, _ == minimum)
 
-    ConstraintSuggestion(
+    CommonConstraintSuggestion(
       constraint,
       profile.column,
       s"Minimum: $minimum",

--- a/src/main/scala/com/amazon/deequ/suggestions/rules/HasMinLength.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/rules/HasMinLength.scala
@@ -16,10 +16,10 @@
 
 package com.amazon.deequ.suggestions.rules
 
-import com.amazon.deequ.checks.Check
 import com.amazon.deequ.constraints.Constraint.minLengthConstraint
 import com.amazon.deequ.profiles.ColumnProfile
 import com.amazon.deequ.profiles.StringColumnProfile
+import com.amazon.deequ.suggestions.CommonConstraintSuggestion
 import com.amazon.deequ.suggestions.ConstraintSuggestion
 
 case class HasMinLength() extends ConstraintRule[ColumnProfile] {
@@ -36,7 +36,7 @@ case class HasMinLength() extends ConstraintRule[ColumnProfile] {
 
     val constraint = minLengthConstraint(profile.column, _ >= minLength)
 
-    ConstraintSuggestion(
+    CommonConstraintSuggestion(
       constraint,
       profile.column,
       "MinLength: " + minLength,

--- a/src/main/scala/com/amazon/deequ/suggestions/rules/HasStandardDeviation.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/rules/HasStandardDeviation.scala
@@ -16,12 +16,11 @@
 
 package com.amazon.deequ.suggestions.rules
 
-import com.amazon.deequ.checks.Check
 import com.amazon.deequ.constraints.Constraint.standardDeviationConstraint
 import com.amazon.deequ.profiles.ColumnProfile
 import com.amazon.deequ.profiles.NumericColumnProfile
+import com.amazon.deequ.suggestions.CommonConstraintSuggestion
 import com.amazon.deequ.suggestions.ConstraintSuggestion
-import com.amazon.deequ.checks
 
 /** If we see only non-negative numbers in a column, we suggest a corresponding
   * constraint
@@ -41,7 +40,7 @@ case class HasStandardDeviation() extends ConstraintRule[ColumnProfile] {
     val description = s"'${profile.column}' <= $stdDev"
     val constraint = standardDeviationConstraint(profile.column, _ == stdDev)
 
-    ConstraintSuggestion(
+    CommonConstraintSuggestion(
       constraint,
       profile.column,
       s"stdDev: $stdDev",

--- a/src/main/scala/com/amazon/deequ/suggestions/rules/NonNegativeNumbersRule.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/rules/NonNegativeNumbersRule.scala
@@ -18,7 +18,9 @@ package com.amazon.deequ.suggestions.rules
 
 import com.amazon.deequ.checks.Check
 import com.amazon.deequ.constraints.Constraint.complianceConstraint
-import com.amazon.deequ.profiles.{ColumnProfile, NumericColumnProfile}
+import com.amazon.deequ.profiles.ColumnProfile
+import com.amazon.deequ.profiles.NumericColumnProfile
+import com.amazon.deequ.suggestions.CommonConstraintSuggestion
 import com.amazon.deequ.suggestions.ConstraintSuggestion
 
 /** If we see only non-negative numbers in a column, we suggest a corresponding constraint */
@@ -45,7 +47,7 @@ case class NonNegativeNumbersRule() extends ConstraintRule[ColumnProfile] {
       case _ => "Error while calculating minimum!"
     }
 
-    ConstraintSuggestion(
+    CommonConstraintSuggestion(
       constraint,
       profile.column,
       "Minimum: " + minimum,

--- a/src/main/scala/com/amazon/deequ/suggestions/rules/RetainCompletenessRule.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/rules/RetainCompletenessRule.scala
@@ -17,8 +17,10 @@
 package com.amazon.deequ.suggestions.rules
 
 import com.amazon.deequ.constraints.Constraint.completenessConstraint
-import com.amazon.deequ.profiles._
+import com.amazon.deequ.profiles.ColumnProfile
+import com.amazon.deequ.suggestions.CommonConstraintSuggestion
 import com.amazon.deequ.suggestions.ConstraintSuggestion
+
 import scala.math.BigDecimal.RoundingMode
 
 /**
@@ -47,7 +49,7 @@ case class RetainCompletenessRule() extends ConstraintRule[ColumnProfile] {
 
     val description = s"'${profile.column}' has less than $boundInPercent% missing values"
 
-    ConstraintSuggestion(
+    CommonConstraintSuggestion(
       constraint,
       profile.column,
       "Completeness: " + profile.completeness.toString,

--- a/src/main/scala/com/amazon/deequ/suggestions/rules/RetainTypeRule.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/rules/RetainTypeRule.scala
@@ -21,6 +21,7 @@ import com.amazon.deequ.checks.Check
 import com.amazon.deequ.constraints.ConstrainableDataTypes
 import com.amazon.deequ.constraints.Constraint.dataTypeConstraint
 import com.amazon.deequ.profiles.ColumnProfile
+import com.amazon.deequ.suggestions.CommonConstraintSuggestion
 import com.amazon.deequ.suggestions.ConstraintSuggestion
 
 /** If we detect a non-string type, we suggest a type constraint */
@@ -46,7 +47,7 @@ case class RetainTypeRule() extends ConstraintRule[ColumnProfile] {
 
     val constraint = dataTypeConstraint(profile.column, typeToCheck, Check.IsOne)
 
-    ConstraintSuggestion(
+    CommonConstraintSuggestion(
       constraint,
       profile.column,
       "DataType: " + profile.dataType.toString,

--- a/src/main/scala/com/amazon/deequ/suggestions/rules/UniqueIfApproximatelyUniqueRule.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/rules/UniqueIfApproximatelyUniqueRule.scala
@@ -19,6 +19,7 @@ package com.amazon.deequ.suggestions.rules
 import com.amazon.deequ.checks.Check
 import com.amazon.deequ.constraints.Constraint.uniquenessConstraint
 import com.amazon.deequ.profiles.ColumnProfile
+import com.amazon.deequ.suggestions.CommonConstraintSuggestion
 import com.amazon.deequ.suggestions.ConstraintSuggestion
 
 /**
@@ -40,7 +41,7 @@ case class UniqueIfApproximatelyUniqueRule() extends ConstraintRule[ColumnProfil
     val constraint = uniquenessConstraint(Seq(profile.column), Check.IsOne)
     val approximateDistinctness = profile.approximateNumDistinctValues.toDouble / numRecords
 
-    ConstraintSuggestion(
+    CommonConstraintSuggestion(
       constraint,
       profile.column,
       "ApproxDistinctness: " + approximateDistinctness.toString,

--- a/src/test/scala/com/amazon/deequ/suggestions/ConstraintSuggestionsIntegrationTest.scala
+++ b/src/test/scala/com/amazon/deequ/suggestions/ConstraintSuggestionsIntegrationTest.scala
@@ -123,6 +123,19 @@ class ConstraintSuggestionsIntegrationTest extends WordSpec with SparkContextSpe
             .instance.startsWith(s"'marketplace' has value range")
       }
 
+      // Categorical range for "marketplace" with values
+      assert(
+        constraintSuggestionResult.constraintSuggestions
+          .getOrElse("marketplace", Seq.empty)
+          .exists {
+            case value: ConstraintSuggestionWithValue[Seq[String]] =>
+              val constraintWithValue = value.value
+              println(constraintWithValue)
+              constraintWithValue.sorted == categories.toSeq.sorted
+            case _ => false
+          }
+      )
+
       // IS NOT NULL for "measurement"
       assertConstraintExistsIn(constraintSuggestionResult) { (analyzer, assertionFunc) =>
         analyzer == Completeness("measurement") && assertionFunc(1.0)


### PR DESCRIPTION
*Description of changes:*

- The new class contains an additional field, which can be used to store a value associated with the constraint.
- This is useful for the categorical range rule, to store the categories. This way, the values can be extracted without needing to parse the constraint code which is stored as a string.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
