### PR TITLE
feat: Post 'no issues found' comment on clean PRs instead of skipping

### DIFF
--- a/src/scripts/issue_bot/main.py
+++ b/src/scripts/issue_bot/main.py
@@ -173,8 +173,8 @@ def analyze():
         except json.JSONDecodeError:
             inline_comments = _parse_file_review_multi(raw)
         _write_artifact({
-            "action": "RESPOND" if inline_comments else "SKIP",
-            "labels": [], "response": "",
+            "action": "RESPOND",
+            "labels": [], "response": "No issues found." if not inline_comments else "",
             "inline_comments": inline_comments,
             "title": title, "html_url": html_url, "number": number,
             "is_pr": True, "prompt_id": prompts.prompt_version(tmpl),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The bot now posts a comment when a PR review finds no issues, instead of silently skipping. This gives PR authors confirmation that the bot reviewed their code.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
