### PR TITLE
fix ratio in constraint_message

### DIFF
--- a/src/main/scala/com/amazon/deequ/comparison/ReferentialIntegrity.scala
+++ b/src/main/scala/com/amazon/deequ/comparison/ReferentialIntegrity.scala
@@ -60,7 +60,7 @@ object ReferentialIntegrity extends ComparisonBase {
       val referenceSparkCols = reference.select(referenceColumns.map(col): _*)
       val mismatchCount = primarySparkCols.except(referenceSparkCols).count()
 
-      val ratio = if (mismatchCount == 0) 1.0 else (primaryCount - mismatchCount).toDouble / primaryCount
+      val ratio = mismatchCount.toDouble / primaryCount
 
       if (assertion(ratio)) {
         ComparisonSucceeded()


### PR DESCRIPTION
Hello!

I've just set up the library and noticed this thing:

Here is the data example:
![image](https://github.com/awslabs/deequ/assets/46625461/c122d2a9-7a83-469e-8b5a-24fbf0266b6a)

The tests:
![image](https://github.com/awslabs/deequ/assets/46625461/f1d30f60-ce2c-4a04-922e-d9d5b07560a9)

And the sample of the results:
![image](https://github.com/awslabs/deequ/assets/46625461/252c07c8-4ef6-4124-a8d9-bba39e8461c9)

As you can see, the first constraint_message says that 60% of data didn't meet the requirement, although 60% of it **did** meet. In the second row, it says that 0% didn't meet which means that 100% is passed successfully, thought it's the opposite: none of the values among ga_visits column is unique.

*Description of changes:*
I propose to change the formula of calculating ratio in constraint_message, so it becomes the ratio of mismatched values.
If we use **val ratio = mismatchCount.toDouble / primaryCount**, then the results for my case would be 4/10=0.4 and 10/10=1 "didn't meet the constraint requirement".

Another approach is to omit **not** in the message, however, I'm not sure if it follows the logic.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
