### PR TITLE
Fix iceberg column pruning

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Analyzer.scala
@@ -80,6 +80,14 @@ trait Analyzer[S <: State[_], +M <: Metric[_]] extends Serializable {
   def computeMetricFrom(state: Option[S]): M
 
   /**
+    * Returns the columns this analyzer reads from the data, if known statically.
+    * Returns Some(columns) when all referenced columns can be determined,
+    * or None when the analyzer may reference arbitrary columns (e.g. free-form SQL predicates).
+    * Used by AnalysisRunner to enable column pruning for V2 DataSource connectors like Iceberg.
+    */
+  def columnsReferenced(): Option[Set[String]] = None
+
+  /**
     * A set of assertions that must hold on the schema of the data frame
     * @return
     */

--- a/src/main/scala/com/amazon/deequ/analyzers/ApproxCountDistinct.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/ApproxCountDistinct.scala
@@ -64,4 +64,7 @@ case class ApproxCountDistinct(column: String, where: Option[String] = None)
   }
 
   override def filterCondition: Option[String] = where
+
+  override def columnsReferenced(): Option[Set[String]] =
+    if (where.isDefined) None else Some(Set(column))
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/ApproxQuantile.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/ApproxQuantile.scala
@@ -109,4 +109,7 @@ case class ApproxQuantile(
   }
 
   override def filterCondition: Option[String] = where
+
+  override def columnsReferenced(): Option[Set[String]] =
+    if (where.isDefined) None else Some(Set(column))
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/ApproxQuantiles.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/ApproxQuantiles.scala
@@ -98,4 +98,6 @@ case class ApproxQuantiles(column: String, quantiles: Seq[Double], relativeError
   override def preconditions: Seq[StructType => Unit] = {
     PARAM_CHECKS :: hasColumn(column) :: isNumeric(column) :: Nil
   }
+
+  override def columnsReferenced(): Option[Set[String]] = Some(Set(column))
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/ColumnCount.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/ColumnCount.scala
@@ -60,4 +60,6 @@ case class ColumnCount() extends Analyzer[NumMatches, DoubleMetric] {
   override private[deequ] def toFailureMetric(failure: Exception): DoubleMetric = {
     Analyzers.metricFromFailure(failure, name, instance, entity)
   }
+
+  override def columnsReferenced(): Option[Set[String]] = Some(Set.empty)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/ColumnExists.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/ColumnExists.scala
@@ -64,4 +64,6 @@ case class ColumnExists(column: String) extends Analyzer[ColumnExistsState, Doub
   override private[deequ] def toFailureMetric(failure: Exception): DoubleMetric = {
     Analyzers.metricFromFailure(failure, name, instance, entity)
   }
+
+  override def columnsReferenced(): Option[Set[String]] = Some(Set.empty)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Completeness.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Completeness.scala
@@ -50,6 +50,9 @@ case class Completeness(column: String, where: Option[String] = None,
 
   override def filterCondition: Option[String] = where
 
+  override def columnsReferenced(): Option[Set[String]] =
+    if (where.isDefined) None else Some(Set(column))
+
   @VisibleForTesting // required by some tests that compare analyzer results to an expected state
   private[deequ] def criterion: Column = conditionalSelection(column, where).isNotNull
 

--- a/src/main/scala/com/amazon/deequ/analyzers/Compliance.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Compliance.scala
@@ -75,4 +75,8 @@ case class Compliance(instance: String,
 
   override protected def additionalPreconditions(): Seq[StructType => Unit] =
     columns.map(hasColumn)
+
+  // Compliance uses free-form SQL predicates that can reference arbitrary columns,
+  // so we cannot safely determine which columns are needed.
+  override def columnsReferenced(): Option[Set[String]] = None
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Correlation.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Correlation.scala
@@ -105,4 +105,7 @@ case class Correlation(
   }
 
   override def filterCondition: Option[String] = where
+
+  override def columnsReferenced(): Option[Set[String]] =
+    if (where.isDefined) None else Some(Set(firstColumn, secondColumn))
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/DataType.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/DataType.scala
@@ -183,4 +183,7 @@ case class DataType(
   }
 
   override def filterCondition: Option[String] = where
+
+  override def columnsReferenced(): Option[Set[String]] =
+    if (where.isDefined) None else Some(Set(column))
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/ExactQuantile.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/ExactQuantile.scala
@@ -60,6 +60,9 @@ with FilterableAnalyzer {
 
   override def filterCondition: Option[String] = where
 
+  override def columnsReferenced(): Option[Set[String]] =
+    if (where.isDefined) None else Some(Set(column))
+
   @VisibleForTesting
   private def criterion: Column = conditionalSelection(column, where).cast(DoubleType)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/KLLSketch.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/KLLSketch.scala
@@ -167,6 +167,8 @@ case class KLLSketch(
   override def preconditions(): Seq[StructType => Unit] = {
     PARAM_CHECK :: hasColumn(column) :: isNumeric(column) :: Nil
   }
+
+  override def columnsReferenced(): Option[Set[String]] = Some(Set(column))
 }
 
 object KLLSketch {

--- a/src/main/scala/com/amazon/deequ/analyzers/MaxLength.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/MaxLength.scala
@@ -54,6 +54,9 @@ case class MaxLength(column: String, where: Option[String] = None, analyzerOptio
 
   override def filterCondition: Option[String] = where
 
+  override def columnsReferenced(): Option[Set[String]] =
+    if (where.isDefined) None else Some(Set(column))
+
   private[deequ] def criterion: Column = {
     val isNullCheck = col(column).isNull
     val colLength = length(col(column)).cast(DoubleType)

--- a/src/main/scala/com/amazon/deequ/analyzers/Maximum.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Maximum.scala
@@ -64,6 +64,9 @@ case class Maximum(column: String, where: Option[String] = None, analyzerOptions
 
   override def filterCondition: Option[String] = where
 
+  override def columnsReferenced(): Option[Set[String]] =
+    if (where.isDefined) None else Some(Set(column))
+
   @VisibleForTesting
   private def criterion: Column = conditionalSelectionWithAugmentedOutcome(col(column), where)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Mean.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Mean.scala
@@ -54,4 +54,7 @@ case class Mean(column: String, where: Option[String] = None)
   }
 
   override def filterCondition: Option[String] = where
+
+  override def columnsReferenced(): Option[Set[String]] =
+    if (where.isDefined) None else Some(Set(column))
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/MinLength.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/MinLength.scala
@@ -54,6 +54,9 @@ case class MinLength(column: String, where: Option[String] = None, analyzerOptio
 
   override def filterCondition: Option[String] = where
 
+  override def columnsReferenced(): Option[Set[String]] =
+    if (where.isDefined) None else Some(Set(column))
+
   private[deequ] def criterion: Column = {
     val isNullCheck = col(column).isNull
     val colLength = length(col(column)).cast(DoubleType)

--- a/src/main/scala/com/amazon/deequ/analyzers/Minimum.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Minimum.scala
@@ -64,6 +64,9 @@ case class Minimum(column: String, where: Option[String] = None, analyzerOptions
 
   override def filterCondition: Option[String] = where
 
+  override def columnsReferenced(): Option[Set[String]] =
+    if (where.isDefined) None else Some(Set(column))
+
   @VisibleForTesting
   private def criterion: Column = conditionalSelectionWithAugmentedOutcome(col(column), where)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/PatternMatch.scala
@@ -58,6 +58,9 @@ case class PatternMatch(column: String, pattern: Regex, where: Option[String] = 
 
   override def filterCondition: Option[String] = where
 
+  override def columnsReferenced(): Option[Set[String]] =
+    if (where.isDefined) None else Some(Set(column))
+
   override protected def additionalPreconditions(): Seq[StructType => Unit] = {
     hasColumn(column) :: isString(column) :: Nil
   }

--- a/src/main/scala/com/amazon/deequ/analyzers/RatioOfSums.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/RatioOfSums.scala
@@ -89,4 +89,7 @@ case class RatioOfSums(
   }
 
   override def filterCondition: Option[String] = where
+
+  override def columnsReferenced(): Option[Set[String]] =
+    if (where.isDefined) None else Some(Set(numerator, denominator))
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Size.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Size.scala
@@ -48,4 +48,7 @@ case class Size(where: Option[String] = None)
   }
 
   override def filterCondition: Option[String] = where
+
+  override def columnsReferenced(): Option[Set[String]] =
+    if (where.isDefined) None else Some(Set.empty)
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/StandardDeviation.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/StandardDeviation.scala
@@ -73,4 +73,7 @@ case class StandardDeviation(column: String, where: Option[String] = None)
   }
 
   override def filterCondition: Option[String] = where
+
+  override def columnsReferenced(): Option[Set[String]] =
+    if (where.isDefined) None else Some(Set(column))
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/Sum.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Sum.scala
@@ -52,4 +52,7 @@ case class Sum(column: String, where: Option[String] = None)
   }
 
   override def filterCondition: Option[String] = where
+
+  override def columnsReferenced(): Option[Set[String]] =
+    if (where.isDefined) None else Some(Set(column))
 }

--- a/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
@@ -21,6 +21,7 @@ import com.amazon.deequ.io.DfsUtils
 import com.amazon.deequ.metrics.{DoubleMetric, Metric}
 import com.amazon.deequ.repository.{MetricsRepository, ResultKey}
 import org.apache.spark.sql.Column
+import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, Row, SparkSession}
 import org.apache.spark.storage.StorageLevel
@@ -360,7 +361,9 @@ object AnalysisRunner {
         val offsets = shareableAnalyzers.scanLeft(0) { case (current, analyzer) =>
           current + analyzer.aggregationFunctions().length
         }
-        val results = data.agg(aggregations.head, aggregations.tail: _*).collect().head
+
+        val prunedData = pruneColumns(data, shareableAnalyzers)
+        val results = prunedData.agg(aggregations.head, aggregations.tail: _*).collect().head
         shareableAnalyzers.zip(offsets).map { case (analyzer, offset) =>
           analyzer ->
             successOrFailureMetricFrom(analyzer, results, offset, aggregateWith, saveStatesTo)
@@ -380,6 +383,35 @@ object AnalysisRunner {
       .toMap[Analyzer[_, Metric[_]], Metric[_]]
 
     sharedResults ++ AnalyzerContext(otherMetrics)
+  }
+
+  /**
+    * Attempts to select only the columns needed by the given analyzers.
+    * This enables column pruning for V2 DataSource connectors (e.g. Iceberg, Delta Lake)
+    * which make scan-planning decisions before Spark's optimizer can simplify the plan.
+    *
+    * Falls back to the original DataFrame if any analyzer cannot statically declare its columns
+    * (e.g. analyzers with free-form SQL predicates or WHERE clauses).
+    */
+  private[this] def pruneColumns(
+      data: DataFrame,
+      analyzers: Seq[Analyzer[_, _]])
+    : DataFrame = {
+
+    val allColumns = analyzers.map(_.columnsReferenced())
+
+    if (allColumns.exists(_.isEmpty)) {
+      // At least one analyzer cannot declare its columns; skip pruning
+      data
+    } else {
+      val neededColumns = allColumns.flatMap(_.get).distinct
+      if (neededColumns.isEmpty) {
+        // All analyzers are dataset-level (e.g. Size), no column selection needed
+        data
+      } else {
+        data.select(neededColumns.map(col): _*)
+      }
+    }
   }
 
   /** Compute scan-shareable analyzer metric from aggregation result, mapping generic exceptions

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
@@ -864,6 +864,57 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
       assert(testVal.value.isSuccess)
       assert(testVal.value.toOption.get.isInfinite)
     }
+
+    "return correct columnsReferenced for analyzers without where clauses" in {
+      assert(Completeness("col1").columnsReferenced() === Some(Set("col1")))
+      assert(Mean("col1").columnsReferenced() === Some(Set("col1")))
+      assert(Maximum("col1").columnsReferenced() === Some(Set("col1")))
+      assert(Minimum("col1").columnsReferenced() === Some(Set("col1")))
+      assert(Sum("col1").columnsReferenced() === Some(Set("col1")))
+      assert(StandardDeviation("col1").columnsReferenced() === Some(Set("col1")))
+      assert(ApproxCountDistinct("col1").columnsReferenced() === Some(Set("col1")))
+      assert(DataType("col1").columnsReferenced() === Some(Set("col1")))
+      assert(PatternMatch("col1", ".*".r).columnsReferenced() === Some(Set("col1")))
+      assert(MaxLength("col1").columnsReferenced() === Some(Set("col1")))
+      assert(MinLength("col1").columnsReferenced() === Some(Set("col1")))
+      assert(ExactQuantile("col1", 0.5).columnsReferenced() === Some(Set("col1")))
+      assert(ApproxQuantile("col1", 0.5).columnsReferenced() === Some(Set("col1")))
+      assert(ApproxQuantiles("col1", Seq(0.25, 0.75)).columnsReferenced() === Some(Set("col1")))
+      assert(Correlation("col1", "col2").columnsReferenced() === Some(Set("col1", "col2")))
+      assert(RatioOfSums("col1", "col2").columnsReferenced() === Some(Set("col1", "col2")))
+      assert(Size().columnsReferenced() === Some(Set.empty))
+      assert(ColumnCount().columnsReferenced() === Some(Set.empty))
+      assert(ColumnExists("col1").columnsReferenced() === Some(Set.empty))
+      assert(KLLSketch("col1").columnsReferenced() === Some(Set("col1")))
+    }
+
+    "return None for columnsReferenced when where clause is present" in {
+      assert(Completeness("col1", Some("col2 > 0")).columnsReferenced() === None)
+      assert(Mean("col1", Some("col2 > 0")).columnsReferenced() === None)
+      assert(Maximum("col1", Some("col2 > 0")).columnsReferenced() === None)
+      assert(Minimum("col1", Some("col2 > 0")).columnsReferenced() === None)
+      assert(Sum("col1", Some("col2 > 0")).columnsReferenced() === None)
+      assert(StandardDeviation("col1", Some("col2 > 0")).columnsReferenced() === None)
+      assert(ApproxCountDistinct("col1", Some("col2 > 0")).columnsReferenced() === None)
+      assert(DataType("col1", Some("col2 > 0")).columnsReferenced() === None)
+      assert(PatternMatch("col1", ".*".r, Some("col2 > 0")).columnsReferenced() === None)
+      assert(MaxLength("col1", Some("col2 > 0")).columnsReferenced() === None)
+      assert(MinLength("col1", Some("col2 > 0")).columnsReferenced() === None)
+      assert(ExactQuantile("col1", 0.5, Some("col2 > 0")).columnsReferenced() === None)
+      assert(ApproxQuantile("col1", 0.5, where = Some("col2 > 0")).columnsReferenced() === None)
+      assert(Correlation("col1", "col2", Some("col1 > 0")).columnsReferenced() === None)
+      assert(RatioOfSums("col1", "col2", Some("col1 > 0")).columnsReferenced() === None)
+      assert(Size(Some("col1 > 0")).columnsReferenced() === None)
+    }
+
+    "return None for columnsReferenced for Compliance (free-form SQL)" in {
+      assert(Compliance("test", "col1 > 0").columnsReferenced() === None)
+      assert(Compliance("test", "col1 > 0", columns = List("col1")).columnsReferenced() === None)
+    }
+
+    "return None for columnsReferenced for CustomSql" in {
+      assert(CustomSql("SELECT COUNT(*) FROM table").columnsReferenced() === None)
+    }
   }
 }
 

--- a/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
@@ -407,5 +407,130 @@ class AnalysisRunnerTests extends AnyWordSpec
 
       assert(!computed.metricMap.keys.exists(_.isInstanceOf[Size]))
     }
+
+    "produce correct results with column pruning for analyzers without where clauses" in
+      withSparkSession { session =>
+        val data = getDfWithNumericValues(session)
+
+        // These analyzers all declare their columns, so pruning will be active
+        val completeness = Completeness("att1")
+        val mean = Mean("att1")
+        val maximum = Maximum("att2")
+        val size = Size()
+
+        val analysis = Analysis()
+          .addAnalyzer(completeness)
+          .addAnalyzer(mean)
+          .addAnalyzer(maximum)
+          .addAnalyzer(size)
+
+        val result = AnalysisRunner.run(data, analysis)
+
+        // Compute expected values directly on individual analyzers (no pruning path)
+        val expectedCompleteness = completeness.calculate(data)
+        val expectedMean = mean.calculate(data)
+        val expectedMaximum = maximum.calculate(data)
+        val expectedSize = size.calculate(data)
+
+        // Verify pruned results match direct computation exactly
+        assert(result.metric(completeness).get.value === expectedCompleteness.value)
+        assert(result.metric(mean).get.value === expectedMean.value)
+        assert(result.metric(maximum).get.value === expectedMaximum.value)
+        assert(result.metric(size).get.value === expectedSize.value)
+      }
+
+    "produce correct results when analyzers have where clauses (pruning disabled)" in
+      withSparkSession { session =>
+        val data = getDfWithNumericValues(session)
+
+        val completenessWithWhere = Completeness("att1", Some("att2 > 0"))
+        val mean = Mean("att1")
+
+        val analysis = Analysis()
+          .addAnalyzer(completenessWithWhere)
+          .addAnalyzer(mean)
+
+        val result = AnalysisRunner.run(data, analysis)
+
+        // Verify values match direct computation
+        val expectedCompleteness = completenessWithWhere.calculate(data)
+        val expectedMean = mean.calculate(data)
+
+        assert(result.metric(completenessWithWhere).get.value === expectedCompleteness.value)
+        assert(result.metric(mean).get.value === expectedMean.value)
+      }
+
+    "produce correct results when mixing Compliance (unknown columns) with other analyzers" in
+      withSparkSession { session =>
+        val data = getDfWithNumericValues(session)
+
+        val compliance = Compliance("att1 > 0", "att1 > 0", columns = List("att1"))
+        val completeness = Completeness("att2")
+
+        val analysis = Analysis()
+          .addAnalyzer(compliance)
+          .addAnalyzer(completeness)
+
+        val result = AnalysisRunner.run(data, analysis)
+
+        val expectedCompliance = compliance.calculate(data)
+        val expectedCompleteness = completeness.calculate(data)
+
+        assert(result.metric(compliance).get.value === expectedCompliance.value)
+        assert(result.metric(completeness).get.value === expectedCompleteness.value)
+      }
+
+    "produce correct results with only dataset-level analyzers (no column pruning needed)" in
+      withSparkSession { session =>
+        val data = getDfWithNumericValues(session)
+
+        val size = Size()
+        val analysis = Analysis().addAnalyzer(size)
+
+        val result = AnalysisRunner.run(data, analysis)
+
+        val expectedSize = size.calculate(data)
+        assert(result.metric(size).get.value === expectedSize.value)
+      }
+
+    "produce correct results with multi-column analyzers" in
+      withSparkSession { session =>
+        val data = getDfWithNumericValues(session)
+
+        val correlation = Correlation("att1", "att2")
+        val completeness = Completeness("att1")
+
+        val analysis = Analysis()
+          .addAnalyzer(correlation)
+          .addAnalyzer(completeness)
+
+        val result = AnalysisRunner.run(data, analysis)
+
+        val expectedCorrelation = correlation.calculate(data)
+        val expectedCompleteness = completeness.calculate(data)
+
+        assert(result.metric(correlation).get.value === expectedCorrelation.value)
+        assert(result.metric(completeness).get.value === expectedCompleteness.value)
+      }
+
+    "produce correct results when same column is referenced by multiple analyzers" in
+      withSparkSession { session =>
+        val data = getDfWithNumericValues(session)
+
+        val completeness = Completeness("att1")
+        val mean = Mean("att1")
+        val minimum = Minimum("att1")
+
+        val analysis = Analysis()
+          .addAnalyzer(completeness)
+          .addAnalyzer(mean)
+          .addAnalyzer(minimum)
+
+        val result = AnalysisRunner.run(data, analysis)
+
+        assert(result.metric(completeness).get.value === completeness.calculate(data).value)
+        assert(result.metric(mean).get.value === mean.calculate(data).value)
+        assert(result.metric(minimum).get.value === minimum.calculate(data).value)
+      }
   }
 }


### PR DESCRIPTION
*Issue #, if available:*
                                                                                                                                                                                     
#667                                                                                                                                                                                  
                                                                                                                                                                                     
*Description of changes:*                                                                                                                                                            
                                                                                                                                                                                     
`AnalysisRunner.runScanningAnalyzers` runs `.agg()` on the full DataFrame without column pruning. V2 DataSource connectors (Iceberg, Delta Lake) make scan-planning decisions before Spark's optimizer simplifies the plan, causing full table reads on wide tables.                                                                                                      
                                                                                                                                                                                     
- Add `columnsReferenced()` method to `Analyzer` trait (default `None` : safe fallback)                                                                                              
- Override in all scanning analyzers to declare their column dependencies                                                                                                            
- Add `pruneColumns()` in `AnalysisRunner` that selects only needed columns before `.agg()`                                                                                          
- Pruning is automatically disabled when any analyzer has a WHERE clause or free-form SQL predicate                                                                                  
- All 1018 tests pass including new tests for column pruning, where clause fallback, multi-column analyzers, and duplicate column handling                                           
                                                                                                                                                                                     
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.  