### PR TITLE
Allow all DQ constraints to be generated from an Analyzer

### DIFF
--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -1083,6 +1083,12 @@ object Check {
   /** A common assertion function checking if the value is 1 */
   val IsOne: Double => Boolean = { _ == 1.0 }
 
+  def fromConstraint(constraint: Constraint,
+                     description: String,
+                     checkLevel: CheckLevel.Value = CheckLevel.Error): Check = {
+    Check(checkLevel, description, constraints = Seq(constraint))
+  }
+
   /**
     * Common assertion function checking if the value can be considered as normal (that no
     * anomalies were detected), given the anomaly detection strategy and details on how to retrieve


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Due to our typing system, it is always possible to create an Analyzer, but converting that into a generic Constraint and generic Check is impossible. 

Instead, give callers the option to convert an Analyzer into a Check with these helper functions. This enables reuse of Analyzers - you can use an Analyzer directly, or convert it to a Check by assigning it a severity and assertion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
