### PR TITLE
[Data Synchronization/Matching] Delegate to Spark for checking existence of columns in the given dataframes

### DIFF
--- a/src/main/scala/com/amazon/deequ/comparison/DataSynchronization.scala
+++ b/src/main/scala/com/amazon/deequ/comparison/DataSynchronization.scala
@@ -96,10 +96,11 @@ object DataSynchronization extends ComparisonBase {
                   assertion: Double => Boolean): ComparisonResult = {
     val columnErrors = areKeyColumnsValid(ds1, ds2, colKeyMap)
     if (columnErrors.isEmpty) {
+      // Get all the non-key columns from DS1 and verify that they are present in DS2
       val colsDS1 = ds1.columns.filterNot(x => colKeyMap.keys.toSeq.contains(x)).sorted
-      val colsDS2 = ds2.columns.filterNot(x => colKeyMap.values.toSeq.contains(x)).sorted
+      val nonKeyColsMatch = colsDS1.forall { col => Try { ds2(col) }.isSuccess }
 
-      if (!(colsDS1 sameElements colsDS2)) {
+      if (!nonKeyColsMatch) {
         ComparisonFailed("Non key columns in the given data frames do not match.")
       } else {
         val mergedMaps = colKeyMap ++ colsDS1.map(x => x -> x).toMap
@@ -152,9 +153,11 @@ object DataSynchronization extends ComparisonBase {
           case compCols => Right(compCols)
         }
       } else {
+        // Get all the non-key columns from DS1 and verify that they are present in DS2
         val ds1NonKeyCols = ds1.columns.filterNot(x => colKeyMap.keys.toSeq.contains(x)).sorted
-        val ds2NonKeyCols = ds2.columns.filterNot(x => colKeyMap.values.toSeq.contains(x)).sorted
-        if (!(ds1NonKeyCols sameElements ds2NonKeyCols)) {
+        val nonKeyColsMatch = ds1NonKeyCols.forall { col => Try { ds2(col) }.isSuccess }
+
+        if (!nonKeyColsMatch) {
           Left(ComparisonFailed("Non key columns in the given data frames do not match."))
         } else {
           Right(ds1NonKeyCols.map { c => c -> c}.toMap)


### PR DESCRIPTION
*Description of changes:*

- Prior to this change, we were doing case sensitive equality checks of non-key columns.
- This makes the utility more restrictive, as Spark does not care about the casing of column names.
- With this change, we rely on Spark to check if a column exists in the given dataframe. If Spark can find the column, we can proceed with the rest of the check.

*Issue #, if available:*
N/A

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
