### PR TITLE
added try_cast for min/max

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/Maximum.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Maximum.scala
@@ -49,7 +49,7 @@ case class Maximum(column: String, where: Option[String] = None, analyzerOptions
     // The criterion returns a column where each row contains an array of 2 elements.
     // The first element of the array is a string that indicates if the row is "in scope" or "filtered" out.
     // The second element is the value used for calculating the metric. We use "element_at" to extract it.
-    max(element_at(criterion, 2).cast(DoubleType)) :: Nil
+    max(element_at(criterion, 2).try_cast(DoubleType)) :: Nil
   }
 
   override def fromAggregationResult(result: Row, offset: Int): Option[MaxState] = {

--- a/src/main/scala/com/amazon/deequ/analyzers/Minimum.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Minimum.scala
@@ -49,7 +49,7 @@ case class Minimum(column: String, where: Option[String] = None, analyzerOptions
     // The criterion returns a column where each row contains an array of 2 elements.
     // The first element of the array is a string that indicates if the row is "in scope" or "filtered" out.
     // The second element is the value used for calculating the metric. We use "element_at" to extract it.
-    min(element_at(criterion, 2).cast(DoubleType)) :: Nil
+    min(element_at(criterion, 2).try_cast(DoubleType)) :: Nil
   }
 
   override def fromAggregationResult(result: Row, offset: Int): Option[MinState] = {

--- a/src/test/scala/com/amazon/deequ/analyzers/MaximumTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/MaximumTest.scala
@@ -59,5 +59,16 @@ class MaximumTest extends AnyWordSpec with Matchers with SparkContextSpec with F
         .map(r => if (r == null) null else r.getAs[Double](tempColName))
       values shouldBe Seq(null, null, null, 5.0, 6.0, 7.0)
     }
+
+    "handle non-numeric strings" in withSparkSession { session =>
+      val data = getDfWithNonNumericValues(session)
+
+      val att1Maximum = Maximum("att1")
+      val state: Option[MaxState] = att1Maximum.computeStateFrom(data)
+      val metric: DoubleMetric with FullColumn = att1Maximum.computeMetricFrom(state)
+
+      metric.value.isSuccess shouldBe true
+      metric.value.get shouldBe 10.0
+    }
   }
 }

--- a/src/test/scala/com/amazon/deequ/analyzers/MinimumTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/MinimumTest.scala
@@ -58,5 +58,17 @@ class MinimumTest extends AnyWordSpec with Matchers with SparkContextSpec with F
         .map(r => if (r == null) null else r.getAs[Double](tempColName))
       values shouldBe Seq(null, null, null, 5.0, 6.0, 7.0)
     }
+
+    "handle non-numeric strings" in withSparkSession { session =>
+      val data = getDfWithNonNumericValues(session)
+
+      val att1Minimum = Minimum("att1")
+      val state: Option[MinState] = att1Minimum.computeStateFrom(data)
+      val metric: DoubleMetric with FullColumn = att1Minimum.computeMetricFrom(state)
+
+      metric.value.isSuccess shouldBe true
+      metric.value.get shouldBe 1.0
+    }
+
   }
 }

--- a/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
+++ b/src/test/scala/com/amazon/deequ/utils/FixtureSupport.scala
@@ -260,6 +260,19 @@ trait FixtureSupport {
     ).toDF("item", "att1", "att2", "att3", "attNull")
   }
 
+  def getDfWithNonNumericValues(sparkSession: SparkSession): DataFrame = {
+    import sparkSession.implicits._
+
+    Seq(
+      ("3", "foo", "10"),
+      ("10", "bar", "20"),
+      ("foo", "5", "baz"),
+      ("5", "10", "30"),
+      ("bar", "baz", "qux"),
+      ("1", "20", "40")
+    ).toDF("att1", "att2", "attAllNonNumeric")
+  }
+
   def getDfWithEscapeCharacters(sparkSession: SparkSession): DataFrame = {
     import sparkSession.implicits._
     // The names are with escape characters '


### PR DESCRIPTION
## Use try_cast in Min/Max analyzers for Spark 4.0 ANSI mode

Spark 4.0 enables ANSI mode by default. The Minimum and Maximum analyzers use `.cast(DoubleType)` to convert column values before computing `min()/max()`. When the column contains non-numeric strings (e.g., applying 
`ColumnValues "myCol1" > 1` on a column with values like "A", "B"), Spark 4.0 throws `CAST_INVALID_INPUT` instead of returning null.

The fix is to use `try_cast` to return null for non-castable values instead of throwing error. `min()/max()` already ignore nulls, so the behavior matches Spark 3.5's non-ANSI mode.
