### PR TITLE
Are unique check

### DIFF
--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -242,7 +242,7 @@ case class Check(
   }
 
   /**
-    * Creates a constraint that asserts on a combined set of columns.
+    * Creates a constraint that asserts on Uniqueness in a combined set of columns.
     *
     * @param columns Columns to run the assertion on
     * @param hint A hint to provide additional context why a constraint could have failed

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -242,6 +242,20 @@ case class Check(
   }
 
   /**
+    * Creates a constraint that asserts on a column uniqueness.
+    *
+    * @param columns Columns to run the assertion on
+    * @param hint A hint to provide additional context why a constraint could have failed
+    * @param analyzerOptions Options to configure analyzer behavior (NullTreatment, FilteredRow)
+    * @return
+    */
+  def areUnique(columns: Seq[String], hint: Option[String] = None,
+               analyzerOptions: Option[AnalyzerOptions] = None): CheckWithLastConstraintFilterable = {
+    addFilterableConstraint { filter =>
+      uniquenessConstraint(columns, Check.IsOne, filter, hint, analyzerOptions) }
+  }
+
+  /**
     * Creates a constraint that asserts on a column(s) primary key characteristics.
     * Currently only checks uniqueness, but reserved for primary key checks if there is another
     * assertion to run on primary key columns.

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -242,7 +242,7 @@ case class Check(
   }
 
   /**
-    * Creates a constraint that asserts on a column uniqueness.
+    * Creates a constraint that asserts on a combined set of columns.
     *
     * @param columns Columns to run the assertion on
     * @param hint A hint to provide additional context why a constraint could have failed

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -176,6 +176,8 @@ class CheckTest extends AnyWordSpec with Matchers with SparkContextSpec with Fix
         .isUnique("halfUniqueCombinedWithNonUnique").where("nonUnique > 0")
         .isUnique("nonUnique")
         .isUnique("nonUniqueWithNulls")
+        .areUnique(Seq("nonUnique", "onlyUniqueWithOtherNonUnique"))
+        .areUnique(Seq("nonUnique", "halfUniqueCombinedWithNonUnique"))
 
       val context = runChecks(getDfWithUniqueColumns(sparkSession), check)
       val result = check.evaluate(context)
@@ -187,6 +189,8 @@ class CheckTest extends AnyWordSpec with Matchers with SparkContextSpec with Fix
       assert(constraintStatuses(2) == ConstraintStatus.Success)
       assert(constraintStatuses(3) == ConstraintStatus.Failure)
       assert(constraintStatuses(4) == ConstraintStatus.Failure)
+      assert(constraintStatuses(5) == ConstraintStatus.Success)
+      assert(constraintStatuses(6) == ConstraintStatus.Failure)
     }
 
     "return the correct check status for primary key" in withSparkSession { sparkSession =>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Add `areUnique` check, similar to the [`areComplete`](https://github.com/awslabs/deequ/blob/82537bd832c731e0730025f781bee2e9682f3637/src/main/scala/com/amazon/deequ/checks/Check.scala#L177-L182) check to check for the uniqueness of multiple columns
- Added unit tests in the CheckTests and VerificationSuiteTests

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
