### PR TITLE
Fix Breeze dependency conflict in Anomaly Detection Spark 3.4+

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>org.scalanlp</groupId>
             <artifactId>breeze_${scala.major.version}</artifactId>
-            <version>0.13.2</version>
+            <version>2.1.0</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
Update breeze version to 2.1 to match with current spark-mlib 3.4 and spark-mlib 3.5 breeze dependency version. This would allow people migrating to spark 3.4+ to use anomaly detection without dependency conflict issue that is mentioned in
https://github.com/awslabs/deequ/issues/336
https://github.com/awslabs/deequ/issues/393
https://github.com/awslabs/deequ/issues/428
https://github.com/awslabs/deequ/issues/428
Also Breeze 0.13.2 has several security vulnerabilities which was solve in breeze 2.1.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
