### PR TITLE
Fail when CustomSql has syntax errors

### DIFF
--- a/src/test/scala/com/amazon/deequ/analyzers/CustomSqlTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/CustomSqlTest.scala
@@ -68,7 +68,22 @@ class CustomSqlTest extends AnyWordSpec with Matchers with SparkContextSpec with
         case Success(_) => fail("Should have failed")
         case Failure(exception) => exception.getMessage shouldBe "Custom SQL did not return exactly 1 column"
       }
+    }
 
+    "returns the error if the SQL statement has a syntax error" in withSparkSession { session =>
+      val data = getDfWithStringColumns(session)
+      data.createOrReplaceTempView("primary")
+
+      val sql = CustomSql("Select `foo` from primary")
+      val state = sql.computeStateFrom(data)
+      val metric = sql.computeMetricFrom(state)
+
+      metric.value.isFailure shouldBe true
+      metric.value match {
+        case Success(_) => fail("Should have failed")
+        case Failure(exception) => exception.getMessage should
+          include("A column or function parameter with name `foo` cannot be resolved")
+      }
     }
   }
 }

--- a/src/test/scala/com/amazon/deequ/analyzers/CustomSqlTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/CustomSqlTest.scala
@@ -81,8 +81,7 @@ class CustomSqlTest extends AnyWordSpec with Matchers with SparkContextSpec with
       metric.value.isFailure shouldBe true
       metric.value match {
         case Success(_) => fail("Should have failed")
-        case Failure(exception) => exception.getMessage should
-          include("A column or function parameter with name `foo` cannot be resolved")
+        case Failure(exception) => exception.getMessage should include("`foo`")
       }
     }
   }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

If the SQL statement has an error, return a failed state from the CustomSql analyzer

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
