### PR TITLE
Test that exceptions within a check's constraints do not affect other…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -206,6 +206,7 @@
                 <artifactId>scalatest-maven-plugin</artifactId>
                 <version>1.0</version>
                 <configuration>
+                    <stdout>F</stdout>
                     <reportsDirectory>${project.build.directory}/surefire-reports</reportsDirectory>
                     <junitxml>.</junitxml>
                     <filereports>WDF TestSuite.txt</filereports>


### PR DESCRIPTION
Add VerificationSuite test to ensure checks which throw an exception will not prevent evaluation of other checks in the suite, and that the exception message will be passed in constraint results.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
