### PR TITLE
fix: Add least-privilege permissions to CI workflow

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ "master" ]
 
+permissions:
+  contents: read
+
 jobs:
   build:
 


### PR DESCRIPTION
### Description of changes

Add explicit `permissions: contents: read` to `.github/workflows/maven.yml` to restrict GITHUB_TOKEN to read-only access.

Without an explicit permissions block, the workflow inherits the repository/org default token permissions, which may include write access to contents, packages, and other scopes that this CI build doesn't need.

Resolves CodeQL `actions/missing-workflow-permissions` code scanning alert.

### Testing

No functional change — this only restricts the CI token's permissions. The `mvn clean verify` build step only needs read access to check out code and restore the Maven cache.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.