### PR TITLE
Refine row count retrieval to skip redundant Size() scans

### DIFF
--- a/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
@@ -337,7 +337,7 @@ class AnalysisRunnerTests extends AnyWordSpec
       val analyzers = Size() :: Completeness("item") :: Nil
 
       val expectedAnalyzerContextOnLoadByKey = AnalysisRunner.onData(df).useRepository(repository)
-          .addAnalyzers(analyzers).run()
+        .addAnalyzers(analyzers).run()
 
       val resultWhichShouldBeOverwritten = AnalyzerContext(Map(Size() -> DoubleMetric(
         Entity.Dataset, "", "", Try(100.0))))
@@ -395,6 +395,17 @@ class AnalysisRunnerTests extends AnyWordSpec
           .useSparkSession(sparkSession)
           .run()
       }
+    }
+
+    "not add Size(None) if grouping analyzers are frequency-based only" in withSparkSession { sparkSession =>
+      val data = getDfWithNumericValues(sparkSession)
+
+      val freqGroupingAnalyzer = Distinctness(Seq("att1"))
+      val analysis = Analysis().addAnalyzer(freqGroupingAnalyzer)
+
+      val computed = AnalysisRunner.run(data, analysis)
+
+      assert(!computed.metricMap.keys.exists(_.isInstanceOf[Size]))
     }
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
#600 
*Description of changes:*

This PR optimizes the use of Size() metrics in AnalysisRunner to avoid redundant 
Spark scans when obtaining the row count for grouping analyzers. 

Specifically:

- Adds a conditional check to include Size(None) only when:
  1) Grouping analyzers require a global row count (i.e., not a FrequencyBasedAnalyzer).
  2) We haven't already included Size(None) implicitly.
  3) There's at least one analyzer whose state isn't already loaded (so an actual scan is needed).

- Introduces a helper method `actuallyNeedsScanning` to detect whether all 
  required analyzer states are already available from `aggregateWith`. If so, we can skip a new scan entirely.

- Extracts the row count from the Size() metric only if it was actually included in the scanning analyzers, preventing unnecessary computations.

This change addresses the [TODO comment in the AnalysisRunner.doAnalysisRun method](https://github.com/awslabs/deequ/blob/master/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala#L171C1-L175C6) regarding row count retrieval efficiency and reduces unnecessary Spark actions, thereby improving performance.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
