### PR TITLE
Add DateTimeMetric, Analyzer and Example

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -233,7 +233,7 @@
                 <version>1.0.0</version>
                 <configuration>
                     <verbose>false</verbose>
-                    <failOnViolation>false</failOnViolation>
+                    <failOnViolation>true</failOnViolation>
                     <includeTestSourceDirectory>true</includeTestSourceDirectory>
                     <failOnWarning>false</failOnWarning>
                     <sourceDirectory>${project.basedir}/src/main/scala</sourceDirectory>

--- a/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
@@ -443,9 +443,9 @@ object Preconditions {
       case _ => false
     }
 
-    if (hasDateType) {
-      throw new WrongColumnTypeException(s"Expected type of column $column to be one of" +
-        s"${dateTypes.mkString(",")}, but found $columnDataType instead!")
+    if (!hasDateType) {
+      throw new WrongColumnTypeException(s"Expected type of column $column to be one of " +
+        s"${dateTypes.mkString(", ")}, but found $columnDataType instead!")
     }
   }
 

--- a/src/main/scala/com/amazon/deequ/analyzers/DateTimeDistribution.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/DateTimeDistribution.scala
@@ -1,0 +1,143 @@
+﻿/**
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.analyzers
+
+import java.time.Instant
+import com.amazon.deequ.analyzers.Analyzers._
+import com.amazon.deequ.analyzers.Preconditions.{hasColumn, isDateType}
+import com.amazon.deequ.analyzers.runners.MetricCalculationException
+import com.amazon.deequ.metrics.{Distribution, DistributionValue, HistogramMetric}
+import org.apache.spark.sql.DeequFunctions.dateTimeDistribution
+import org.apache.spark.sql.types.StructType
+import org.apache.spark.sql.{Column, Row}
+
+import scala.util.{Failure, Success}
+
+object DistributionInterval extends Enumeration {
+  val QUARTER_HOUR, HOURLY, DAILY, WEEKLY, MONTHLY = Value
+}
+
+case class DateTimeDistributionState(distribution: Map[(Instant, Instant), Long])
+  extends State[DateTimeDistributionState] {
+
+  override def sum(other: DateTimeDistributionState): DateTimeDistributionState = {
+
+    DateTimeDistributionState(distribution ++ other.distribution.map {
+      case (k, v) => k -> (v + distribution.getOrElse(k, 0L))
+    })
+  }
+}
+
+object DateTimeDistributionState {
+
+  def computeStateFromResult(
+    result: Map[Long, Long],
+    frequency: Long
+  ): Map[(Instant, Instant), Long] = {
+    result.map({
+      case (x, y) => (new Instant(x), new Instant(x + frequency - 1L)) -> y
+    })
+  }
+
+  def toDistribution(histogram: DateTimeDistributionState): Distribution = {
+    val totalCount = histogram.distribution.foldLeft(0L)(_ + _._2)
+    Distribution(
+      histogram.distribution.map {
+        case (x, y) =>
+          ("(" + x._1.toString + " to " + x._2.toString + ")") -> DistributionValue(y, y.toDouble / totalCount)
+      },
+      totalCount
+    )
+  }
+}
+
+/**
+ *
+ * @param column   : column on which distribution analysis is to be performed
+ * @param interval : interval of the distribution;
+ * @param where    : optional filter condition
+ */
+case class DateTimeDistribution(
+                                 column: String,
+                                 interval: Long,
+                                 where: Option[String] = None)
+  extends ScanShareableAnalyzer[DateTimeDistributionState, HistogramMetric]
+    with FilterableAnalyzer {
+
+  /** Defines the aggregations to compute on the data */
+  override private[deequ] def aggregationFunctions(): Seq[Column] = {
+    dateTimeDistribution(conditionalSelection(column, where), interval) :: Nil
+  }
+
+  /** Computes the state from the result of the aggregation functions */
+  override private[deequ] def fromAggregationResult(
+    result: Row,
+    offset: Int
+  ): Option[DateTimeDistributionState] = {
+    ifNoNullsIn(result, offset) { _ =>
+      DateTimeDistributionState(
+        DateTimeDistributionState.computeStateFromResult(
+          Map.empty[Long, Long] ++ result.getMap(0),
+          interval
+        )
+      )
+    }
+  }
+
+  override def preconditions: Seq[StructType => Unit] = {
+    hasColumn(column) +: isDateType(column) +: super.preconditions
+  }
+
+  override def filterCondition: Option[String] = where
+
+  /**
+   * Compute the metric from the state (sufficient statistics)
+   *
+   * @param state wrapper holding a state of type S (required due to typing issues...)
+   * @return
+   */
+  override def computeMetricFrom(state: Option[DateTimeDistributionState]): HistogramMetric = {
+    state match {
+      case Some(histogram) =>
+        HistogramMetric(column, Success(DateTimeDistributionState.toDistribution(histogram)))
+      case _ =>
+        toFailureMetric(emptyStateException(this))
+    }
+  }
+
+  override private[deequ] def toFailureMetric(failure: Exception): HistogramMetric = {
+    HistogramMetric(column, Failure(MetricCalculationException.wrapIfNecessary(failure)))
+  }
+}
+
+object DateTimeDistribution {
+  def apply(column: String,
+            interval: DistributionInterval.Value,
+            where: Option[String] = None): DateTimeDistribution =
+    new DateTimeDistribution(column, interval = getDateTimeAggIntervalValue(interval), where)
+
+  def getDateTimeAggIntervalValue(interval: DistributionInterval.Value): Long = {
+    interval match {
+      case DistributionInterval.QUARTER_HOUR => 900000L // 15 Minutes
+      case DistributionInterval.HOURLY => 3600000L // 60 Minutes
+      case DistributionInterval.DAILY => 86400000L // 24 Hours
+      case DistributionInterval.WEEKLY => 604800000L
+      case _ => 604800000L // 7 * 24 Hours
+    }
+  }
+
+}

--- a/src/main/scala/com/amazon/deequ/analyzers/DateTimeDistribution.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/DateTimeDistribution.scala
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not
@@ -49,7 +49,7 @@ object DateTimeDistributionState {
     frequency: Long
   ): Map[(Instant, Instant), Long] = {
     result.map({
-      case (x, y) => (new Instant(x), new Instant(x + frequency - 1L)) -> y
+      case (x, y) => (Instant.ofEpochMilli(x), Instant.ofEpochMilli(x + frequency - 1L)) -> y
     })
   }
 
@@ -127,8 +127,12 @@ case class DateTimeDistribution(
 object DateTimeDistribution {
   def apply(column: String,
             interval: DistributionInterval.Value,
-            where: Option[String] = None): DateTimeDistribution =
+            where: Option[String]): DateTimeDistribution =
     new DateTimeDistribution(column, interval = getDateTimeAggIntervalValue(interval), where)
+
+  def apply(column: String,
+            interval: DistributionInterval.Value): DateTimeDistribution =
+    new DateTimeDistribution(column, interval = getDateTimeAggIntervalValue(interval), None)
 
   def getDateTimeAggIntervalValue(interval: DistributionInterval.Value): Long = {
     interval match {

--- a/src/main/scala/com/amazon/deequ/analyzers/DateTimeDistribution.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/DateTimeDistribution.scala
@@ -57,10 +57,9 @@ object DateTimeDistributionState {
     val totalCount = histogram.distribution.foldLeft(0L)(_ + _._2)
     Distribution(
       histogram.distribution.map {
-        case (x, y) =>
-          ("(" + x._1.toString + " to " + x._2.toString + ")") -> DistributionValue(y, y.toDouble / totalCount)
+        case (x, y) => (s"(${x._1} to ${x._2})") -> DistributionValue(y, y.toDouble / totalCount)
       },
-      totalCount
+      histogram.distribution.keys.size
     )
   }
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/MaximumDateTime.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/MaximumDateTime.scala
@@ -1,0 +1,54 @@
+﻿/**
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.analyzers
+
+import com.amazon.deequ.analyzers.Preconditions.{hasColumn, isDateType}
+import org.apache.spark.sql.{Column, Row}
+import org.apache.spark.sql.functions.max
+import org.apache.spark.sql.types.{TimestampType, StructType}
+import Analyzers._
+import java.time.Instant
+
+case class MaxDateTimeState(maxValue: Instant) extends DateTimeValuedState[MaxDateTimeState] {
+
+  override def sum(other: MaxDateTimeState): MaxDateTimeState = {
+    MaxDateTimeState(if (maxValue.compareTo(other.maxValue) > 0) maxValue else other.maxValue)
+  }
+
+  override def metricValue(): Instant = maxValue
+}
+
+case class MaximumDateTime(column: String, where: Option[String] = None)
+  extends TimestampScanShareableAnalyzer[MaxDateTimeState]("Maximum Date Time", column)
+  with FilterableAnalyzer {
+
+  override def aggregationFunctions(): Seq[Column] = {
+    max(conditionalSelection(column, where)).cast(TimestampType) :: Nil
+  }
+
+  override def fromAggregationResult(result: Row, offset: Int): Option[MaxDateTimeState] = {
+    ifNoNullsIn(result, offset) { _ =>
+        MaxDateTimeState(result.getInstant(offset))
+    }
+  }
+
+  override protected def additionalPreconditions(): Seq[StructType => Unit] = {
+    hasColumn(column) :: isDateType(column) :: Nil
+  }
+
+  override def filterCondition: Option[String] = where
+}

--- a/src/main/scala/com/amazon/deequ/analyzers/MaximumDateTime.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/MaximumDateTime.scala
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not

--- a/src/main/scala/com/amazon/deequ/analyzers/MinimumDateTime.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/MinimumDateTime.scala
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.analyzers
+
+import com.amazon.deequ.analyzers.Preconditions.{hasColumn, isDateType}
+import org.apache.spark.sql.{Column, Row}
+import org.apache.spark.sql.functions.min
+import org.apache.spark.sql.types.{TimestampType, StructType}
+import Analyzers._
+import java.time.Instant
+
+case class MinDateTimeState(minValue: Instant) extends DateTimeValuedState[MinDateTimeState] {
+
+  override def sum(other: MinDateTimeState): MinDateTimeState = {
+    MinDateTimeState(if (minValue.compareTo(other.minValue) < 0) minValue else other.minValue)
+  }
+
+  override def metricValue(): Instant = {
+    minValue
+  }
+}
+
+case class MinimumDateTime(column: String, where: Option[String] = None)
+  extends TimestampScanShareableAnalyzer[MinDateTimeState]("Minimum Date Time", column)
+  with FilterableAnalyzer {
+
+  override def aggregationFunctions(): Seq[Column] = {
+    min(conditionalSelection(column, where)).cast(TimestampType) :: Nil
+  }
+
+  override def fromAggregationResult(result: Row, offset: Int): Option[MinDateTimeState] = {
+    ifNoNullsIn(result, offset) { _ => MinDateTimeState(result.getInstant(offset)) }
+  }
+
+  override protected def additionalPreconditions(): Seq[StructType => Unit] = {
+    hasColumn(column) :: isDateType(column) :: Nil
+  }
+
+  override def filterCondition: Option[String] = where
+}

--- a/src/main/scala/com/amazon/deequ/analyzers/catalyst/DateTimeAggregation.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/catalyst/DateTimeAggregation.scala
@@ -1,0 +1,49 @@
+﻿/**
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package org.apache.spark.sql
+
+import org.apache.spark.sql.expressions.Aggregator
+import org.apache.spark.sql.catalyst.encoders.ExpressionEncoder
+
+import java.time.Instant
+
+
+private[sql] class DateTimeAggregation(
+  frequency: Long
+) extends Aggregator[Instant, Map[Long, Long], Map[Long, Long]] {
+  override def zero: Map[Long, Long] = Map.empty[Long, Long]
+
+  override def reduce(agg: Map[Long, Long], input: Instant): Map[Long, Long] = {
+    val dateTime = input.toEpochMilli
+    val batchTime = dateTime - (dateTime % frequency)
+    agg + (batchTime -> (agg.getOrElse(batchTime, 0L) + 1L))
+  }
+
+  override def merge(b1: Map[Long, Long], b2: Map[Long, Long]): Map[Long, Long] = {
+    b1 ++ b2.map {
+      case (k, v) => k -> (v + b1.getOrElse(k, 0L))
+    }
+  }
+
+  override def finish(reduction: Map[Long, Long]): Map[Long, Long] = reduction
+
+  // Define encoder for buffer
+  def bufferEncoder: Encoder[Map[Long, Long]] = ExpressionEncoder()
+
+  // Define encoder for output
+  def outputEncoder: Encoder[Map[Long, Long]] = ExpressionEncoder()
+}

--- a/src/main/scala/com/amazon/deequ/analyzers/catalyst/DateTimeAggregation.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/catalyst/DateTimeAggregation.scala
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not

--- a/src/main/scala/com/amazon/deequ/analyzers/catalyst/DeequFunctions.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/catalyst/DeequFunctions.scala
@@ -18,6 +18,7 @@ package org.apache.spark.sql
 
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateFunction, StatefulApproxQuantile, StatefulHyperloglogPlus}
 import org.apache.spark.sql.catalyst.expressions.Literal
+import org.apache.spark.sql.functions.udaf
 
 /* Custom aggregation functions used internally by deequ */
 object DeequFunctions {
@@ -95,8 +96,8 @@ object DeequFunctions {
    * @return Column: aggregation function Column
    * */
   def dateTimeDistribution(column: Column, interval: Long): Column = {
-    val dateTimeAgg = new DateTimeAggregation(interval)
-    dateTimeAgg.toColumn(column)
+    val dateTimeDistribution = udaf(new DateTimeAggregation(interval))
+    dateTimeDistribution(column)
   }
 }
 

--- a/src/main/scala/com/amazon/deequ/analyzers/catalyst/DeequFunctions.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/catalyst/DeequFunctions.scala
@@ -16,7 +16,6 @@
 
 package org.apache.spark.sql
 
-
 import org.apache.spark.sql.catalyst.expressions.aggregate.{AggregateFunction, StatefulApproxQuantile, StatefulHyperloglogPlus}
 import org.apache.spark.sql.catalyst.expressions.Literal
 
@@ -86,6 +85,18 @@ object DeequFunctions {
       shrinkingFactor: Double): Column = {
     val statefulKLL = new StatefulKLLSketch(sketchSize, shrinkingFactor)
     statefulKLL(column)
+  }
+
+  /**
+   * return DateTime distribution aggregation function
+   *
+   * @param column   : column on which aggregation to be performed
+   * @param interval : interval of date time aggregation
+   * @return Column: aggregation function Column
+   * */
+  def dateTimeDistribution(column: Column, interval: Long): Column = {
+    val dateTimeAgg = new DateTimeAggregation(interval)
+    dateTimeAgg.toColumn(column)
   }
 }
 

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -40,6 +40,7 @@ import com.amazon.deequ.repository.MetricsRepository
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.expressions.UserDefinedFunction
 
+import java.time.Instant
 import scala.util.matching.Regex
 
 object CheckLevel extends Enumeration {
@@ -1235,6 +1236,96 @@ case class Check(
     satisfies(predicate, s"$column between $lowerBound and $upperBound", hint = hint,
       columns = List(column), analyzerOptions = analyzerOptions)
   }
+
+  def hasMinTimestamp(
+    column: String,
+    assertion: Instant => Boolean,
+    hint: Option[String] = None)
+  : CheckWithLastConstraintFilterable = addFilterableConstraint { filter =>
+    minTimestampConstraint(column, assertion, filter, hint)
+  }
+
+  def hasMaxTimestamp(
+    column: String,
+    assertion: Instant => Boolean,
+    hint: Option[String] = None)
+  : CheckWithLastConstraintFilterable = addFilterableConstraint { filter =>
+    maxTimestampConstraint(column, assertion, filter, hint)
+  }
+
+  /**
+   * Asserts that, in each row, the value of column (DateType or TimestampType)
+   * is less than the given datetime (Timestamp)
+   *
+   * @param column    Column to run the assertion on
+   * @param datetime  value of Timestamp to run assert
+   * @param assertion Function that receives a Timestamp input parameter and returns a boolean
+   * @param hint      A hint to provide additional context why a constraint could have failed
+   * @return
+   */
+  def isDateTimeLessThan(
+    column: String,
+    datetime: Instant,
+    assertion: Double => Boolean = Check.IsOne,
+    hint: Option[String] = None)
+  : CheckWithLastConstraintFilterable = satisfies(s"$column < to_timestamp('${datetime.toString}')",
+    s"$column is less than '${datetime.toString}'", assertion,
+    hint = hint)
+
+  /**
+   *
+   * Asserts that, in each row, the value of column (DateType or TimestampType)
+   * is greater than the given datetime (Timestamp)
+   *
+   * @param column    Column to run the assertion on
+   * @param datetime  value of Timestamp to run assert
+   * @param assertion Function that receives a Timestamp input parameter and returns a boolean
+   * @param hint      A hint to provide additional context why a constraint could have failed
+   * @return
+   */
+  def isDateTimeGreaterThan(
+    column: String,
+    datetime: Instant,
+    assertion: Double => Boolean = Check.IsOne,
+    hint: Option[String] = None)
+  : CheckWithLastConstraintFilterable = satisfies(s"$column > to_timestamp('${datetime.toString}')",
+    s"$column is greater than '${datetime.toString}'", assertion,
+    hint = hint)
+
+  /**
+   *
+   * Asserts that, in each row, the value of column (DateType or TimestampType) contains a past date
+   *
+   * @param column    Column to run the assertion on
+   * @param assertion Function that receives a Timestamp input parameter and returns a boolean
+   * @param hint      A hint to provide additional context why a constraint could have failed
+   * @return
+   */
+  def hasPastDates(
+    column: String,
+    assertion: Double => Boolean = Check.IsOne,
+    hint: Option[String] = None)
+  : CheckWithLastConstraintFilterable = satisfies(s"$column < now()",
+    s"$column has all past dates", assertion,
+    hint = hint)
+
+  /**
+   *
+   * Asserts that, in each row, the value of column (DateType or TimestampType)
+   * contains a future date
+   *
+   * @param column    Column to run the assertion on
+   * @param assertion Function that receives a Timestamp input parameter and returns a boolean
+   * @param hint      A hint to provide additional context why a constraint could have failed
+   * @return
+   */
+  def hasFutureDates(
+    column: String,
+    assertion: Double => Boolean = Check.IsOne,
+    hint: Option[String] = None)
+  : CheckWithLastConstraintFilterable = satisfies(s"$column > now()",
+    s"$column has all future dates", assertion,
+    hint = hint)
 
   /**
     * Evaluate this check on computed metrics

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -22,6 +22,7 @@ import com.amazon.deequ.metrics.Distribution
 import com.amazon.deequ.metrics.Metric
 import org.apache.spark.sql.expressions.UserDefinedFunction
 
+import java.time.Instant
 import scala.util.Failure
 import scala.util.Success
 import scala.util.matching.Regex
@@ -612,6 +613,42 @@ object Constraint {
       s"MinLengthConstraint($minLength)",
       s"ColumnLength-$column",
       sparkAssertion)
+  }
+
+  def minTimestampConstraint(
+    column: String,
+    assertion: Instant => Boolean,
+    where: Option[String] = None,
+    hint: Option[String] = None)
+  : Constraint = {
+
+    val minimum = MinimumDateTime(column, where)
+
+    val constraint = AnalysisBasedConstraint[MinDateTimeState, Instant, Instant](
+      minimum,
+      assertion,
+      hint = hint
+    )
+
+    new NamedConstraint(constraint, s"MinimumTimestampConstraint($minimum)")
+  }
+
+  def maxTimestampConstraint(
+    column: String,
+    assertion: Instant => Boolean,
+    where: Option[String] = None,
+    hint: Option[String] = None)
+  : Constraint = {
+
+    val maximum = MaximumDateTime(column, where)
+
+    val constraint = AnalysisBasedConstraint[MaxDateTimeState, Instant, Instant](
+      maximum,
+      assertion,
+      hint = hint
+    )
+
+    new NamedConstraint(constraint, s"MaximumTimestampConstraint($maximum)")
   }
 
   /**

--- a/src/main/scala/com/amazon/deequ/examples/DateTimeMetricExample.scala
+++ b/src/main/scala/com/amazon/deequ/examples/DateTimeMetricExample.scala
@@ -1,0 +1,51 @@
+﻿/**
+ * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.examples
+
+import java.time.Instant
+import com.amazon.deequ.analyzers.runners.{AnalysisRunner, AnalyzerContext}
+import com.amazon.deequ.analyzers.{DateTimeDistribution, DistributionInterval, MaximumDateTime, MinimumDateTime}
+import com.amazon.deequ.examples.ExampleUtils.{customerAsDataframe, withSpark}
+import com.amazon.deequ.analyzers.runners.AnalyzerContext.successMetricsAsDataFrame
+
+private[examples] object DateTimeMetricExample extends App {
+  withSpark { session =>
+
+    val data = customerAsDataframe(session,
+      Customer(1, "john doe", Instant.parse("2021-11-11T07:15:00Z")),
+      Customer(2, "marry jane", Instant.parse("2022-01-11T07:45:00Z")),
+      Customer(3, "Thomas Yu", Instant.parse("2023-02-11T08:15:00Z")),
+      Customer(4, "Steve Powell", Instant.parse("2019-04-11T12:15:00Z")),
+      Customer(5, "Andrej Kar", Instant.parse("2020-08-11T12:30:00Z")),
+    )
+
+    val analysisResult: AnalyzerContext = { AnalysisRunner
+      .onData(data)
+      .addAnalyzer(DateTimeDistribution("dateOfBirth", DistributionInterval.HOURLY))
+      .addAnalyzer(MinimumDateTime("dateOfBirth"))
+      .addAnalyzer(MaximumDateTime("dateOfBirth"))
+      .run()
+    }
+
+    successMetricsAsDataFrame(session, analysisResult).show(false)
+
+    analysisResult.metricMap.foreach( x =>
+      println(s"column '${x._2.instance}' has ${x._2.name} : ${x._2.value.get}")
+    )
+
+  }
+}

--- a/src/main/scala/com/amazon/deequ/examples/DateTimeMetricExample.scala
+++ b/src/main/scala/com/amazon/deequ/examples/DateTimeMetricExample.scala
@@ -31,13 +31,14 @@ private[examples] object DateTimeMetricExample extends App {
       Customer(3, "Thomas Yu", Instant.parse("2023-02-11T08:15:00Z")),
       Customer(4, "Steve Powell", Instant.parse("2019-04-11T12:15:00Z")),
       Customer(5, "Andrej Kar", Instant.parse("2020-08-11T12:30:00Z")),
+      Customer(6, "Ji Sung", Instant.parse("2020-08-11T12:30:00Z")),
     )
 
     val analysisResult: AnalyzerContext = { AnalysisRunner
       .onData(data)
       .addAnalyzer(DateTimeDistribution("dateOfBirth", DistributionInterval.HOURLY))
-//      .addAnalyzer(MinimumDateTime("dateOfBirth"))
-//      .addAnalyzer(MaximumDateTime("dateOfBirth"))
+      .addAnalyzer(MinimumDateTime("dateOfBirth"))
+      .addAnalyzer(MaximumDateTime("dateOfBirth"))
       .run()
     }
 

--- a/src/main/scala/com/amazon/deequ/examples/DateTimeMetricExample.scala
+++ b/src/main/scala/com/amazon/deequ/examples/DateTimeMetricExample.scala
@@ -1,4 +1,4 @@
-﻿/**
+/**
  * Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License"). You may not
@@ -36,8 +36,8 @@ private[examples] object DateTimeMetricExample extends App {
     val analysisResult: AnalyzerContext = { AnalysisRunner
       .onData(data)
       .addAnalyzer(DateTimeDistribution("dateOfBirth", DistributionInterval.HOURLY))
-      .addAnalyzer(MinimumDateTime("dateOfBirth"))
-      .addAnalyzer(MaximumDateTime("dateOfBirth"))
+//      .addAnalyzer(MinimumDateTime("dateOfBirth"))
+//      .addAnalyzer(MaximumDateTime("dateOfBirth"))
       .run()
     }
 

--- a/src/main/scala/com/amazon/deequ/examples/ExampleUtils.scala
+++ b/src/main/scala/com/amazon/deequ/examples/ExampleUtils.scala
@@ -25,6 +25,7 @@ private[deequ] object ExampleUtils {
       .master("local")
       .appName("test")
       .config("spark.ui.enabled", "false")
+      .config("spark.sql.datetime.java8API.enabled", "true")
       .getOrCreate()
     session.sparkContext.setCheckpointDir(System.getProperty("java.io.tmpdir"))
 

--- a/src/main/scala/com/amazon/deequ/examples/ExampleUtils.scala
+++ b/src/main/scala/com/amazon/deequ/examples/ExampleUtils.scala
@@ -45,4 +45,9 @@ private[deequ] object ExampleUtils {
     val rdd = session.sparkContext.parallelize(manufacturers)
     session.createDataFrame(rdd)
   }
+
+  def customerAsDataframe(session: SparkSession, customer: Customer*): DataFrame = {
+    val rdd = session.sparkContext.parallelize(customer)
+    session.createDataFrame(rdd)
+  }
 }

--- a/src/main/scala/com/amazon/deequ/examples/entities.scala
+++ b/src/main/scala/com/amazon/deequ/examples/entities.scala
@@ -16,6 +16,8 @@
 
 package com.amazon.deequ.examples
 
+import java.time.Instant
+
 private[deequ] case class Item(
     id: Long,
     productName: String,
@@ -28,4 +30,10 @@ private[deequ] case class Manufacturer(
     id: Long,
     manufacturerName: String,
     countryCode: String
+)
+
+private[deequ] case class Customer(
+  id: Long,
+  name: String,
+  dateOfBirth: Instant
 )

--- a/src/main/scala/com/amazon/deequ/metrics/Metric.scala
+++ b/src/main/scala/com/amazon/deequ/metrics/Metric.scala
@@ -18,6 +18,7 @@ package com.amazon.deequ.metrics
 
 import org.apache.spark.sql.Column
 
+import java.time.Instant
 import scala.util.{Failure, Success, Try}
 
 object Entity extends Enumeration {
@@ -87,5 +88,17 @@ case class KeyedDoubleMetric(
     } else {
       Seq(DoubleMetric(entity, s"$name", instance, Failure(value.failed.get)))
     }
+  }
+}
+
+case class DateTimeMetric(
+  entity: Entity.Value,
+  name: String,
+  instance: String,
+  value: Try[Instant]
+) extends Metric[Instant] {
+  override def flatten(): Seq[DoubleMetric] = value match {
+    case Success(v) => Seq(DoubleMetric(entity, "Timestamp milliseconds", instance, Success(v.toEpochMilli.toDouble)))
+    case Failure(e) => Seq(DoubleMetric(entity, "Timestamp milliseconds", instance, Failure(e)))
   }
 }

--- a/src/test/scala/com/amazon/deequ/SparkContextSpec.scala
+++ b/src/test/scala/com/amazon/deequ/SparkContextSpec.scala
@@ -51,6 +51,20 @@ trait SparkContextSpec {
     }
   }
 
+  /**
+   * @param testFun thunk to run with SparkSession as an argument
+   */
+  def withSparkSessionJava8APIEnabled(testFun: SparkSession => Any): Unit = {
+    val session = setupSparkSession()
+    session.conf.set("spark.sql.datetime.java8API.enabled", "true")
+    try {
+      testFun(session)
+    } finally {
+      /* empty cache of RDD size, as the referred ids are only valid within a session */
+      tearDownSparkSession(session)
+    }
+  }
+
   def withSparkSessionIcebergCatalog(testFun: SparkSession => Any): Unit = {
     val session = setupSparkSession(Some(tmpWareHouseDir.toAbsolutePath.toString))
     session.conf.set("spark.sql.catalog.local", "org.apache.iceberg.spark.SparkCatalog")

--- a/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
+++ b/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
@@ -23,6 +23,7 @@ import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.Row
 import org.apache.spark.sql.SparkSession
 
+import java.time.{Instant, LocalDate}
 import scala.util.Random
 
 
@@ -144,6 +145,18 @@ trait FixtureSupport {
       ("3", "-3", "-3.0"),
       ("4", "-4", "-4.0")
     ).toDF("item", "att1", "att2")
+  }
+
+  def getDfWithLocalDateAndInstant(sparkSession: SparkSession): DataFrame = {
+    import sparkSession.implicits._
+
+    Seq(
+      (1, "john doe", Instant.parse("2021-11-11T07:15:00Z"), LocalDate.of(2017, 10, 14)),
+      (2, "marry jane", Instant.parse("2021-11-11T08:15:00Z"), LocalDate.of(2017, 10, 14)),
+      (3, "Thomas Yu", Instant.parse("2021-11-11T09:15:00Z"), LocalDate.of(2017, 10, 14)),
+      (4, "Steve Powell", Instant.parse("2019-04-11T12:15:00Z"), LocalDate.of(2017, 11, 14)),
+      (5, "Andrej Kar", Instant.parse("2019-04-11T13:15:00Z"), LocalDate.of(2017, 11, 14)),
+    ).toDF("id", "name", "dateOfBirth", "signupDate")
   }
 
   def getDfCompleteAndInCompleteColumns(sparkSession: SparkSession): DataFrame = {


### PR DESCRIPTION
*Description of changes:*
Add DateTimeMetric support. This chunk part of #299 to only DateTimeMetric support:
-  Remove usage of deprecated UDAF from original PR
-  use `java.time.Instant` isntead of `java.sql.timestamp`
- Fix bug + Adding Test 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
