### PR TITLE
Fix row level bug when composing outcome

### DIFF
--- a/src/main/scala/com/amazon/deequ/VerificationResult.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationResult.scala
@@ -147,7 +147,7 @@ object VerificationResult {
       case asserted: RowLevelAssertedConstraint =>
         constraintResult.metric.flatMap(metricToColumn).map(asserted.assertion(_)).orElse(Some(lit(false)))
       case _: RowLevelConstraint =>
-        constraintResult.metric.flatMap(metricToColumn)
+        constraintResult.metric.flatMap(metricToColumn).orElse(Some(lit(false)))
       case _: RowLevelGroupedConstraint =>
         constraintResult.metric.flatMap(metricToColumn)
       case _ => None

--- a/src/main/scala/com/amazon/deequ/VerificationResult.scala
+++ b/src/main/scala/com/amazon/deequ/VerificationResult.scala
@@ -31,6 +31,7 @@ import com.amazon.deequ.repository.SimpleResultSerde
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.functions.lit
 import org.apache.spark.sql.functions.{col, monotonically_increasing_id}
 
 import java.util.UUID
@@ -144,7 +145,7 @@ object VerificationResult {
     val constraint = constraintResult.constraint
     constraint match {
       case asserted: RowLevelAssertedConstraint =>
-        constraintResult.metric.flatMap(metricToColumn).map(asserted.assertion(_))
+        constraintResult.metric.flatMap(metricToColumn).map(asserted.assertion(_)).orElse(Some(lit(false)))
       case _: RowLevelConstraint =>
         constraintResult.metric.flatMap(metricToColumn)
       case _: RowLevelGroupedConstraint =>
@@ -159,7 +160,6 @@ object VerificationResult {
       case _ => None
     }
   }
-
 
   private[this] def getSimplifiedCheckResultOutput(
       verificationResult: VerificationResult)


### PR DESCRIPTION
*Description of changes:*

- When a check fails due to a precondition failure, the row level results are not evaluated correctly.
- For example, let's say a check has a completeness constraint which passes, and a minimum constraint which fails due to a precondition failure.
- The row level results will be the results for just the completeness constraint. There will be no results generated for the minimum constraint, and therefore the row level results will be incorrect.
- We fix this by adding a default outcome for when the row level result column is not provided by the analyzer.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
