### PR TITLE
Add ColumnExists Check, Constraint, and DQDL Rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,8 +153,9 @@ Deequ also supports [DQDL](https://docs.aws.amazon.com/glue/latest/dg/dqdl.html)
 - **Sum**: `Sum "column" = 100`
 - **UniqueValueRatio**: `UniqueValueRatio "column" > 0.7`
 - **CustomSql**: `CustomSql "SELECT COUNT(*) FROM primary" > 0`
-- **IsPrimaryKey**: `IsPrimaryKey "att1"`
-- **ColumnLength**: `ColumnLength "att1" between 1 and 5`
+- **IsPrimaryKey**: `IsPrimaryKey "column"`
+- **ColumnLength**: `ColumnLength "column" between 1 and 5`
+- **ColumnExists**: `ColumnExists "column"`
 
 ### Scala Example
 

--- a/src/main/scala/com/amazon/deequ/analyzers/ColumnExists.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/ColumnExists.scala
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
+ * either express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ *
+ */
+
+package com.amazon.deequ.analyzers
+
+import com.amazon.deequ.metrics.{DoubleMetric, Entity}
+import org.apache.spark.sql.DataFrame
+
+case class ColumnExistsState(exists: Boolean, column: String) extends DoubleValuedState[ColumnExistsState] {
+  override def sum(other: ColumnExistsState): ColumnExistsState = this
+
+  override def metricValue(): Double = if (exists) 1.0 else 0.0
+}
+
+case class ColumnExists(column: String) extends Analyzer[ColumnExistsState, DoubleMetric] {
+
+  val name = "ColumnExists"
+  val instance: String = column
+  val entity: Entity.Value = Entity.Dataset
+
+  /**
+   * Compute the state (sufficient statistics) from the data
+   *
+   * @param data the input dataframe
+   * @return 1 if the column exists, 0 otherwise
+   */
+  override def computeStateFrom(data: DataFrame, filterCondition: Option[String]): Option[ColumnExistsState] = {
+    if (filterCondition.isDefined) {
+      throw new IllegalArgumentException("ColumnExists does not accept a filter condition")
+    } else {
+      val exists = data.columns.contains(column)
+      Some(ColumnExistsState(exists, column))
+    }
+  }
+
+  /**
+   * Compute the metric from the state (sufficient statistics)
+   *
+   * @param state the computed state from [[computeStateFrom]]
+   * @return a double metric indicating whether the column exists (1.0) or not (0.0)
+   */
+  override def computeMetricFrom(state: Option[ColumnExistsState]): DoubleMetric = state match {
+    case Some(s) => Analyzers.metricFromValue(s.metricValue(), name, instance, entity)
+    case None => Analyzers.metricFromEmpty(this, name, instance, entity)
+  }
+
+  /**
+   * Compute the metric from a failure
+   */
+  override private[deequ] def toFailureMetric(failure: Exception): DoubleMetric = {
+    Analyzers.metricFromFailure(failure, name, instance, entity)
+  }
+}

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -160,6 +160,15 @@ case class Check(
     addFilterableConstraint { filter => completenessConstraint(column, assertion, filter, hint, analyzerOptions) }
   }
 
+  def hasColumn(
+   column: String,
+   hint: Option[String] = None)
+  : Check = {
+    val constraint = columnExistsConstraint(column, hint)
+    addConstraint(constraint)
+  }
+
+
   /**
     * Creates a constraint that asserts on completion in combined set of columns.
     *

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -17,6 +17,7 @@
 package com.amazon.deequ.constraints
 
 import com.amazon.deequ.analyzers._
+import com.amazon.deequ.checks.Check
 import com.amazon.deequ.metrics.BucketDistribution
 import com.amazon.deequ.metrics.Distribution
 import com.amazon.deequ.metrics.Metric
@@ -738,6 +739,25 @@ object Constraint {
       hint = hint)
 
     new NamedConstraint(constraint, s"SumConstraint($sum)")
+  }
+
+  /**
+   * Creates a constraint that checks if a column exists in the DataFrame
+   *
+   * @param column Column to check for existence
+   * @param hint A hint to provide additional context why a constraint could have failed
+   */
+  def columnExistsConstraint(
+      column: String,
+      hint: Option[String] = None)
+  : Constraint = {
+
+    val columnExists = ColumnExists(column)
+
+    val constraint = AnalysisBasedConstraint[ColumnExistsState, Double, Double](
+      columnExists, Check.IsOne, hint = hint)
+
+    new NamedConstraint(constraint, s"ColumnExistsConstraint($column)")
   }
 
   /**

--- a/src/main/scala/com/amazon/deequ/dqdl/translation/DQDLRuleTranslator.scala
+++ b/src/main/scala/com/amazon/deequ/dqdl/translation/DQDLRuleTranslator.scala
@@ -32,6 +32,7 @@ import com.amazon.deequ.dqdl.translation.rules.SumRule
 import com.amazon.deequ.dqdl.translation.rules.UniqueValueRatioRule
 import com.amazon.deequ.dqdl.translation.rules.UniquenessRule
 import com.amazon.deequ.dqdl.translation.rules.ColumnLengthRule
+import com.amazon.deequ.dqdl.translation.rules.ColumnExistsRule
 import software.amazon.glue.dqdl.model.DQRule
 import software.amazon.glue.dqdl.model.DQRuleset
 
@@ -60,7 +61,8 @@ object DQDLRuleTranslator {
     "UniqueValueRatio" -> new UniqueValueRatioRule,
     "CustomSql" -> new CustomSqlRule,
     "IsPrimaryKey" -> new IsPrimaryKeyRule,
-    "ColumnLength" -> new ColumnLengthRule
+    "ColumnLength" -> new ColumnLengthRule,
+    "ColumnExists" -> new ColumnExistsRule
   )
 
   /**

--- a/src/main/scala/com/amazon/deequ/dqdl/translation/rules/ColumnExistsRule.scala
+++ b/src/main/scala/com/amazon/deequ/dqdl/translation/rules/ColumnExistsRule.scala
@@ -1,0 +1,33 @@
+/**
+ * Copyright 2025 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.dqdl.translation.rules
+
+import com.amazon.deequ.checks.{Check, CheckLevel}
+import com.amazon.deequ.dqdl.model.DeequMetricMapping
+import com.amazon.deequ.dqdl.translation.DQDLRuleConverter
+import software.amazon.glue.dqdl.model.DQRule
+
+import scala.collection.JavaConverters._
+
+case class ColumnExistsRule() extends DQDLRuleConverter {
+  override def convert(rule: DQRule): Either[String, (Check, Seq[DeequMetricMapping])] = {
+    val col = rule.getParameters.asScala("TargetColumn")
+    val check = Check(CheckLevel.Error, java.util.UUID.randomUUID.toString)
+      .hasColumn(col)
+    Right((check, Seq(DeequMetricMapping("Dataset", col, "ColumnExists", "ColumnExists", None, rule = rule))))
+  }
+}

--- a/src/test/scala/com/amazon/deequ/dqdl/EvaluateDataQualitySpec.scala
+++ b/src/test/scala/com/amazon/deequ/dqdl/EvaluateDataQualitySpec.scala
@@ -483,6 +483,55 @@ class EvaluateDataQualitySpec extends AnyWordSpec with Matchers with SparkContex
       row.getAs[String]("Outcome") should be("Passed")
       row.getAs[Map[String, Double]]("EvaluatedMetrics") should contain key "Column.item.MaximumLength"
     }
+
+    "support ColumnExists rule" in withSparkSession { sparkSession =>
+      // given
+      val df = getDfCompleteAndInCompleteColumnsAndVarLengthStrings(sparkSession)
+      val ruleset = "Rules=[ColumnExists \"item\"]"
+
+      // when
+      val results = EvaluateDataQuality.process(df, ruleset)
+
+      // then
+      val row = results.collect()(0)
+      row.getAs[String]("Outcome") should be("Passed")
+      row.getAs[Map[String, Double]]("EvaluatedMetrics") should contain key "Dataset.item.ColumnExists"
+      row.getAs[Map[String, Double]]("EvaluatedMetrics") should contain value 1.0
+    }
+
+    "support ColumnExists rule fail" in withSparkSession { sparkSession =>
+      // given
+      val df = getDfCompleteAndInCompleteColumnsAndVarLengthStrings(sparkSession)
+      val ruleset = "Rules=[ColumnExists \"sampom\"]"
+
+      // when
+      val results = EvaluateDataQuality.process(df, ruleset)
+
+      // then
+      val row = results.collect()(0)
+      row.getAs[String]("Outcome") should be("Failed")
+      row.getAs[Map[String, Double]]("EvaluatedMetrics") should contain key "Dataset.sampom.ColumnExists"
+      row.getAs[Map[String, Double]]("EvaluatedMetrics") should contain value 0.0
+    }
+
+    "support multiple ColumnExists rule" in withSparkSession { sparkSession =>
+      val df = getDfCompleteAndInCompleteColumnsAndVarLengthStrings(sparkSession)
+
+      val testOutcomes = Map(
+        "sampom" -> 0.0,
+        "item" -> 1.0,
+        "val1" -> 1.0,
+        "pomerantz" -> 0.0
+      )
+
+      testOutcomes.foreach { case (columnName, expectedMetric) =>
+        val ruleset = s"""Rules=[ColumnExists "$columnName"]"""
+        val results = EvaluateDataQuality.process(df, ruleset)
+        val metrics = results.collect()(0).getAs[Map[String, Double]]("EvaluatedMetrics")
+        metrics should contain key s"Dataset.$columnName.ColumnExists"
+        metrics should contain value expectedMetric
+      }
+    }
   }
 
 }

--- a/src/test/scala/com/amazon/deequ/examples/ScalaDQDLExample.scala
+++ b/src/test/scala/com/amazon/deequ/examples/ScalaDQDLExample.scala
@@ -39,7 +39,8 @@ object ScalaDQDLExample {
     ).toDF("item", "att1", "att2")
 
     // Define rules using DQDL syntax
-    val ruleset = """Rules=[IsUnique "item", RowCount < 10, Completeness "item" > 0.8, Uniqueness "item" = 1.0]"""
+    val ruleset = """Rules=[IsUnique "item", RowCount < 10, Completeness "item" > 0.8,""" +
+      """Uniqueness "item" = 1.0, ColumnExists "item"]"""
 
     // Evaluate data quality
     val results = EvaluateDataQuality.process(df, ruleset)


### PR DESCRIPTION
*Description of changes:*
Added ColumnExists
- Analyzer / Constraint / Check
- DQDL implementation
- Unit Test

From
- https://docs.aws.amazon.com/glue/latest/dg/dqdl-rule-types-ColumnExists.html

*new*
ColumnExists now outputs a metric!
```
Rules=[ColumnExists \"sampom\"]

Dataset.sampom.ColumnExists -> 1.0
```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
