### PR TITLE
Add HistogramBinned analyzer and serialization support

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/StateProvider.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/StateProvider.scala
@@ -16,14 +16,12 @@
 
 package com.amazon.deequ.analyzers
 
-import java.util.concurrent.ConcurrentHashMap
-
-import com.google.common.io.Closeables
-import org.apache.hadoop.fs.{FSDataInputStream, FSDataOutputStream, FileSystem, Path}
-import org.apache.spark.sql.SparkSession
-import org.apache.spark.sql.catalyst.expressions.aggregate.{ApproximatePercentile, DeequHyperLogLogPlusPlusUtils}
 import org.apache.spark.sql.SaveMode
+import org.apache.spark.sql.SparkSession
+import org.apache.spark.sql.catalyst.expressions.aggregate.ApproximatePercentile
+import org.apache.spark.sql.catalyst.expressions.aggregate.DeequHyperLogLogPlusPlusUtils
 
+import java.util.concurrent.ConcurrentHashMap
 import scala.collection.JavaConversions._
 import scala.util.hashing.MurmurHash3
 
@@ -112,7 +110,7 @@ case class HdfsStateProvider(
       case _: MinLength =>
         persistDoubleState(state.asInstanceOf[MinState].minValue, identifier)
 
-      case _ : FrequencyBasedAnalyzer | _ : Histogram =>
+      case _ : FrequencyBasedAnalyzer | _ : Histogram | _ : HistogramBinned =>
         persistDataframeLongState(state.asInstanceOf[FrequenciesAndNumRows], identifier)
 
       case _: DataType =>
@@ -165,7 +163,7 @@ case class HdfsStateProvider(
 
       case _ : MinLength => MinState(loadDoubleState(identifier))
 
-      case _ : FrequencyBasedAnalyzer | _ : Histogram => loadDataframeLongState(identifier)
+      case _ : FrequencyBasedAnalyzer | _ : Histogram | _ : HistogramBinned => loadDataframeLongState(identifier)
 
       case _ : DataType => DataTypeHistogram.fromBytes(loadBytes(identifier))
 

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -20,6 +20,7 @@ import com.amazon.deequ.analyzers._
 import com.amazon.deequ.checks.Check
 import com.amazon.deequ.metrics.BucketDistribution
 import com.amazon.deequ.metrics.Distribution
+import com.amazon.deequ.metrics.DistributionBinned
 import com.amazon.deequ.metrics.Metric
 import org.apache.spark.sql.expressions.UserDefinedFunction
 
@@ -196,6 +197,44 @@ object Constraint {
       histogram, assertion, Some(_.numberOfBins), hint)
 
     new NamedConstraint(constraint, s"HistogramBinConstraint($histogram)")
+  }
+
+  /**
+    * Runs HistogramBinned analysis on the given column and executes the assertion
+    */
+  def histogramBinnedConstraint(
+      column: String,
+      assertion: DistributionBinned => Boolean,
+      binCount: Option[Int] = Some(HistogramBinned.DefaultBinCount),
+      where: Option[String] = None,
+      hint: Option[String] = None)
+    : Constraint = {
+
+    val histogramBinned = HistogramBinned(column, binCount, where = where)
+
+    val constraint = AnalysisBasedConstraint[FrequenciesAndNumRows, DistributionBinned, DistributionBinned](
+      histogramBinned, assertion, hint = hint)
+
+    new NamedConstraint(constraint, s"HistogramBinnedConstraint($histogramBinned)")
+  }
+
+  /**
+    * Runs HistogramBinned analysis on the given column and executes the assertion on bin count
+    */
+  def histogramBinnedBinConstraint(
+      column: String,
+      assertion: Long => Boolean,
+      binCount: Option[Int] = Some(HistogramBinned.DefaultBinCount),
+      where: Option[String] = None,
+      hint: Option[String] = None)
+    : Constraint = {
+
+    val histogramBinned = HistogramBinned(column, binCount, where = where)
+
+    val constraint = AnalysisBasedConstraint[FrequenciesAndNumRows, DistributionBinned, Long](
+      histogramBinned, assertion, Some(_.numberOfBins), hint)
+
+    new NamedConstraint(constraint, s"HistogramBinnedBinConstraint($histogramBinned)")
   }
 
   /**

--- a/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
+++ b/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
@@ -74,6 +74,12 @@ private[deequ] case class NumericColumnStatistics(
 
 private[deequ] case class CategoricalColumnStatistics(histograms: Map[String, Distribution])
 
+// TODO: Add HistogramBinned support for numerical column profiling
+// This would require:
+// - New NumericColumnStatistics case class with Map[String, DistributionBinned]
+// - Separate profiling logic for numeric vs categorical columns
+// - Integration in createProfiles() method
+
 /** Computes single-column profiles in three scans over the data, intented for large (TB) datasets
   *
   * In the first phase, we compute the number of records, as well as the datatype, approx. num

--- a/src/test/scala/com/amazon/deequ/analyzers/StateProviderTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/StateProviderTest.scala
@@ -168,6 +168,23 @@ class StateProviderTest extends AnyWordSpec
 
       assert(provider.load(histogramCountAnalyzer).isDefined)
     }
+
+    "should store HistogramBinned result to InMemoryStateProvider" in withSparkSession { session =>
+
+      val provider = InMemoryStateProvider()
+
+      val data = someData(session)
+      val histogramBinnedAnalyzer = HistogramBinned("count", Some(5))
+
+      val analysis = Analysis().addAnalyzer(histogramBinnedAnalyzer)
+
+      AnalysisRunner.run(
+        data = data,
+        analysis = analysis,
+        saveStatesWith = Some(provider))
+
+      assert(provider.load(histogramBinnedAnalyzer).isDefined)
+    }
   }
 
   def assertCorrectlyRestoresNumMatchesAndCount(persister: StatePersister,

--- a/src/test/scala/com/amazon/deequ/constraints/ConstraintsTest.scala
+++ b/src/test/scala/com/amazon/deequ/constraints/ConstraintsTest.scala
@@ -65,6 +65,29 @@ class ConstraintsTest extends WordSpec with Matchers with SparkContextSpec with 
     }
   }
 
+  "Histogram binned constraint" should {
+    "succeed for valid binned distribution assertions" in withSparkSession { sparkSession =>
+      val df = sparkSession.createDataFrame(Seq(
+        (1, 10.0), (2, 20.0), (3, 30.0), (4, 40.0), (5, 50.0)
+      )).toDF("id", "value")
+
+      calculate(Constraint.histogramBinnedConstraint("value",
+        _.numberOfBins == 5), df).status shouldBe ConstraintStatus.Success
+
+      calculate(Constraint.histogramBinnedBinConstraint("value",
+        _ == 5), df).status shouldBe ConstraintStatus.Success
+    }
+
+    "fail for invalid binned distribution assertions" in withSparkSession { sparkSession =>
+      val df = sparkSession.createDataFrame(Seq(
+        (1, 10.0), (2, 20.0)
+      )).toDF("id", "value")
+
+      calculate(Constraint.histogramBinnedConstraint("value",
+        _.numberOfBins == 10), df).status shouldBe ConstraintStatus.Failure
+    }
+  }
+
   "Mutual information constraint" should {
     "yield a mutual information of 0 for conditionally uninformative columns" in
       withSparkSession { sparkSession =>


### PR DESCRIPTION
### TLDR

Integrate HistogramBinned analyzer with constraints and add full serialization support.

### Description of changes

**Constraint integration** such as:
- **Distribution shape validation** - Assert on bin frequencies, ratios, and statistical properties
- **Range-based checks** - Validate data falls within expected numeric ranges across bins
- **Peak detection** - Identify and validate distribution peaks and outliers
- **Filtered analysis** - Apply constraints with WHERE clauses for conditional validation

For example, this constraint fails if bins have less than 100 values:
```
.hasHistogramBinnedValues("price", _.bins.exists(_.frequency > 100))
```

**Column Profiler integration** (started, not finished) for:
- **Automatic profiling** - HistogramBinned automatically included when profiling numeric columns

Column profiler is an automatic data exploration tool. When run on a dataset, it generates a summary report showing statistics, distributions, null counts, etc. for every column. HistogramBinned gets automatically included.

Not integrating this currently (left TODO) until decisions are made for what column types to run HistogramBinned on versus Histogram.

**Serialization support** with JSON:
- **Infinity handling** - Gson configuration for -Infinity serialization of null bins
- **State persistence** - Full integration with StateProvider for incremental analysis

### Disclaimer

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
