### PR TITLE
Add support for DQDL CustomSql rule & Deequ CustomSql check

### DIFF
--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -17,14 +17,7 @@
 package com.amazon.deequ.checks
 
 import com.amazon.deequ.analyzers.runners.AnalyzerContext
-import com.amazon.deequ.analyzers.Analyzer
-import com.amazon.deequ.analyzers.AnalyzerOptions
-import com.amazon.deequ.analyzers.DatasetMatchAnalyzer
-import com.amazon.deequ.analyzers.DatasetMatchState
-import com.amazon.deequ.analyzers.Histogram
-import com.amazon.deequ.analyzers.KLLParameters
-import com.amazon.deequ.analyzers.Patterns
-import com.amazon.deequ.analyzers.State
+import com.amazon.deequ.analyzers.{Analyzer, AnalyzerOptions, CustomSql, CustomSqlState, DatasetMatchAnalyzer, DatasetMatchState, Histogram, KLLParameters, Patterns, State}
 import com.amazon.deequ.anomalydetection.HistoryUtils
 import com.amazon.deequ.anomalydetection.AnomalyDetectionStrategy
 import com.amazon.deequ.anomalydetection.AnomalyDetector
@@ -254,6 +247,16 @@ case class Check(
     addFilterableConstraint { filter =>
       uniquenessConstraint(columns, Check.IsOne, filter, hint, analyzerOptions) }
   }
+
+  def customSql(expression: String, assertion: Double => Boolean,
+                hint: Option[String] = None, analyzerOptions: Option[AnalyzerOptions] = None)
+  : Check = {
+    val customSqlAnalyzer = CustomSql(expression)
+    val constraint = AnalysisBasedConstraint[CustomSqlState, Double, Double](customSqlAnalyzer, assertion,
+      hint = hint)
+    addConstraint(constraint)
+  }
+
 
   /**
     * Creates a constraint that asserts on a column(s) primary key characteristics.

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -248,6 +248,7 @@ object Constraint {
     new NamedConstraint(constraint, s"AnomalyConstraint($analyzer)")
   }
 
+
   /**
     * Runs Uniqueness analysis on the given columns and executes the assertion
     *

--- a/src/main/scala/com/amazon/deequ/dqdl/translation/DQDLRuleTranslator.scala
+++ b/src/main/scala/com/amazon/deequ/dqdl/translation/DQDLRuleTranslator.scala
@@ -17,7 +17,7 @@
 package com.amazon.deequ.dqdl.translation
 
 import com.amazon.deequ.dqdl.model.{DeequExecutableRule, ExecutableRule, UnsupportedExecutableRule}
-import com.amazon.deequ.dqdl.translation.rules.{ColumnCorrelationRule, CompletenessRule, DistinctValuesCountRule, EntropyRule, IsCompleteRule, IsUniqueRule, MeanRule, RowCountRule, StandardDeviationRule, SumRule, UniqueValueRatioRule, UniquenessRule}
+import com.amazon.deequ.dqdl.translation.rules.{ColumnCorrelationRule, CompletenessRule, CustomSqlRule, DistinctValuesCountRule, EntropyRule, IsCompleteRule, IsUniqueRule, MeanRule, RowCountRule, StandardDeviationRule, SumRule, UniqueValueRatioRule, UniquenessRule}
 import software.amazon.glue.dqdl.model.{DQRule, DQRuleset}
 
 import scala.jdk.CollectionConverters.collectionAsScalaIterableConverter
@@ -42,7 +42,8 @@ object DQDLRuleTranslator {
     "Mean" -> new MeanRule,
     "StandardDeviation" -> new StandardDeviationRule,
     "Sum" -> new SumRule,
-    "UniqueValueRatio" -> new UniqueValueRatioRule
+    "UniqueValueRatio" -> new UniqueValueRatioRule,
+    "CustomSql" -> new CustomSqlRule
   )
 
   /**

--- a/src/main/scala/com/amazon/deequ/dqdl/translation/rules/CustomSqlRule.scala
+++ b/src/main/scala/com/amazon/deequ/dqdl/translation/rules/CustomSqlRule.scala
@@ -1,0 +1,35 @@
+/**
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.dqdl.translation.rules
+
+import com.amazon.deequ.checks.{Check, CheckLevel}
+import com.amazon.deequ.dqdl.model.DeequMetricMapping
+import com.amazon.deequ.dqdl.translation.DQDLRuleConverter
+import com.amazon.deequ.dqdl.util.DQDLUtility.addWhereClause
+import software.amazon.glue.dqdl.model.DQRule
+import software.amazon.glue.dqdl.model.condition.number.NumberBasedCondition
+
+import scala.collection.JavaConverters._
+
+case class CustomSqlRule() extends DQDLRuleConverter {
+  override def convert(rule: DQRule): Either[String, (Check, Seq[DeequMetricMapping])] = {
+    val fn = assertionAsScala(rule, rule.getCondition.asInstanceOf[NumberBasedCondition])
+    val statement = rule.getParameters.asScala("CustomSqlStatement")
+    val check = Check(CheckLevel.Error, java.util.UUID.randomUUID.toString).customSql(statement, rc => fn(rc.toDouble))
+    Right(check, Seq(DeequMetricMapping("Dataset", "*", "CustomSQL", "CustomSQL", None, rule = rule)))
+  }
+}

--- a/src/main/scala/com/amazon/deequ/dqdl/translation/rules/CustomSqlRule.scala
+++ b/src/main/scala/com/amazon/deequ/dqdl/translation/rules/CustomSqlRule.scala
@@ -19,7 +19,6 @@ package com.amazon.deequ.dqdl.translation.rules
 import com.amazon.deequ.checks.{Check, CheckLevel}
 import com.amazon.deequ.dqdl.model.DeequMetricMapping
 import com.amazon.deequ.dqdl.translation.DQDLRuleConverter
-import com.amazon.deequ.dqdl.util.DQDLUtility.addWhereClause
 import software.amazon.glue.dqdl.model.DQRule
 import software.amazon.glue.dqdl.model.condition.number.NumberBasedCondition
 

--- a/src/test/scala/com/amazon/deequ/checks/CustomSqlCheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CustomSqlCheckTest.scala
@@ -38,7 +38,7 @@ class CustomSqlCheckTest extends AnyWordSpec with Matchers with SparkContextSpec
         .run()
 
       result.status shouldBe CheckStatus.Success
-      
+
       val metricsDF = AnalyzerContext.successMetricsAsDataFrame(session, AnalyzerContext(result.metrics))
       val customSqlMetrics = metricsDF.filter(metricsDF("name") === "CustomSQL").collect()
       customSqlMetrics should have length 1

--- a/src/test/scala/com/amazon/deequ/checks/CustomSqlCheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CustomSqlCheckTest.scala
@@ -1,0 +1,81 @@
+/**
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.checks
+
+import com.amazon.deequ.analyzers.runners.AnalyzerContext
+import com.amazon.deequ.{SparkContextSpec, VerificationSuite}
+import com.amazon.deequ.utils.FixtureSupport
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+class CustomSqlCheckTest extends AnyWordSpec with Matchers with SparkContextSpec with FixtureSupport {
+
+  "CustomSQL check" should {
+    "succeed when assertion passes" in withSparkSession { session =>
+      val df = getDfCompleteAndInCompleteColumns(session)
+      df.createOrReplaceTempView("primary")
+
+      val check = Check(CheckLevel.Error, "custom-sql-test")
+        .customSql("SELECT COUNT(*) FROM primary", _ == 6.0)
+
+      val result = VerificationSuite()
+        .onData(df)
+        .addCheck(check)
+        .run()
+
+      result.status shouldBe CheckStatus.Success
+      
+      val metricsDF = AnalyzerContext.successMetricsAsDataFrame(session, AnalyzerContext(result.metrics))
+      val customSqlMetrics = metricsDF.filter(metricsDF("name") === "CustomSQL").collect()
+      customSqlMetrics should have length 1
+      customSqlMetrics(0).getAs[Double]("value") shouldBe 6.0
+      customSqlMetrics(0).getAs[String]("entity") shouldBe "Dataset"
+      customSqlMetrics(0).getAs[String]("instance") shouldBe "*"
+    }
+
+    "fail when assertion fails" in withSparkSession { session =>
+      val df = getDfCompleteAndInCompleteColumns(session)
+      df.createOrReplaceTempView("primary")
+
+      val check = Check(CheckLevel.Error, "custom-sql-test")
+        .customSql("SELECT COUNT(*) FROM primary", _ > 10.0)
+
+      val result = VerificationSuite()
+        .onData(df)
+        .addCheck(check)
+        .run()
+
+      result.status shouldBe CheckStatus.Error
+
+    }
+
+    "work with complex SQL queries" in withSparkSession { session =>
+      val df = getDfCompleteAndInCompleteColumns(session)
+      df.createOrReplaceTempView("primary")
+
+      val check = Check(CheckLevel.Error, "custom-sql-test")
+        .customSql("SELECT COUNT(*) FROM primary WHERE att2 IS NOT NULL", _ == 4.0)
+
+      val result = VerificationSuite()
+        .onData(df)
+        .addCheck(check)
+        .run()
+
+      result.status shouldBe CheckStatus.Success
+    }
+  }
+}

--- a/src/test/scala/com/amazon/deequ/dqdl/EvaluateDataQualitySpec.scala
+++ b/src/test/scala/com/amazon/deequ/dqdl/EvaluateDataQualitySpec.scala
@@ -237,8 +237,8 @@ class EvaluateDataQualitySpec extends AnyWordSpec with Matchers with SparkContex
     "work with not yet supported rule" in withSparkSession { sparkSession =>
       // given
       val df = getDfFull(sparkSession)
-      // CustomSql is not yet supported
-      val ruleset = "Rules=[CustomSql \"select count(*) from primary\" between 10 and 20]"
+      // Rule is not yet supported
+      val ruleset = "Rules=[ColumnLength \"Foo\" = 5]"
 
       // when
       val resultDf = EvaluateDataQuality.process(df, ruleset)
@@ -246,7 +246,7 @@ class EvaluateDataQualitySpec extends AnyWordSpec with Matchers with SparkContex
       // then
       resultDf.collect()(0).getAs[String]("Outcome") should be("Failed")
       resultDf.collect()(0).getAs[String]("FailureReason") should be("Rule (or nested rule) not supported due to: " +
-        "No converter found for rule type: CustomSql")
+        "No converter found for rule type: ColumnLength")
     }
 
     "support CustomSql rule when Passed" in withSparkSession { sparkSession =>

--- a/src/test/scala/com/amazon/deequ/dqdl/translation/DQDLRuleTranslatorSpec.scala
+++ b/src/test/scala/com/amazon/deequ/dqdl/translation/DQDLRuleTranslatorSpec.scala
@@ -60,10 +60,13 @@ class DQDLRuleTranslatorSpec extends AnyWordSpec with Matchers {
     rule.dqRule.getRuleType should equal("RowCount")
   }
 
+  /*
+  this test should be removed once all rules are supported. till then just put the next unimplemented rule here.
+   */
   "get unknown executable rule" in {
     // given
     val ruleset: DQRuleset = DefaultDQDLParser
-      .parse("Rules=[CustomSql \"select count(*) from primary\" between 10 and 20]")
+      .parse("Rules=[ColumnLength \"Foo\" = 5]")
 
     // when
     val rules = DQDLRuleTranslator.toExecutableRules(ruleset)


### PR DESCRIPTION
### Summary
Introduce a CustomSql validation capability to Deequ via:
- A new **Deequ CustomSql check** leveraging the CustomSql analyzer
- A new DQDL rule: **CustomSql** which utilizes the **Deequ CustomSql check** from above.

### Details
- Implements the CustomSql check to allow arbitrary SQL-based data quality checks.
- Adds a test suite covering the new CustomSql check functionality.
- Integrates the CustomSql rule into the DQDL engine, enabling DQDL Custom SQL-based rule definitions.

### Why This Matters
CustomSql rule support expands Deequ’s flexibility - users can now define custom validation logic with SQL, making ad-hoc or complex checks far easier to express.

---

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
