### PR TITLE
Bugfix- isNonNegative and isPositive checks

### DIFF
--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -990,7 +990,7 @@ case class Check(
     satisfies(
       // coalescing column to not count NULL values as non-compliant
       // NOTE: cast to DECIMAL(20, 10) is needed to handle scientific notations
-      s"COALESCE(CAST($column AS DECIMAL(20,10)), 0.0) >= 0",
+      s"COALESCE(CAST('$column' AS DECIMAL(20,10)), 0.0) >= 0",
       s"$column is non-negative",
       assertion,
       hint = hint,
@@ -1014,7 +1014,7 @@ case class Check(
     // coalescing column to not count NULL values as non-compliant
     // NOTE: cast to DECIMAL(20, 10) is needed to handle scientific notations
     satisfies(
-      s"COALESCE(CAST($column AS DECIMAL(20,10)), 1.0) > 0",
+      s"COALESCE(CAST('$column' AS DECIMAL(20,10)), 1.0) > 0",
       s"$column is positive",
       assertion,
       hint,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
existing isNonNegative and isPositive function does not work well with columns that have white space in between, and results in breaking of other constraints as well. I added extra quotes around the column name so columns with white space in the name does not break the final generated query.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
