### PR TITLE
feat: Auto-review fork PRs via pull_request_target

### DIFF
--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -3,7 +3,7 @@ name: Deequ Bot
 on:
   issues:
     types: [opened, reopened]
-  pull_request:
+  pull_request_target: # Runs base branch code with secrets; safe because bot fetches diff via API, never executes PR code. NEVER add ref: to checkout.
     types: [opened, reopened, synchronize]
   issue_comment:
     types: [created]
@@ -29,8 +29,7 @@ jobs:
     if: >-
       (github.event_name == 'workflow_dispatch') ||
       (github.actor != 'github-actions[bot]' &&
-       (github.event.pull_request.head.repo.full_name == github.repository || github.event_name != 'pull_request') &&
-       (github.event.issue.pull_request == null || github.event_name == 'pull_request'))
+       (github.event.issue.pull_request == null || github.event_name == 'pull_request_target'))
     permissions:
       contents: read
       id-token: write

--- a/src/scripts/issue_bot/main.py
+++ b/src/scripts/issue_bot/main.py
@@ -64,7 +64,7 @@ def analyze():
     is_followup = cfg.event_type == "issue_comment" and cfg.event_action == "created"
 
     item = None
-    if cfg.event_type == "pull_request":
+    if cfg.event_type in ("pull_request", "pull_request_target"):
         is_pr = True
     elif cfg.event_type in ("issues", "issue_comment"):
         is_pr = False


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Switches the bot workflow from `pull_request` to `pull_request_target` so fork PRs get auto-reviewed without manual `workflow_dispatch`. 

 **Why:** Most PRs on this repo come from forks. The `pull_request` trigger blocks fork PRs because secrets aren't available. Maintainers had to manually trigger the bot for every external PR.                    
                                                                                                                                                                                                                     **How it's safe:** `pull_request_target` runs the workflow from the base branch (trusted code), not the PR head. The bot never executes PR code, it fetches the diff via GitHub API. The checkout gets the base branch only.                                                                                                                                                                                                       
                                                                                                                                                                                                                     **Changes:**                                       
 - `issue-bot.yml`: `pull_request` -> `pull_request_target`, removed fork-blocking `if` condition                                                                                                                    
 - `main.py`: Handle `pull_request_target` event name alongside `pull_request`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.