### PR TITLE
Fix performance of building row-level results

### DIFF
--- a/src/main/scala/com/amazon/deequ/VerificationResult.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationResult.scala
@@ -97,7 +97,8 @@ object VerificationResult {
 
     val columnNamesToMetrics: Map[String, Column] = verificationResultToColumn(verificationResult)
 
-    data.withColumns(columnNamesToMetrics)
+    val dataWithID = data.withColumn(UNIQUENESS_ID, monotonically_increasing_id())
+    dataWithID.withColumns(columnNamesToMetrics).drop(UNIQUENESS_ID)
   }
 
   def checkResultsAsJson(verificationResult: VerificationResult,

--- a/src/main/scala/com/amazon/deequ/VerificationResult.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationResult.scala
@@ -97,10 +97,7 @@ object VerificationResult {
 
     val columnNamesToMetrics: Map[String, Column] = verificationResultToColumn(verificationResult)
 
-    val dataWithID = data.withColumn(UNIQUENESS_ID, monotonically_increasing_id())
-    columnNamesToMetrics.foldLeft(dataWithID)(
-      (dataWithID, newColumn: (String, Column)) =>
-        dataWithID.withColumn(newColumn._1, newColumn._2)).drop(UNIQUENESS_ID)
+    data.withColumns(columnNamesToMetrics)
   }
 
   def checkResultsAsJson(verificationResult: VerificationResult,


### PR DESCRIPTION
Fixes #576

Iteratively calling `withColumn` (singular) on a DataFrame causes performance issues when iterating over a large sequence of columns. (See issue for more details.) The code was iterating to add each `(name, column)` pair in a map to the DataFrame, so we can use [`withColumns`](https://spark.apache.org/docs/latest/api/scala/org/apache/spark/sql/Dataset.html#withColumns(colsMap:Map%5BString,org.apache.spark.sql.Column%5D):org.apache.spark.sql.DataFrame), which takes a `Map[String, Column]` as its parameter, as a drop-in replacement.

After running the performance test in the bug ticket, the performance is much better:
```
Gathering row-level results
51 columns in row level results
Duration was 67ms

Gathering row-level results
101 columns in row level results
Duration was 53ms

Gathering row-level results
151 columns in row level results
Duration was 49ms

Gathering row-level results
201 columns in row level results
Duration was 45ms

Gathering row-level results
251 columns in row level results
Duration was 48ms

Gathering row-level results
301 columns in row level results
Duration was 48ms

Gathering row-level results
351 columns in row level results
Duration was 41ms

Gathering row-level results
401 columns in row level results
Duration was 41ms
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
