### PR TITLE
[Min/Max] Apply filtered row behavior at the row level evaluation

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/Minimum.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Minimum.scala
@@ -23,8 +23,6 @@ import org.apache.spark.sql.types.{DoubleType, StructType}
 import Analyzers._
 import com.amazon.deequ.metrics.FullColumn
 import com.google.common.annotations.VisibleForTesting
-import org.apache.spark.sql.functions.expr
-import org.apache.spark.sql.functions.not
 
 case class MinState(minValue: Double, override val fullColumn: Option[Column] = None)
   extends DoubleValuedState[MinState] with FullColumn {
@@ -48,7 +46,7 @@ case class Minimum(column: String, where: Option[String] = None, analyzerOptions
 
   override def fromAggregationResult(result: Row, offset: Int): Option[MinState] = {
     ifNoNullsIn(result, offset) { _ =>
-      MinState(result.getDouble(offset), Some(rowLevelResults))
+      MinState(result.getDouble(offset), Some(criterion))
     }
   }
 
@@ -59,19 +57,5 @@ case class Minimum(column: String, where: Option[String] = None, analyzerOptions
   override def filterCondition: Option[String] = where
 
   @VisibleForTesting
-  private def criterion: Column = {
-    conditionalSelection(column, where).cast(DoubleType)
-  }
-
-  private[deequ] def rowLevelResults: Column = {
-    val filteredRowOutcome = getRowLevelFilterTreatment(analyzerOptions)
-    val whereNotCondition = where.map { expression => not(expr(expression)) }
-
-    filteredRowOutcome match {
-      case FilteredRowOutcome.TRUE =>
-        conditionSelectionGivenColumn(col(column), whereNotCondition, replaceWith = Double.MaxValue).cast(DoubleType)
-      case _ =>
-        criterion
-    }
-  }
+  private def criterion: Column = conditionalSelection(column, where).cast(DoubleType)
 }


### PR DESCRIPTION
*Description of changes:*

- This changes from applying the behavior at the analyzer level. It allows us to prevent the usage of MinValue/MaxValue as placeholder values for filtered rows.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
