### PR TITLE
Replace Spark SQL isNull check with Spark Scala based DSL

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
@@ -465,18 +465,24 @@ private[deequ] object Analyzers {
     conditionalSelection(col(selection), where)
   }
 
-  def conditionalSelection(selection: Column, where: Option[String], replaceWith: Double): Column = {
-    val conditionColumn = where.map(expr)
-    conditionColumn
+  def conditionSelectionGivenColumn(selection: Column, where: Option[Column], replaceWith: Double): Column = {
+    where
       .map { condition => when(condition, replaceWith).otherwise(selection) }
       .getOrElse(selection)
   }
 
-  def conditionalSelection(selection: Column, where: Option[String], replaceWith: String): Column = {
-    val conditionColumn = where.map(expr)
-    conditionColumn
+  def conditionSelectionGivenColumn(selection: Column, where: Option[Column], replaceWith: String): Column = {
+    where
       .map { condition => when(condition, replaceWith).otherwise(selection) }
       .getOrElse(selection)
+  }
+
+  def conditionalSelection(selection: Column, where: Option[String], replaceWith: Double): Column = {
+    conditionSelectionGivenColumn(selection, where.map(expr), replaceWith)
+  }
+
+  def conditionalSelection(selection: Column, where: Option[String], replaceWith: String): Column = {
+    conditionSelectionGivenColumn(selection, where.map(expr), replaceWith)
   }
 
   def conditionalSelection(selection: Column, condition: Option[String]): Column = {

--- a/src/main/scala/com/amazon/deequ/analyzers/MaxLength.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/MaxLength.scala
@@ -49,12 +49,13 @@ case class MaxLength(column: String, where: Option[String] = None, analyzerOptio
   override def filterCondition: Option[String] = where
 
   private def criterion(nullBehavior: NullBehavior): Column = {
+    val isNullCheck = col(column).isNull
     nullBehavior match {
       case NullBehavior.Fail =>
         val colLengths: Column = length(conditionalSelection(column, where)).cast(DoubleType)
-        conditionalSelection(colLengths, Option(s"${column} IS NULL"), replaceWith = Double.MaxValue)
+        conditionSelectionGivenColumn(colLengths, Option(isNullCheck), replaceWith = Double.MaxValue)
       case NullBehavior.EmptyString =>
-        length(conditionalSelection(col(column), Option(s"${column} IS NULL"), replaceWith = "")).cast(DoubleType)
+        length(conditionSelectionGivenColumn(col(column), Option(isNullCheck), replaceWith = "")).cast(DoubleType)
       case _ => length(conditionalSelection(column, where)).cast(DoubleType)
     }
   }

--- a/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
+++ b/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
@@ -159,6 +159,19 @@ trait FixtureSupport {
     ).toDF("item", "att1", "att2")
   }
 
+  def getDfCompleteAndInCompleteColumnsWithSpacesInNames(sparkSession: SparkSession): DataFrame = {
+    import sparkSession.implicits._
+
+    Seq(
+      ("1", "ab", "abc1"),
+      ("2", "bc", null),
+      ("3", "ab", "def2ghi"),
+      ("4", "ab", null),
+      ("5", "bcd", "ab"),
+      ("6", "a", "pqrs")
+    ).toDF("some item", "att 1", "att 2")
+  }
+
   def getDfCompleteAndInCompleteColumnsAndVarLengthStrings(sparkSession: SparkSession): DataFrame = {
     import sparkSession.implicits._
 


### PR DESCRIPTION
*Issue*
- The column profiling for min/max lengths for a string column is not working when the column name has a space in it.

*Description of changes:*
- Replaced Spark SQL isNull check with Spark Scala based DSL
- This is to ensure columns with spaces in their names get their names escaped correctly in the where condition.
- Added a test to verify.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
