### PR TITLE
HistogramBinned should count empty and null bins in total

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/HistogramBinned.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/HistogramBinned.scala
@@ -181,7 +181,8 @@ case class HistogramBinned(
             binDataSeq
           }
 
-          DistributionBinned(finalBins, binCount)
+          val totalBins = finalBins.size // Count null and empty bins
+          DistributionBinned(finalBins, totalBins)
         }
 
         HistogramBinnedMetric(column, value)

--- a/src/test/scala/com/amazon/deequ/constraints/ConstraintsTest.scala
+++ b/src/test/scala/com/amazon/deequ/constraints/ConstraintsTest.scala
@@ -72,19 +72,19 @@ class ConstraintsTest extends WordSpec with Matchers with SparkContextSpec with 
       )).toDF("id", "value")
 
       calculate(Constraint.histogramBinnedConstraint("value",
-        _.numberOfBins == 5), df).status shouldBe ConstraintStatus.Success
+        _.numberOfBins == 10), df).status shouldBe ConstraintStatus.Success
 
       calculate(Constraint.histogramBinnedBinConstraint("value",
-        _ == 5), df).status shouldBe ConstraintStatus.Success
+        _ == 10), df).status shouldBe ConstraintStatus.Success
     }
 
-    "fail for invalid binned distribution assertions" in withSparkSession { sparkSession =>
+    "fail when total frequency exceeds data count" in withSparkSession { sparkSession =>
       val df = sparkSession.createDataFrame(Seq(
         (1, 10.0), (2, 20.0)
       )).toDF("id", "value")
 
       calculate(Constraint.histogramBinnedConstraint("value",
-        _.numberOfBins == 10), df).status shouldBe ConstraintStatus.Failure
+        _.bins.map(_.frequency).sum > 5), df).status shouldBe ConstraintStatus.Failure
     }
   }
 


### PR DESCRIPTION
### Description of changes

Count null bins (similar to existing `Histogram` implementation) and empty bins. Counting empty bins is proper behavior. Counting null bins is a design choice, but maintaining what is already in place by `Histogram`.
- `HistogramBinnedTest.scala` unit tests verifies this behavior (was failing previously).
- The existing test "handle all null data gracefully" checked the null bin was already counted.
- `ConstraintsTest.scala` was modified because the empty bins need to be included in the total bin count. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
