### PR TITLE
Backport breeze version upgrade to spark 3.4

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -327,13 +327,6 @@
             </plugin>
         </plugins>
     </build>
-    <repositories>
-        <repository>
-            <id>maven_central</id>
-            <name>Maven Central</name>
-            <url>https://repo.maven.apache.org/maven2/</url>
-        </repository>
-    </repositories>
 
     <profiles>
         <profile>

--- a/pom.xml
+++ b/pom.xml
@@ -103,7 +103,7 @@
         <dependency>
             <groupId>org.scalanlp</groupId>
             <artifactId>breeze_${scala.major.version}</artifactId>
-            <version>0.13.2</version>
+            <version>2.1.0</version>
         </dependency>
 
         <dependency>
@@ -327,6 +327,13 @@
             </plugin>
         </plugins>
     </build>
+    <repositories>
+        <repository>
+            <id>maven_central</id>
+            <name>Maven Central</name>
+            <url>https://repo.maven.apache.org/maven2/</url>
+        </repository>
+    </repositories>
 
     <profiles>
         <profile>


### PR DESCRIPTION
In #545, we were expecting to see breeze 2.1.0 release with spark 3.4+ but Deequ 2.0.7-spark3.4 doesn't seem to include this changes even though the release note mentioned it https://github.com/awslabs/deequ/releases/tag/2.0.7.
Can we backport this change and release it for Deequ 2.0.7-spark3.4 or maybe Deequ 2.0.8?

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
