### PR TITLE
add DQDL parser dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,6 +107,12 @@
         </dependency>
 
         <dependency>
+            <groupId>software.amazon.glue</groupId>
+            <artifactId>dqdl</artifactId>
+            <version>1.0.0</version>
+        </dependency>
+
+        <dependency>
             <groupId>org.scalatest</groupId>
             <artifactId>scalatest_${scala.major.version}</artifactId>
             <version>3.1.2</version>

--- a/src/test/scala/com/amazon/deequ/dqdl/ParserTest.scala
+++ b/src/test/scala/com/amazon/deequ/dqdl/ParserTest.scala
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.dqdl
+
+import org.scalatest.{Matchers, WordSpec}
+import software.amazon.glue.dqdl.parser.DQDLParser
+
+import scala.jdk.CollectionConverters.collectionAsScalaIterableConverter
+
+
+class ParserTest extends WordSpec with Matchers {
+
+  val parser = new DQDLParser()
+
+  "DQDL Parser" should {
+    "parse DQDL rules" in {
+
+      val ruleset = "Rules = [ RowCount > 1, ColumnCount = 3]"
+      val dqRuleset = parser.parse(ruleset)
+      val rules = dqRuleset.getRules.asScala
+
+      // Test number of rules
+      rules.size shouldBe 2
+
+      // Test individual rules
+      val rowCountRule = rules.find(_.getRuleType == "RowCount")
+      rowCountRule.isDefined shouldBe true
+      rowCountRule.map(_.toString) shouldBe Some("RowCount > 1")
+
+      val columnCountRule = rules.find(_.getRuleType == "ColumnCount")
+      columnCountRule.isDefined shouldBe true
+      columnCountRule.map(_.toString) shouldBe Some("ColumnCount = 3")
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

Add dependency to Glue Data Quality Definition Language Parser. (DQDL Parser)
This change enables the use of DQ rulesets.

More info about the parser https://github.com/awslabs/dqdl
DQDL Reference: https://docs.aws.amazon.com/glue/latest/dg/dqdl.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
