### PR TITLE
Fix row-level results implementation for Spark versions <3.3

### DIFF
--- a/src/main/scala/com/amazon/deequ/VerificationResult.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationResult.scala
@@ -31,7 +31,7 @@ import com.amazon.deequ.repository.SimpleResultSerde
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.functions.monotonically_increasing_id
+import org.apache.spark.sql.functions.{col, monotonically_increasing_id}
 
 import java.util.UUID
 
@@ -96,9 +96,10 @@ object VerificationResult {
       data: DataFrame): DataFrame = {
 
     val columnNamesToMetrics: Map[String, Column] = verificationResultToColumn(verificationResult)
+    val columnsAliased = columnNamesToMetrics.toSeq.map { case (name, col) => col.as(name) }
 
     val dataWithID = data.withColumn(UNIQUENESS_ID, monotonically_increasing_id())
-    dataWithID.withColumns(columnNamesToMetrics).drop(UNIQUENESS_ID)
+    dataWithID.select(col("*") +: columnsAliased: _*).drop(UNIQUENESS_ID)
   }
 
   def checkResultsAsJson(verificationResult: VerificationResult,


### PR DESCRIPTION
Fixes a bug introduced in #577.

[`withColumns`](https://spark.apache.org/docs/latest/api/scala/org/apache/spark/sql/Dataset.html#withColumns(colsMap:Map[String,org.apache.spark.sql.Column]):org.apache.spark.sql.DataFrame) was introduced in Spark 3.3, so it won't work for Deequ's <3.3 builds. This switches the implementation to instead use `select`, which is what's recommended in the note in [`withColumn`](https://spark.apache.org/docs/latest/api/scala/org/apache/spark/sql/Dataset.html#withColumn(colName:String,col:org.apache.spark.sql.Column):org.apache.spark.sql.DataFrame), and which is available for all versions of Spark that Deequ builds for.

I ran the same performance test and verified performance is still good:
```
Gathering row-level results
51 columns in row level results
Duration was 59ms

Gathering row-level results
101 columns in row level results
Duration was 52ms

Gathering row-level results
151 columns in row level results
Duration was 46ms

Gathering row-level results
201 columns in row level results
Duration was 40ms

Gathering row-level results
251 columns in row level results
Duration was 54ms

Gathering row-level results
301 columns in row level results
Duration was 37ms

Gathering row-level results
351 columns in row level results
Duration was 43ms

Gathering row-level results
401 columns in row level results
Duration was 41ms
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
