### PR TITLE
Add support for DQDL IsPrimaryKey rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,23 @@ Our library contains much more functionality than what we showed in the basic ex
 
 Deequ also supports [DQDL](https://docs.aws.amazon.com/glue/latest/dg/dqdl.html), a declarative language for defining data quality rules. DQDL allows you to express data quality constraints in a simple, readable format.
 
+### Supported DQDL Rules
+
+- **RowCount**: `RowCount < 100`
+- **Completeness**: `Completeness "column" > 0.9`
+- **IsComplete**: `IsComplete "column"`
+- **Uniqueness**: `Uniqueness "column" = 1.0`
+- **IsUnique**: `IsUnique "column"`
+- **ColumnCorrelation**: `ColumnCorrelation "col1" "col2" > 0.8`
+- **DistinctValuesCount**: `DistinctValuesCount "column" = 5`
+- **Entropy**: `Entropy "column" > 2.0`
+- **Mean**: `Mean "column" between 10 and 50`
+- **StandardDeviation**: `StandardDeviation "column" < 5.0`
+- **Sum**: `Sum "column" = 100`
+- **UniqueValueRatio**: `UniqueValueRatio "column" > 0.7`
+- **CustomSql**: `CustomSql "SELECT COUNT(*) FROM primary" > 0`
+- **IsPrimaryKey**: `IsPrimaryKey "att1"`
+
 ### Scala Example
 
 ScalaDQDLExample.scala
@@ -201,23 +218,6 @@ String ruleset = "Rules=[IsUnique \"item\", RowCount < 10, Completeness \"item\"
 Dataset<Row> results = EvaluateDataQuality.process(df, ruleset);
 results.show();
 ```
-
-### Supported DQDL Rules
-
-- **RowCount**: `RowCount < 100`
-- **Completeness**: `Completeness "column" > 0.9`
-- **IsComplete**: `IsComplete "column"`
-- **Uniqueness**: `Uniqueness "column" = 1.0`
-- **IsUnique**: `IsUnique "column"`
-- **ColumnCorrelation**: `ColumnCorrelation "col1" "col2" > 0.8`
-- **DistinctValuesCount**: `DistinctValuesCount "column" = 5`
-- **Entropy**: `Entropy "column" > 2.0`
-- **Mean**: `Mean "column" between 10 and 50`
-- **StandardDeviation**: `StandardDeviation "column" < 5.0`
-- **Sum**: `Sum "column" = 100`
-- **UniqueValueRatio**: `UniqueValueRatio "column" > 0.7`
-- **CustomSql**: `CustomSql "SELECT COUNT(*) FROM primary" > 0`
-
 
 ## Citation
 

--- a/src/main/scala/com/amazon/deequ/dqdl/translation/DQDLRuleTranslator.scala
+++ b/src/main/scala/com/amazon/deequ/dqdl/translation/DQDLRuleTranslator.scala
@@ -17,7 +17,20 @@
 package com.amazon.deequ.dqdl.translation
 
 import com.amazon.deequ.dqdl.model.{DeequExecutableRule, ExecutableRule, UnsupportedExecutableRule}
-import com.amazon.deequ.dqdl.translation.rules.{ColumnCorrelationRule, CompletenessRule, CustomSqlRule, DistinctValuesCountRule, EntropyRule, IsCompleteRule, IsUniqueRule, MeanRule, RowCountRule, StandardDeviationRule, SumRule, UniqueValueRatioRule, UniquenessRule}
+import com.amazon.deequ.dqdl.translation.rules.ColumnCorrelationRule
+import com.amazon.deequ.dqdl.translation.rules.CompletenessRule
+import com.amazon.deequ.dqdl.translation.rules.CustomSqlRule
+import com.amazon.deequ.dqdl.translation.rules.DistinctValuesCountRule
+import com.amazon.deequ.dqdl.translation.rules.EntropyRule
+import com.amazon.deequ.dqdl.translation.rules.IsCompleteRule
+import com.amazon.deequ.dqdl.translation.rules.IsPrimaryKeyRule
+import com.amazon.deequ.dqdl.translation.rules.IsUniqueRule
+import com.amazon.deequ.dqdl.translation.rules.MeanRule
+import com.amazon.deequ.dqdl.translation.rules.RowCountRule
+import com.amazon.deequ.dqdl.translation.rules.StandardDeviationRule
+import com.amazon.deequ.dqdl.translation.rules.SumRule
+import com.amazon.deequ.dqdl.translation.rules.UniqueValueRatioRule
+import com.amazon.deequ.dqdl.translation.rules.UniquenessRule
 import software.amazon.glue.dqdl.model.{DQRule, DQRuleset}
 
 import scala.jdk.CollectionConverters.collectionAsScalaIterableConverter
@@ -43,7 +56,8 @@ object DQDLRuleTranslator {
     "StandardDeviation" -> new StandardDeviationRule,
     "Sum" -> new SumRule,
     "UniqueValueRatio" -> new UniqueValueRatioRule,
-    "CustomSql" -> new CustomSqlRule
+    "CustomSql" -> new CustomSqlRule,
+    "IsPrimaryKey" -> new IsPrimaryKeyRule
   )
 
   /**

--- a/src/main/scala/com/amazon/deequ/dqdl/translation/rules/IsPrimaryKeyRule.scala
+++ b/src/main/scala/com/amazon/deequ/dqdl/translation/rules/IsPrimaryKeyRule.scala
@@ -1,0 +1,58 @@
+/**
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.dqdl.translation.rules
+
+import com.amazon.deequ.checks.{Check, CheckLevel}
+import com.amazon.deequ.dqdl.model.DeequMetricMapping
+import com.amazon.deequ.dqdl.translation.DQDLRuleConverter
+import com.amazon.deequ.dqdl.util.DQDLUtility.addWhereClause
+import software.amazon.glue.dqdl.model.DQRule
+import software.amazon.glue.dqdl.model.condition.number.NumberBasedCondition
+
+import scala.collection.JavaConverters._
+
+case class IsPrimaryKeyRule() extends DQDLRuleConverter {
+  override def convert(rule: DQRule): Either[String, (Check, Seq[DeequMetricMapping])] = {
+    val columns = rule.getParameters.asScala.collect { case (k, v) if k.startsWith("TargetColumn") => v }.toSeq
+    val check = Check(CheckLevel.Error, java.util.UUID.randomUUID.toString)
+    columns match {
+      case Nil => Left("Required parameters not found")
+      case Seq(singleCol) =>
+        val singleColCheck = addWhereClause(rule, check.isPrimaryKey(singleCol, None)).isComplete(singleCol, None)
+        Right(
+          addWhereClause(rule, singleColCheck),
+          Seq(
+            DeequMetricMapping("Column", singleCol, "Uniqueness", "Uniqueness", None, rule = rule),
+            DeequMetricMapping("Column", singleCol, "Completeness", "Completeness", None, rule = rule)
+          )
+        )
+      case cols@(head +: tail) =>
+        val multiColCheck = addWhereClause(rule, check.isPrimaryKey(head, None, tail: _*))
+        cols.foldLeft(multiColCheck) {
+          (mc, col) => addWhereClause(rule, mc.isComplete(col))
+        }
+        val completenessMetricMappings = cols.map(
+          col => DeequMetricMapping("Column", col, "Completeness", "Completeness", None, rule = rule)
+        )
+        Right(
+          multiColCheck,
+          Seq(DeequMetricMapping("Multicolumn", cols.mkString(","), "Uniqueness", "Uniqueness", None, rule = rule))
+            ++ completenessMetricMappings
+        )
+    }
+  }
+}


### PR DESCRIPTION

*Description of changes:*

Add support for DQDL rule: IsPrimaryKey, allowing users to enforce primary key-like uniqueness and non-null constraints on selected columns


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
