### PR TITLE
Fix bug in MinLength and MaxLength when NullBehavior.EmptyString

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/MaxLength.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/MaxLength.scala
@@ -75,7 +75,8 @@ case class MaxLength(column: String, where: Option[String] = None, analyzerOptio
       case NullBehavior.Fail =>
         conditionSelectionGivenColumn(colLengths, Option(isNullCheck), replaceWith = Double.MaxValue)
       case NullBehavior.EmptyString =>
-        length(conditionSelectionGivenColumn(col(column), Option(isNullCheck), replaceWith = "")).cast(DoubleType)
+        // Empty String is 0 length string
+        conditionSelectionGivenColumn(colLengths, Option(isNullCheck), replaceWith = 0.0).cast(DoubleType)
       case _ =>
         colLengths
     }

--- a/src/main/scala/com/amazon/deequ/analyzers/MinLength.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/MinLength.scala
@@ -75,7 +75,8 @@ case class MinLength(column: String, where: Option[String] = None, analyzerOptio
       case NullBehavior.Fail =>
         conditionSelectionGivenColumn(colLengths, Option(isNullCheck), replaceWith = Double.MinValue)
       case NullBehavior.EmptyString =>
-        length(conditionSelectionGivenColumn(col(column), Option(isNullCheck), replaceWith = "")).cast(DoubleType)
+        // Empty String is 0 length string
+        conditionSelectionGivenColumn(colLengths, Option(isNullCheck), replaceWith = 0.0).cast(DoubleType)
       case _ =>
         colLengths
     }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- While testing, we found a bug that when using the `MaxLength` or `MinLength` analyzers with the `NullBehavior.EmptyString` analyzer option, we weren't properly emitting metrics when using a where filter. 
- This was because the `filter` was not properly applied to constructing the criterion.
- This PR fixes this issue for both `MaxLength` and `MinLength` analyzers and adds tests to verify.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
