### PR TITLE
Modify maven publishing to use central portal

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -415,14 +415,12 @@
                         </executions>
                     </plugin>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.3</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.8.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://aws.oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Following instructions from this announcement to publish to the central portal: https://central.sonatype.org/news/20250326_ossrh_sunset/#support-for-gradle-and-other-publishers

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
