### PR TITLE
Add implementation of outcome mapping in DeequOutcomeTranslator

### DIFF
--- a/src/main/scala/com/amazon/deequ/dqdl/EvaluateDataQuality.scala
+++ b/src/main/scala/com/amazon/deequ/dqdl/EvaluateDataQuality.scala
@@ -51,11 +51,10 @@ object EvaluateDataQuality {
     val executableRules: Seq[ExecutableRule] = DQDLRuleTranslator.toExecutableRules(ruleset)
 
     // 3. Execute the rules against the DataFrame.
-    val result = DQDLExecutor.executeRules(executableRules, df)
+    val executedRulesResult = DQDLExecutor.executeRules(executableRules, df)
 
     // 4. Translate the results into a Spark DataFrame.
-    val outcomeTranslator = new DeequOutcomeTranslator(df.sparkSession)
-    outcomeTranslator.translate(result)
+    DeequOutcomeTranslator.translate(executedRulesResult, df)
   }
 
 }

--- a/src/test/scala/com/amazon/deequ/dqdl/EvaluateDataQualitySpec.scala
+++ b/src/test/scala/com/amazon/deequ/dqdl/EvaluateDataQualitySpec.scala
@@ -1,0 +1,54 @@
+/**
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.dqdl
+
+import com.amazon.deequ.SparkContextSpec
+import com.amazon.deequ.utils.FixtureSupport
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class EvaluateDataQualitySpec extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport {
+
+"EvaluateDataQuality process" should {
+
+    "run successfully on a ruleset" in withSparkSession { sparkSession =>
+      // given
+      val df = getDfFull(sparkSession)
+      val ruleset = "Rules=[RowCount < 10]"
+
+      // when
+      val results = EvaluateDataQuality.process(df, ruleset)
+
+      // then
+      results.schema.fields.map(_.name) should contain allOf(
+        "Rule",
+        "Outcome",
+        "FailureReason",
+        "EvaluatedMetrics",
+        "EvaluatedRule"
+      )
+
+      val row = results.collect()(0)
+
+      row.getAs[String]("Rule") should be("RowCount < 10")
+      row.getAs[String]("Outcome") should be("Passed")
+      row.getAs[String]("FailureReason") should be(null)
+      row.getAs[Map[String, Double]]("EvaluatedMetrics") should contain("Dataset.*.RowCount" -> 4.0)
+
+    }
+  }
+}


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

implemented DeequOutcomeTranslator to a singleton object and implemented the translate method so that the DQ executed results are mapped to spark DataFrame like this: 
+-------------+-------+-------------+---------------------------+-------------+
|Rule         |Outcome|FailureReason|EvaluatedMetrics                       |EvaluatedRule|
+-------------+-------+-------------+---------------------------+-------------+
|RowCount < 10|Passed |NULL         |{Dataset.*.RowCount -> 5.0}.  |NULL              |
+-------------+-------+-------------+---------------------------+-------------+

Please note that the "EvaluatedRule" field is currently not populated (returns NULL) and will be implemented in future PRs. This field is included now to maintain compatibility with the output format used in AWS Glue DataQuality.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
