### PR TITLE
Add AnalyzerOptions to Analyzer serialize / deserialize logic

### DIFF
--- a/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
+++ b/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
@@ -441,7 +441,10 @@ private[deequ] object AnalyzerDeserializer
         Size(getOptionalWhereParam(json))
 
       case "Completeness" =>
-        Completeness(json.get(COLUMN_FIELD).getAsString, getOptionalWhereParam(json))
+        Completeness(
+          json.get(COLUMN_FIELD).getAsString,
+          getOptionalWhereParam(json),
+          getOptionalAnalyzerOptions(json))
 
       case "Compliance" =>
         Compliance(
@@ -449,13 +452,14 @@ private[deequ] object AnalyzerDeserializer
           json.get("predicate").getAsString,
           getOptionalWhereParam(json),
           getColumnsAsSeq(context, json).toList,
-          getOptionalAnalyzerOptions(json, context))
+          getOptionalAnalyzerOptions(json))
 
       case "PatternMatch" =>
         PatternMatch(
           json.get(COLUMN_FIELD).getAsString,
           json.get("pattern").getAsString.r,
-          getOptionalWhereParam(json))
+          getOptionalWhereParam(json),
+          getOptionalAnalyzerOptions(json))
 
       case "Sum" =>
         Sum(
@@ -476,12 +480,14 @@ private[deequ] object AnalyzerDeserializer
       case "Minimum" =>
         Minimum(
           json.get(COLUMN_FIELD).getAsString,
-          getOptionalWhereParam(json))
+          getOptionalWhereParam(json),
+          getOptionalAnalyzerOptions(json))
 
       case "Maximum" =>
         Maximum(
           json.get(COLUMN_FIELD).getAsString,
-          getOptionalWhereParam(json))
+          getOptionalWhereParam(json),
+          getOptionalAnalyzerOptions(json))
 
       case "CountDistinct" =>
         CountDistinct(getColumnsAsSeq(context, json))
@@ -496,10 +502,14 @@ private[deequ] object AnalyzerDeserializer
         MutualInformation(getColumnsAsSeq(context, json))
 
       case "UniqueValueRatio" =>
-        UniqueValueRatio(getColumnsAsSeq(context, json))
+        UniqueValueRatio(
+          getColumnsAsSeq(context, json),
+          analyzerOptions = getOptionalAnalyzerOptions(json))
 
       case "Uniqueness" =>
-        Uniqueness(getColumnsAsSeq(context, json))
+        Uniqueness(
+          getColumnsAsSeq(context, json),
+          analyzerOptions = getOptionalAnalyzerOptions(json))
 
       case "Histogram" =>
         Histogram(
@@ -551,12 +561,14 @@ private[deequ] object AnalyzerDeserializer
       case "MinLength" =>
         MinLength(
           json.get(COLUMN_FIELD).getAsString,
-          getOptionalWhereParam(json))
+          getOptionalWhereParam(json),
+          getOptionalAnalyzerOptions(json))
 
       case "MaxLength" =>
         MaxLength(
           json.get(COLUMN_FIELD).getAsString,
-          getOptionalWhereParam(json))
+          getOptionalWhereParam(json),
+          getOptionalAnalyzerOptions(json))
 
       case analyzerName =>
         throw new IllegalArgumentException(s"Unable to deserialize analyzer $analyzerName.")
@@ -577,8 +589,7 @@ private[deequ] object AnalyzerDeserializer
     }
   }
 
-  private[this] def getOptionalAnalyzerOptions(jsonObject: JsonObject,
-    context: JsonDeserializationContext): Option[AnalyzerOptions] = {
+  private[this] def getOptionalAnalyzerOptions(jsonObject: JsonObject): Option[AnalyzerOptions] = {
 
     if (jsonObject.has("analyzerOptions")) {
       val options = jsonObject.get("analyzerOptions").getAsJsonObject

--- a/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
@@ -35,7 +35,9 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
 
     val analyzerContextWithAllSuccValues = new AnalyzerContext(Map(
       Size() -> DoubleMetric(Entity.Column, "Size", "*", Success(5.0)),
-      Completeness("ColumnA") ->
+      Completeness("ColumnA", analyzerOptions = Some(AnalyzerOptions(
+        nullBehavior = NullBehavior.Ignore
+      ))) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
       Compliance("rule1", "att1 > 3", columns = List("att1"),
         analyzerOptions = Some(AnalyzerOptions(

--- a/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
@@ -37,7 +37,11 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
       Size() -> DoubleMetric(Entity.Column, "Size", "*", Success(5.0)),
       Completeness("ColumnA") ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
-      Compliance("rule1", "att1 > 3", columns = List("att1")) ->
+      Compliance("rule1", "att1 > 3", columns = List("att1"),
+        analyzerOptions = Some(AnalyzerOptions(
+          nullBehavior = NullBehavior.Ignore
+        ))
+      ) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
       ApproxCountDistinct("columnA", Some("test")) ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),


### PR DESCRIPTION
*Issue #, if available:* #596 

*Description of changes:*
This PR addresses a discrepancy when using a `FileSystemMetricsRepository` with an `Analyzer` that has `analyzerOptions` set.

Given an analyzer which has `analyzerOptions` configured:
```
Compliance("rule1", "att1 > 3", columns = List("att1"),
  analyzerOptions = Some(AnalyzerOptions(
    nullBehavior = NullBehavior.Ignore,
    filteredRow = FilteredRowOutcome.NULL
  ))
)
```
Because the `FileSystemMetricsRepository.get()` function [compares the entire analyzer object](https://github.com/awslabs/deequ/blob/310699b434d413f8f07ccf54d6eff9bc4de35e58/src/main/scala/com/amazon/deequ/repository/fs/FileSystemMetricsRepository.scala#L154), it fails to match the current analyzer (with `analyzerOptions`) to any historical metric analyzer.

This issue occurs due to the following:
- When the results are persisted to a `FileSystemMetricsRepository`, the `AnalysisResultSerde.serialize` function [does not add](https://github.com/awslabs/deequ/blob/0476ed582512a10ed2d35d0f8a254fa56e82cd4e/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala#L248) `analyzerOptions` to the result object.

- Similarly, when `AnalysisResultSerde.deserialize` pulls historic metrics from a file, it [does not parse](https://github.com/awslabs/deequ/blob/0476ed582512a10ed2d35d0f8a254fa56e82cd4e/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala#L438) `analyzerOptions` even if they were present.

This issue means that no matter how many historical metrics are in the metrics repository file, none would be matched to the current analyzer, which would result in the check failing due to insufficient historical metrics. The current workaround would be to avoid using `analyzerOptions` if using `FileSystemMetricsRepository`, or switch to using `InMemoryMetricsRepository`

The fix I propose in this PR is to add the optional `AnalyzerOptions` object to the serializer and deserializer functions so that they may be persisted and fetched properly. This will enable the `FileSystemMetricsRepository.get()` function to successfully compare two analyzer objects and find an exact match.

Note that there is no issue using an `InMemoryMetricsRepository` as there is no serialization/deserialization happening in that case.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
