### PR TITLE
Add HistogramBinned analyzer support for custom edges

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/HistogramBinned.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/HistogramBinned.scala
@@ -23,6 +23,7 @@ import com.amazon.deequ.metrics.BinData
 import com.amazon.deequ.metrics.DistributionBinned
 import com.amazon.deequ.metrics.DistributionValue
 import com.amazon.deequ.metrics.HistogramBinnedMetric
+import org.apache.spark.sql.Column
 import org.apache.spark.sql.DataFrame
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.functions.floor
@@ -48,7 +49,7 @@ import scala.util.Try
 case class HistogramBinned(
                             override val column: String,
                             binCount: Option[Int] = None,
-                            customEdges: Option[Array[Double]] = None, // TODO: implement
+                            customEdges: Option[Array[Double]] = None,
                             override val where: Option[String] = None,
                             override val computeFrequenciesAsRatio: Boolean = true,
                             // Reuse Histogram's AggregateFunction implementations since just grouping
@@ -60,11 +61,39 @@ case class HistogramBinned(
   require(binCount.isDefined ^ customEdges.isDefined,
     "Must specify either binCount (equal-width) or customEdges (custom)")
 
+  require(customEdges.forall(_.length >= 2),
+    "Custom edges must have at least 2 values")
+
+  // Array has reference equality in Scala; override so AnalyzerContext map
+  // lookups and serde round-trips compare contents, not references.
+  override def equals(obj: Any): Boolean = obj match {
+    case other: HistogramBinned =>
+      column == other.column &&
+        binCount == other.binCount &&
+        customEdges.map(_.toSeq) == other.customEdges.map(_.toSeq) &&
+        where == other.where &&
+        computeFrequenciesAsRatio == other.computeFrequenciesAsRatio &&
+        aggregateFunction == other.aggregateFunction
+    case _ => false
+  }
+
+  override def hashCode(): Int = {
+    (column, binCount, customEdges.map(_.toSeq), where,
+      computeFrequenciesAsRatio, aggregateFunction).hashCode()
+  }
+
   private var storedEdges: Array[Double] = _
 
   protected[this] val PARAM_CHECK: StructType => Unit = { _ =>
     binCount.foreach { count =>
       if (count > HistogramBinned.MaximumAllowedDetailBins) {
+        throw new IllegalAnalyzerParameterException(s"Cannot return histogram values for more " +
+          s"than ${HistogramBinned.MaximumAllowedDetailBins} bins")
+      }
+    }
+    customEdges.foreach { edges =>
+      val numBins = edges.length - 1
+      if (numBins > HistogramBinned.MaximumAllowedDetailBins) {
         throw new IllegalAnalyzerParameterException(s"Cannot return histogram values for more " +
           s"than ${HistogramBinned.MaximumAllowedDetailBins} bins")
       }
@@ -99,6 +128,45 @@ case class HistogramBinned(
     // Create binned data using DataFrame operations
     val binnedData = if (storedEdges.isEmpty) {
       filteredData.withColumn(column, lit(Histogram.NullFieldReplacement))
+    } else if (customEdges.isDefined) {
+      val edges = storedEdges
+
+      // Builds a balanced binary decision tree of when/otherwise expressions,
+      // giving O(log n) comparisons per row instead of O(n) for a linear chain.
+      // This matches Spark's own Bucketizer.binarySearchForBuckets approach
+      // (see org.apache.spark.ml.feature.Bucketizer) and matters at scale:
+      // e.g. 100 bins x 1B rows = ~7 comparisons/row vs ~99 for linear scan.
+      def buildBinaryCondition(binIndices: Seq[Int]): Column = {
+        if (binIndices.isEmpty) {
+          lit(Histogram.NullFieldReplacement)
+        } else if (binIndices.size == 1) {
+          // Single bin, check if value falls in this bin
+          val i = binIndices.head
+          val condition = if (i == edges.length - 2) {
+            // Last bin includes upper bound [a, b]
+            numericCol >= edges(i) && numericCol <= edges(i + 1)
+          } else {
+            // All other bins exclude upper bound [a, b)
+            numericCol >= edges(i) && numericCol < edges(i + 1)
+          }
+          when(condition, lit(i.toString)).otherwise(lit(Histogram.NullFieldReplacement))
+        } else {
+          // Split bins in half and create decision tree
+          val mid = binIndices.size / 2
+          val (leftBins, rightBins) = binIndices.splitAt(mid)
+          val splitEdge = edges(rightBins.head)
+
+          when(numericCol < splitEdge, buildBinaryCondition(leftBins))
+            .otherwise(buildBinaryCondition(rightBins))
+        }
+      }
+
+      val allBinIndices = (0 until edges.length - 1)
+      val binCondition = buildBinaryCondition(allBinIndices)
+      val finalCondition = when(numericCol.isNull, lit(Histogram.NullFieldReplacement))
+        .otherwise(binCondition)
+
+      filteredData.withColumn(column, finalCondition)
     } else {
       val minVal = storedEdges.head
       val binWidth = (storedEdges.last - storedEdges.head) / (storedEdges.length - 1)
@@ -120,7 +188,7 @@ case class HistogramBinned(
   }
 
   private def computeCustomEdges(): Array[Double] = {
-    throw new UnsupportedOperationException("Custom edges not yet implemented")
+    customEdges.get.sorted
   }
 
   private def computeEqualWidthEdges(filteredData: DataFrame,
@@ -181,7 +249,8 @@ case class HistogramBinned(
             binDataSeq
           }
 
-          val totalBins = finalBins.size // Count null and empty bins
+          // Total bins including empty bins and null bin, not just non-empty row count
+          val totalBins = finalBins.size
           DistributionBinned(finalBins, totalBins)
         }
 

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -596,11 +596,12 @@ case class Check(
       column: String,
       assertion: DistributionBinned => Boolean,
       binCount: Option[Int] = Some(HistogramBinned.DefaultBinCount),
+      customEdges: Option[Array[Double]] = None,
       hint: Option[String] = None)
     : CheckWithLastConstraintFilterable = {
 
     addFilterableConstraint { filter =>
-      histogramBinnedConstraint(column, assertion, binCount, filter, hint) }
+      histogramBinnedConstraint(column, assertion, binCount, customEdges, filter, hint) }
   }
 
   /**
@@ -619,11 +620,12 @@ case class Check(
       column: String,
       assertion: Long => Boolean,
       binCount: Option[Int] = Some(HistogramBinned.DefaultBinCount),
+      customEdges: Option[Array[Double]] = None,
       hint: Option[String] = None)
     : CheckWithLastConstraintFilterable = {
 
     addFilterableConstraint { filter =>
-      histogramBinnedBinConstraint(column, assertion, binCount, filter, hint) }
+      histogramBinnedBinConstraint(column, assertion, binCount, customEdges, filter, hint) }
   }
 
   /**

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -228,11 +228,15 @@ object Constraint {
       column: String,
       assertion: DistributionBinned => Boolean,
       binCount: Option[Int] = Some(HistogramBinned.DefaultBinCount),
+      customEdges: Option[Array[Double]] = None,
       where: Option[String] = None,
       hint: Option[String] = None)
     : Constraint = {
 
-    val histogramBinned = HistogramBinned(column, binCount, where = where)
+    // HistogramBinned requires exactly one of binCount or customEdges to be defined
+    // If customEdges is provided, we must set binCount to None
+    val actualBinCount = if (customEdges.isDefined) None else binCount
+    val histogramBinned = HistogramBinned(column, actualBinCount, customEdges, where = where)
 
     val constraint = AnalysisBasedConstraint[FrequenciesAndNumRows, DistributionBinned, DistributionBinned](
       histogramBinned, assertion, hint = hint)
@@ -247,11 +251,15 @@ object Constraint {
       column: String,
       assertion: Long => Boolean,
       binCount: Option[Int] = Some(HistogramBinned.DefaultBinCount),
+      customEdges: Option[Array[Double]] = None,
       where: Option[String] = None,
       hint: Option[String] = None)
     : Constraint = {
 
-    val histogramBinned = HistogramBinned(column, binCount, where = where)
+    // HistogramBinned requires exactly one of binCount or customEdges to be defined
+    // If customEdges is provided, we must set binCount to None
+    val actualBinCount = if (customEdges.isDefined) None else binCount
+    val histogramBinned = HistogramBinned(column, actualBinCount, customEdges, where = where)
 
     val constraint = AnalysisBasedConstraint[FrequenciesAndNumRows, DistributionBinned, Long](
       histogramBinned, assertion, Some(_.numberOfBins), hint)

--- a/src/test/scala/com/amazon/deequ/analyzers/HistogramBinnedTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/HistogramBinnedTest.scala
@@ -17,8 +17,14 @@
 package com.amazon.deequ.analyzers
 
 import com.amazon.deequ.SparkContextSpec
+import com.amazon.deequ.analyzers.runners.IllegalAnalyzerParameterException
 import com.amazon.deequ.analyzers.runners.MetricCalculationRuntimeException
 import com.amazon.deequ.utils.FixtureSupport
+import scala.util.Failure
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions.collect_list
+import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.functions.when
 import org.scalatest.matchers.should.Matchers
 import org.scalatest.wordspec.AnyWordSpec
 
@@ -328,19 +334,331 @@ class HistogramBinnedTest extends AnyWordSpec with Matchers with SparkContextSpe
   }
 
   "HistogramBinned (custom edges)" should {
-    "throw UnsupportedOperationException for custom edges (not yet implemented)" in withSparkSession { spark =>
+    "create bins with custom edges for integer data" in withSparkSession { spark =>
       import spark.implicits._
 
-      val data = Seq(1, 2, 3, 4, 5).toDF("values")
-      val customEdges = Array(1.0, 2.0, 3.0, 4.0, 5.0)
+      val data = Seq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 20, 25, 30).toDF("values")
+      val customEdges = Array(0.0, 5.0, 10.0, 20.0, 35.0)
 
       val histogram = HistogramBinned("values", customEdges = Some(customEdges))
       val result = histogram.calculate(data)
 
-      result.value.isFailure shouldBe true
-      result.value.failed.get shouldBe a[MetricCalculationRuntimeException]
-      result.value.failed.get.getCause shouldBe a[UnsupportedOperationException]
-      result.value.failed.get.getCause.getMessage shouldBe "Custom edges not yet implemented"
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      distribution.numberOfBins shouldBe 4
+      distribution.bins.size shouldBe 4
+
+      // Custom edges follow left-inclusive, right-exclusive convention [a, b) except last bin [a, b]
+      // Bin 0: [0.0, 5.0) - includes 0.0, excludes 5.0 -> values 1, 2, 3, 4
+      // Bin 1: [5.0, 10.0) - includes 5.0, excludes 10.0 -> values 5, 6, 7, 8, 9 (note: 5 is included, 10 is excluded)
+      // Bin 2: [10.0, 20.0) - includes 10.0, excludes 20.0 -> values 10, 15 (note: 10 is included here)
+      // Bin 3: [20.0, 35.0] - includes both bounds -> values 20, 25, 30
+
+      // Test exact bin ranges and counts
+      distribution(0).binStart shouldBe 0.0
+      distribution(0).binEnd shouldBe 5.0
+      distribution(0).frequency shouldBe 4  // values 1, 2, 3, 4
+
+      distribution(1).binStart shouldBe 5.0
+      distribution(1).binEnd shouldBe 10.0
+      distribution(1).frequency shouldBe 5  // values 5, 6, 7, 8, 9 (5 included, 10 excluded)
+
+      distribution(2).binStart shouldBe 10.0
+      distribution(2).binEnd shouldBe 20.0
+      distribution(2).frequency shouldBe 2  // values 10, 15 (10 included here)
+
+      distribution(3).binStart shouldBe 20.0
+      distribution(3).binEnd shouldBe 35.0
+      distribution(3).frequency shouldBe 3  // values 20, 25, 30
+
+      // Test interval strings
+      distribution.getInterval(0) shouldBe "[0.00, 5.00)"
+      distribution.getInterval(1) shouldBe "[5.00, 10.00)"
+      distribution.getInterval(2) shouldBe "[10.00, 20.00)"
+      distribution.getInterval(3) shouldBe "[20.00, 35.00]"
+    }
+
+    "create bins with custom edges for double data" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(1.1, 2.5, 3.7, 4.0, 4.2, 5.8, 6.3, 7.0, 7.9, 8.1, 9.4, 10.6).toDF("values")
+      val customEdges = Array(1.0, 4.0, 7.0, 11.0)
+
+      val histogram = HistogramBinned("values", customEdges = Some(customEdges))
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      distribution.numberOfBins shouldBe 3
+      distribution.bins.size shouldBe 3
+
+      // Custom edges follow left-inclusive, right-exclusive convention [a, b) except last bin [a, b]
+      // Bin 0: [1.0, 4.0) - includes 1.0, excludes 4.0 -> values 1.1, 2.5, 3.7 (note: 4.0 is excluded)
+      // Bin 1: [4.0, 7.0) - includes 4.0, excludes 7.0 -> values 4.0, 4.2, 5.8, 6.3 (note: 4.0 included, 7.0 excluded)
+      // Bin 2: [7.0, 11.0] - includes both bounds -> values 7.0, 7.9, 8.1, 9.4, 10.6 (note: 7.0 included here)
+
+      // Test exact bin ranges and counts
+      distribution(0).binStart shouldBe 1.0
+      distribution(0).binEnd shouldBe 4.0
+      distribution(0).frequency shouldBe 3  // values 1.1, 2.5, 3.7 (4.0 excluded)
+
+      distribution(1).binStart shouldBe 4.0
+      distribution(1).binEnd shouldBe 7.0
+      distribution(1).frequency shouldBe 4  // values 4.0, 4.2, 5.8, 6.3 (4.0 included, 7.0 excluded)
+
+      distribution(2).binStart shouldBe 7.0
+      distribution(2).binEnd shouldBe 11.0
+      distribution(2).frequency shouldBe 5  // values 7.0, 7.9, 8.1, 9.4, 10.6 (7.0 included here)
+
+      // Test interval strings
+      distribution.getInterval(0) shouldBe "[1.00, 4.00)"
+      distribution.getInterval(1) shouldBe "[4.00, 7.00)"
+      distribution.getInterval(2) shouldBe "[7.00, 11.00]"
+    }
+
+    "handle floating point precision at boundaries" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(9.999999999, 10.0, 10.000000001).toDF("values")
+      val customEdges = Array(0.0, 10.0, 20.0)
+
+      val histogram = HistogramBinned("values", customEdges = Some(customEdges))
+      val result = histogram.calculate(data).value.get
+      val distribution = result.bins
+
+      distribution.length shouldBe 2
+
+      // 9.999999999 should go in bin 0: [0.0, 10.0)
+      // 10.0 should go in bin 1: [10.0, 20.0]
+      // 10.000000001 should go in bin 1: [10.0, 20.0]
+      distribution(0).frequency shouldBe 1  // 9.999999999
+      distribution(1).frequency shouldBe 2  // 10.0, 10.000000001
+    }
+
+    "handle null values with custom edges" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(Some(1.0), None, Some(3.0), None, Some(5.0), Some(7.0), None, Some(9.0)).toDF("values")
+      val customEdges = Array(0.0, 4.0, 8.0, 10.0)
+
+      val histogram = HistogramBinned("values", customEdges = Some(customEdges))
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      distribution.numberOfBins shouldBe 4 // 3 numeric bins + 1 NullValue bin
+      distribution.bins.size shouldBe 4
+
+      // Check numeric bins (non-null values: 1, 3, 5, 7, 9)
+      distribution(0).binStart shouldBe 0.0
+      distribution(0).binEnd shouldBe 4.0
+      distribution(0).frequency shouldBe 2 // values 1.0, 3.0
+
+      distribution(1).binStart shouldBe 4.0
+      distribution(1).binEnd shouldBe 8.0
+      distribution(1).frequency shouldBe 2 // values 5.0, 7.0
+
+      distribution(2).binStart shouldBe 8.0
+      distribution(2).binEnd shouldBe 10.0
+      distribution(2).frequency shouldBe 1 // value 9.0
+
+      // Check NullValue bin
+      distribution(3).binStart shouldBe Double.NegativeInfinity
+      distribution(3).binEnd shouldBe Double.PositiveInfinity
+      distribution(3).frequency shouldBe 3 // 3 null values
+    }
+
+    "handle duplicate values at bin boundaries correctly" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(5.0, 5.0, 5.0, 10.0, 10.0, 15.0).toDF("values")
+      val customEdges = Array(0.0, 5.0, 10.0, 20.0)
+
+      val histogram = HistogramBinned("values", customEdges = Some(customEdges))
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      distribution.numberOfBins shouldBe 3
+      distribution.bins.size shouldBe 3
+
+      // Multiple 5.0 values should all go to bin 1 [5.0, 10.0)
+      // Multiple 10.0 values should all go to bin 2 [10.0, 20.0]
+      distribution(0).frequency shouldBe 0  // [0.0, 5.0) - empty
+      distribution(1).frequency shouldBe 3  // [5.0, 10.0) - three 5.0 values
+      distribution(2).frequency shouldBe 3  // [10.0, 20.0] - two 10.0 values + one 15.0
+    }
+
+    "work with single bin (two edges)" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(1, 2, 3, 4, 5).toDF("values")
+      val customEdges = Array(0.0, 10.0)
+
+      val histogram = HistogramBinned("values", customEdges = Some(customEdges))
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      distribution.numberOfBins shouldBe 1
+      distribution.bins.size shouldBe 1
+
+      // All values should go into the single bin [0.0, 10.0]
+      distribution(0).binStart shouldBe 0.0
+      distribution(0).binEnd shouldBe 10.0
+      distribution(0).frequency shouldBe 5
+      distribution.getInterval(0) shouldBe "[0.00, 10.00]"
+    }
+
+    "handle negative edges correctly" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(-10, -5, 0, 5, 10).toDF("values")
+      val customEdges = Array(-15.0, -2.0, 3.0, 12.0)
+
+      val histogram = HistogramBinned("values", customEdges = Some(customEdges))
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      distribution.numberOfBins shouldBe 3
+      distribution.bins.size shouldBe 3
+
+      // Bin 0: [-15.0, -2.0) should contain -10, -5
+      // Bin 1: [-2.0, 3.0) should contain 0
+      // Bin 2: [3.0, 12.0] should contain 5, 10
+      distribution(0).frequency shouldBe 2  // -10, -5
+      distribution(1).frequency shouldBe 1  // 0
+      distribution(2).frequency shouldBe 2  // 5, 10
+    }
+
+    "handle boundary values correctly" in withSparkSession { spark =>
+      import spark.implicits._
+
+      // Test values exactly on edges - critical for binary search correctness
+      val data = Seq(0.0, 5.0, 10.0, 15.0, 20.0).toDF("values")
+      val customEdges = Array(0.0, 5.0, 10.0, 20.0)
+
+      val histogram = HistogramBinned("values", customEdges = Some(customEdges))
+      val result = histogram.calculate(data).value.get
+      val distribution = result.bins
+
+      distribution.length shouldBe 3
+
+      // Bin 0: [0.0, 5.0) should contain 0.0 only
+      distribution(0).frequency shouldBe 1
+      distribution(0).binStart shouldBe 0.0
+      distribution(0).binEnd shouldBe 5.0
+
+      // Bin 1: [5.0, 10.0) should contain 5.0 only
+      distribution(1).frequency shouldBe 1
+      distribution(1).binStart shouldBe 5.0
+      distribution(1).binEnd shouldBe 10.0
+
+      // Bin 2: [10.0, 20.0] should contain 10.0, 15.0, 20.0 (last bin includes upper bound)
+      distribution(2).frequency shouldBe 3
+      distribution(2).binStart shouldBe 10.0
+      distribution(2).binEnd shouldBe 20.0
+    }
+
+    "handle gaps with empty bins" in withSparkSession { spark =>
+      import spark.implicits._
+
+      // Data that skips middle bins - tests binary search with sparse data
+      val data = Seq(1.0, 19.0).toDF("values")
+      val customEdges = Array(0.0, 5.0, 10.0, 15.0, 20.0)
+
+      val histogram = HistogramBinned("values", customEdges = Some(customEdges))
+      val result = histogram.calculate(data).value.get
+      val distribution = result.bins
+
+      distribution.length shouldBe 4
+
+      // Bin 0: [0.0, 5.0) should contain 1.0
+      distribution(0).frequency shouldBe 1
+
+      // Bin 1: [5.0, 10.0) should be empty
+      distribution(1).frequency shouldBe 0
+
+      // Bin 2: [10.0, 15.0) should be empty
+      distribution(2).frequency shouldBe 0
+
+      // Bin 3: [15.0, 20.0] should contain 19.0
+      distribution(3).frequency shouldBe 1
+    }
+
+    "handle unsorted custom edges by sorting them" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(1, 2, 3, 4, 5, 6, 7, 8, 9, 10).toDF("values")
+      val customEdges = Array(10.0, 0.0, 5.0) // unsorted
+
+      val histogram = HistogramBinned("values", customEdges = Some(customEdges))
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      distribution.numberOfBins shouldBe 2
+      distribution.bins.size shouldBe 2
+
+      // Should be sorted to [0.0, 5.0, 10.0]
+      distribution(0).binStart shouldBe 0.0
+      distribution(0).binEnd shouldBe 5.0
+      distribution(0).frequency shouldBe 4  // values 1, 2, 3, 4
+
+      distribution(1).binStart shouldBe 5.0
+      distribution(1).binEnd shouldBe 10.0
+      distribution(1).frequency shouldBe 6  // values 5, 6, 7, 8, 9, 10
+    }
+
+    "work with Sum aggregation and custom edges" in withSparkSession { spark =>
+      import spark.implicits._
+
+      // Tax bracket example: income ranges and total tax collected per bracket
+      val data = Seq(
+        (25000.0, 2500), // Low income bracket
+        (35000.0, 4200), // Low income bracket
+        (45000.0, 6750), // Middle income bracket
+        (75000.0, 15000), // Middle income bracket
+        (120000.0, 28800), // High income bracket
+        (200000.0, 54000) // High income bracket
+      ).toDF("income", "tax_paid")
+
+      // Tax brackets: 0-40k, 40k-100k, 100k+
+      val customEdges = Array(0.0, 40000.0, 100000.0, 300000.0)
+
+      val histogram = HistogramBinned(
+        "income",
+        customEdges = Some(customEdges),
+        aggregateFunction = Histogram.Sum("tax_paid")
+      )
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      distribution.numberOfBins shouldBe 3
+      distribution.bins.size shouldBe 3
+
+      // Verify sum aggregation - total tax collected per income bracket
+      distribution(0).frequency shouldBe 6700 // 2500 + 4200 (incomes 25k, 35k)
+      distribution(1).frequency shouldBe 21750 // 6750 + 15000 (incomes 45k, 75k)
+      distribution(2).frequency shouldBe 82800 // 28800 + 54000 (incomes 120k, 200k)
+
+      // Verify bin ranges represent tax brackets
+      distribution(0).binStart shouldBe 0.0
+      distribution(0).binEnd shouldBe 40000.0
+      distribution(1).binStart shouldBe 40000.0
+      distribution(1).binEnd shouldBe 100000.0
+      distribution(2).binStart shouldBe 100000.0
+      distribution(2).binEnd shouldBe 300000.0
     }
   }
 
@@ -357,6 +675,50 @@ class HistogramBinnedTest extends AnyWordSpec with Matchers with SparkContextSpe
         HistogramBinned("values", binCount = Some(5), customEdges = Some(Array(1.0, 2.0, 3.0)))
       }
       exception.getMessage should include("Must specify either binCount (equal-width) or customEdges (custom)")
+    }
+
+    "throw IllegalArgumentException when custom edges has less than 2 values" in withSparkSession { spark =>
+      val exception = intercept[IllegalArgumentException] {
+        HistogramBinned("values", customEdges = Some(Array(1.0)))
+      }
+      exception.getMessage should include("Custom edges must have at least 2 values")
+    }
+
+    "throw IllegalAnalyzerParameterException when equal edges creates too many bins" in withSparkSession { spark =>
+      import spark.implicits._
+      import com.amazon.deequ.analyzers.runners.AnalysisRunner
+
+      val data = Seq(1, 2, 3).toDF("values")
+      val histogram = HistogramBinned("values", binCount = Some(HistogramBinned.MaximumAllowedDetailBins + 1))
+
+      val analysis = AnalysisRunner.onData(data).addAnalyzer(histogram)
+      val result = analysis.run()
+
+      val metric = result.metricMap(histogram)
+      metric.value.isFailure shouldBe true
+      metric.value.asInstanceOf[Failure[Exception]].exception shouldBe a[IllegalAnalyzerParameterException]
+      metric.value.asInstanceOf[Failure[Exception]].exception.getMessage should include(
+        s"Cannot return histogram values for more than ${HistogramBinned.MaximumAllowedDetailBins} bins"
+      )
+    }
+
+    "throw IllegalAnalyzerParameterException when custom edges creates too many bins" in withSparkSession { spark =>
+      import spark.implicits._
+      import com.amazon.deequ.analyzers.runners.AnalysisRunner
+
+      val data = Seq(1, 2, 3).toDF("values")
+      val tooManyEdges = Array.range(0, HistogramBinned.MaximumAllowedDetailBins + 2).map(_.toDouble)
+      val histogram = HistogramBinned("values", customEdges = Some(tooManyEdges))
+
+      val analysis = AnalysisRunner.onData(data).addAnalyzer(histogram)
+      val result = analysis.run()
+
+      val metric = result.metricMap(histogram)
+      metric.value.isFailure shouldBe true
+      metric.value.asInstanceOf[Failure[Exception]].exception shouldBe a[IllegalAnalyzerParameterException]
+      metric.value.asInstanceOf[Failure[Exception]].exception.getMessage should include(
+        s"Cannot return histogram values for more than ${HistogramBinned.MaximumAllowedDetailBins} bins"
+      )
     }
   }
 }

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -716,6 +716,123 @@ class CheckTest extends AnyWordSpec with Matchers with SparkContextSpec with Fix
         assertEvaluatesTo(check9, context1, CheckStatus.Error)
       }
 
+    "return the correct check status for histogram binned constraints with custom edges" in
+      withSparkSession { sparkSession =>
+
+        // Create test data for custom edges (income tax bracket scenario)
+        val df = sparkSession.createDataFrame(Seq(
+          (1, Some(25000.0)), (2, Some(35000.0)), (3, Some(120000.0)), (4, Some(150000.0)),
+          (5, Some(65000.0)), (6, Some(200000.0)), (7, Some(45000.0)), (8, Some(55000.0)),
+          (9, Some(75000.0)), (10, Some(85000.0)), (11, Some(95000.0)), (12, None)
+        )).toDF("id", "income")
+
+        // Custom edges for tax brackets: 0-40k, 40k-100k, 100k-300k
+        val incomeEdges = Array(0.0, 40000.0, 100000.0, 300000.0)
+
+        // Bin-specific assertions with custom edges
+        val check1 = Check(CheckLevel.Error, "custom-edges-bin-tests")
+          .hasHistogramBinnedValues(
+            "income", _.bins(0).frequency >= 1, customEdges = Some(incomeEdges)
+          ) // Low bracket has values
+          .hasHistogramBinnedValues(
+            "income", _.bins(1).frequency >= 3, customEdges = Some(incomeEdges)
+          ) // Middle bracket has multiple values
+          .hasHistogramBinnedValues(
+            "income", _.bins(2).frequency >= 1, customEdges = Some(incomeEdges)
+          ) // High bracket has values
+
+        // Null handling with custom edges
+        val check2 = Check(CheckLevel.Error, "custom-edges-null-tests")
+          .hasHistogramBinnedValues(
+            "income",
+            _.bins.exists(_.binStart == Double.NegativeInfinity),
+            customEdges = Some(incomeEdges)
+          )
+          .hasHistogramBinnedValues(
+            "income",
+            _.bins.filter(_.binStart == Double.NegativeInfinity).head.frequency == 1,
+            customEdges = Some(incomeEdges)
+          )
+
+        // Distribution shape tests with custom edges
+        val check3 = Check(CheckLevel.Error, "custom-edges-distribution-tests")
+          .hasHistogramBinnedValues(
+            "income", _.bins.count(_.frequency > 0) >= 3, customEdges = Some(incomeEdges)
+          ) // All brackets have data
+          .hasHistogramBinnedValues(
+            "income", _.bins.exists(_.frequency >= 6), customEdges = Some(incomeEdges)
+          ) // Middle bracket is most populated
+          .hasHistogramBinnedValues(
+            "income", _.bins.forall(_.frequency <= 10), customEdges = Some(incomeEdges)
+          ) // No bracket too large
+
+        // Range / interval tests with custom edges
+        val check4 = Check(CheckLevel.Error, "custom-edges-range-tests")
+          .hasHistogramBinnedValues(
+            "income", _.bins(0).binStart == 0.0, customEdges = Some(incomeEdges)
+          ) // First bracket starts at 0
+          .hasHistogramBinnedValues(
+            "income", _.bins(0).binEnd == 40000.0, customEdges = Some(incomeEdges)
+          ) // First bracket ends at 40k
+          .hasHistogramBinnedValues(
+            "income", _.bins(1).binStart == 40000.0, customEdges = Some(incomeEdges)
+          ) // Second bracket starts at 40k
+          .hasHistogramBinnedValues(
+            "income", _.bins(2).binEnd == 300000.0, customEdges = Some(incomeEdges)
+          ) // Last bracket ends at 300k
+
+        // Statistical distribution tests with custom edges
+        val check5 = Check(CheckLevel.Error, "custom-edges-statistical-tests")
+          .hasHistogramBinnedValues(
+            "income",
+            _.bins.maxBy(_.frequency).binStart >= 40000.0,
+            customEdges = Some(incomeEdges)
+          ) // Peak in middle/high bracket
+          .hasHistogramBinnedValues(
+            "income",
+            _.bins.filter(_.binStart != Double.NegativeInfinity).forall(_.frequency >= 0),
+            customEdges = Some(incomeEdges)
+          )
+          .hasHistogramBinnedValues(
+            "income",
+            _.bins.map(_.frequency).sum >= 11,
+            customEdges = Some(incomeEdges)
+          ) // Total non-null values
+
+        // Bin structure tests with custom edges
+        val check6 = Check(CheckLevel.Error, "custom-edges-structure-tests")
+          .hasHistogramBinnedBins("income", _ >= 3)                 // Expected number of bins
+          .hasHistogramBinnedValues(
+            "income", _.numberOfBins >= 3, customEdges = Some(incomeEdges)
+          ) // numberOfBins matches
+          .hasHistogramBinnedValues("income", _.bins.filter(_.binStart != Double.NegativeInfinity)
+            .forall(b => b.binEnd > b.binStart), customEdges = Some(incomeEdges)) // Valid bin ranges
+
+        // Filtered constraint tests with custom edges
+        val check7 = Check(CheckLevel.Error, "custom-edges-filtered-tests")
+          .hasHistogramBinnedValues("income", _.bins.exists(_.frequency > 0), customEdges = Some(incomeEdges))
+          .where("id <= 6")    // Filter to first 6 rows (low-middle income)
+          .hasHistogramBinnedBins("income", _ >= 2)
+          .where("income > 100000")  // Filter to high income only
+
+        // Failure cases with custom edges
+        val check8 = Check(CheckLevel.Error, "custom-edges-failure-tests")
+          .hasHistogramBinnedValues("income", _.bins.isEmpty, customEdges = Some(incomeEdges)) // Should fail - has bins
+          .hasHistogramBinnedBins("income", _ == 0)           // Should fail - has bins
+
+        val context1 = runChecks(df, check1, check2, check3, check4, check5, check6)
+        val context2 = runChecks(df, check7)
+
+        assertEvaluatesTo(check1, context1, CheckStatus.Success)
+        assertEvaluatesTo(check2, context1, CheckStatus.Success)
+        assertEvaluatesTo(check3, context1, CheckStatus.Success)
+        assertEvaluatesTo(check4, context1, CheckStatus.Success)
+        assertEvaluatesTo(check5, context1, CheckStatus.Success)
+        assertEvaluatesTo(check6, context1, CheckStatus.Success)
+        assertEvaluatesTo(check7, context2, CheckStatus.Success)
+        assertEvaluatesTo(check8, context1, CheckStatus.Error)
+      }
+
     "return the correct check status for entropy constraints" in withSparkSession { sparkSession =>
 
       val expectedValue = -(0.75 * math.log(0.75) + 0.25 * math.log(0.25))

--- a/src/test/scala/com/amazon/deequ/constraints/ConstraintsTest.scala
+++ b/src/test/scala/com/amazon/deequ/constraints/ConstraintsTest.scala
@@ -95,6 +95,70 @@ class ConstraintsTest extends WordSpec with Matchers with SparkContextSpec with 
       calculate(Constraint.histogramBinnedConstraint("value",
         _.bins.map(_.frequency).sum > 5), df).status shouldBe ConstraintStatus.Failure
     }
+
+    "succeed for valid custom edges binned distribution assertions" in withSparkSession { sparkSession =>
+      val df = sparkSession.createDataFrame(Seq(
+        (1, 15000.0), (2, 25000.0), (3, 35000.0), (4, 45000.0), (5, 55000.0),
+        (6, 75000.0), (7, 85000.0), (8, 120000.0), (9, 180000.0)
+      )).toDF("id", "income")
+
+      val incomeEdges = Array(0.0, 40000.0, 100000.0, 200000.0)
+
+      // Test custom edges constraint - should have 3 bins
+      calculate(Constraint.histogramBinnedConstraint("income",
+        _.numberOfBins == 3, customEdges = Some(incomeEdges)), df).status shouldBe ConstraintStatus.Success
+
+      calculate(Constraint.histogramBinnedBinConstraint("income",
+        _ == 3, customEdges = Some(incomeEdges)), df).status shouldBe ConstraintStatus.Success
+
+      // Test specific bin frequencies with custom edges
+      calculate(Constraint.histogramBinnedConstraint("income",
+        _.bins(0).frequency == 3,
+        customEdges = Some(incomeEdges)), df
+      ).status shouldBe ConstraintStatus.Success  // Low bracket: 15k, 25k, 35k
+
+      calculate(Constraint.histogramBinnedConstraint("income",
+        _.bins(1).frequency == 4,
+        customEdges = Some(incomeEdges)), df
+      ).status shouldBe ConstraintStatus.Success  // Middle bracket: 45k, 55k, 75k, 85k
+
+      calculate(Constraint.histogramBinnedConstraint("income",
+        _.bins(2).frequency == 2,
+        customEdges = Some(incomeEdges)), df
+      ).status shouldBe ConstraintStatus.Success  // High bracket: 120k, 180k
+
+      // Test bin ranges with custom edges
+      calculate(Constraint.histogramBinnedConstraint("income",
+        (dist => dist.bins(0).binStart == 0.0 && dist.bins(0).binEnd == 40000.0),
+        customEdges = Some(incomeEdges)), df
+      ).status shouldBe ConstraintStatus.Success
+
+      calculate(Constraint.histogramBinnedConstraint("income",
+        (dist => dist.bins(1).binStart == 40000.0 && dist.bins(1).binEnd == 100000.0),
+        customEdges = Some(incomeEdges)), df
+      ).status shouldBe ConstraintStatus.Success
+
+      calculate(Constraint.histogramBinnedConstraint("income",
+        (dist => dist.bins(2).binStart == 100000.0 && dist.bins(2).binEnd == 200000.0),
+        customEdges = Some(incomeEdges)), df
+      ).status shouldBe ConstraintStatus.Success
+    }
+
+    "fail for invalid custom edges binned distribution assertions" in withSparkSession { sparkSession =>
+      val df = sparkSession.createDataFrame(Seq(
+        (1, 25000.0), (2, 75000.0)
+      )).toDF("id", "income")
+
+      val customEdges = Array(0.0, 50000.0, 100000.0)
+
+      // Should fail - expecting 3 bins but assertion is wrong
+      calculate(Constraint.histogramBinnedConstraint("income",
+        _.numberOfBins == 5, customEdges = Some(customEdges)), df).status shouldBe ConstraintStatus.Failure
+
+      // Should fail - wrong frequency expectation
+      calculate(Constraint.histogramBinnedConstraint("income",
+        _.bins(0).frequency == 5, customEdges = Some(customEdges)), df).status shouldBe ConstraintStatus.Failure
+    }
   }
 
   "Mutual information constraint" should {

--- a/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
@@ -492,6 +492,90 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
     assert(deserialize(histogramBinnedWithNullsJson) == List(expected))
   }
 
+  val histogramBinnedCustomEdgesJson =
+      """[
+        |  {
+        |    "resultKey": {
+        |      "dataSetDate": 0,
+        |      "tags": {}
+        |    },
+        |    "analyzerContext": {
+        |      "metricMap": [
+        |        {
+        |          "analyzer": {
+        |            "analyzerName": "HistogramBinned",
+        |            "column": "income",
+        |            "customEdges": [
+        |              0.0,
+        |              40000.0,
+        |              100000.0,
+        |              200000.0
+        |            ]
+        |          },
+        |          "metric": {
+        |            "metricName": "HistogramBinnedMetric",
+        |            "column": "income",
+        |            "numberOfBins": 3,
+        |            "value": {
+        |              "numberOfBins": 3,
+        |              "bins": [
+        |                {
+        |                  "binStart": 0.0,
+        |                  "binEnd": 40000.0,
+        |                  "frequency": 2,
+        |                  "ratio": 0.4
+        |                },
+        |                {
+        |                  "binStart": 40000.0,
+        |                  "binEnd": 100000.0,
+        |                  "frequency": 2,
+        |                  "ratio": 0.4
+        |                },
+        |                {
+        |                  "binStart": 100000.0,
+        |                  "binEnd": 200000.0,
+        |                  "frequency": 1,
+        |                  "ratio": 0.2
+        |                }
+        |              ]
+        |            }
+        |          }
+        |        }
+        |      ]
+        |    }
+        |  }
+        |]""".stripMargin
+
+  "HistogramBinned serialization" should "properly serialize custom edges binned distribution" in {
+    val expected = histogramBinnedCustomEdgesJson
+    val customEdges = Array(0.0, 40000.0, 100000.0, 200000.0)
+    val analyzer = HistogramBinned("income", customEdges = Some(customEdges))
+    val metric = HistogramBinnedMetric("income", Success(DistributionBinned(
+      Vector(
+        BinData(0.0, 40000.0, 2, 0.4),
+        BinData(40000.0, 100000.0, 2, 0.4),
+        BinData(100000.0, 200000.0, 1, 0.2)
+      ), 3)))
+    val context = AnalyzerContext(Map(analyzer -> metric))
+    val result = new AnalysisResult(ResultKey(0), context)
+
+    assert(serialize(List(result)) == expected)
+  }
+
+  "HistogramBinned deserialization" should "properly deserialize custom edges binned distribution" in {
+    val customEdges = Array(0.0, 40000.0, 100000.0, 200000.0)
+    val analyzer = HistogramBinned("income", customEdges = Some(customEdges))
+    val metric = HistogramBinnedMetric("income", Success(DistributionBinned(
+      Vector(
+        BinData(0.0, 40000.0, 2, 0.4),
+        BinData(40000.0, 100000.0, 2, 0.4),
+        BinData(100000.0, 200000.0, 1, 0.2)
+      ), 3)))
+    val context = AnalyzerContext(Map(analyzer -> metric))
+    val expected = new AnalysisResult(ResultKey(0), context)
+    assert(deserialize(histogramBinnedCustomEdgesJson) == List(expected))
+  }
+
   def assertCorrectlyConvertsAnalysisResults(
       analysisResults: Seq[AnalysisResult],
       shouldFail: Boolean = false)


### PR DESCRIPTION
### Description of changes
Implements custom bin edges support for the `HistogramBinned` analyzer. Previously, `customEdges` was accepted as a parameter but threw `UnsupportedOperationException` at runtime. This PR makes it fully functional.

#### What it does
Users can now specify exact bin boundaries instead of relying on equal-width auto-computed bins. This enables domain-specific binning (e.g., tax brackets, age groups, score ranges) where equal-width bins don't make sense.

#### Bin semantics
- All bins are left-inclusive, right-exclusive: `[a, b)`
- Last bin is inclusive on both sides: `[a, b]`
- Null values get a separate implicit bin (not part of the custom edges)
- Values outside the specified range go to the null bin (overflow being added in follow-up)
- Unsorted edges are automatically sorted

#### Implementation: binary search decision tree

The binning logic builds a balanced binary tree of Spark when/otherwise expressions, giving `O(log n)` comparisons per row instead of `O(n)` for a linear chain. This matches Spark's own `Bucketizer.binarySearchForBuckets` approach and matters at scale (e.g., 100 bins x 1B rows = ~7 comparisons/row vs ~99 for linear scan) .

#### Changes
- `HistogramBinned.scala`: implements `computeCustomEdges()`, adds binary search binning logic, adds validation for min 2 edges and max bin count
- `Check.scala`: adds `customEdges` parameter to `hasHistogramBinnedValues` and `hasHistogramBinnedBins`
- `Constraint.scala`: adds `customEdges` parameter to `histogramBinnedConstraint` and `histogramBinnedBinConstraint`, handles the XOR requirement (sets `binCount = None` when `customEdges` is provided)
- `HistogramBinned.scala`: adds `equals`/`hashCode` override for structural equality of `Array[Double]` in `AnalyzerContext` map lookups
- 
#### Breaking changes
- `hasHistogramBinnedValues` and `hasHistogramBinnedBins` in `Check.scala` have a new `customEdges` parameter inserted before `hint`. Positional callers will need to add the parameter name. Named-argument callers are unaffected.

### Testing
- **Integer data**: verifies correct bin assignment for values 1–30 across 4 custom bins
- **Double data**: verifies fractional values land in correct bins with edges [1.0, 4.0, 7.0, 11.0]
- **Floating point precision at boundaries**: values like 9.999999999 vs 10.0 land in correct bins
- **Null handling**: nulls get a separate bin, don't interfere with numeric bins
- **Duplicate values at bin boundaries**: multiple values exactly on an edge all go to the correct bin
- **Single bin (two edges)**: minimal valid configuration works
- **Negative edges**: bins with negative boundaries work correctly
- **Boundary values**: values exactly on every edge are assigned correctly (critical for binary search)
- **Empty bins**: sparse data with gaps produces bins with frequency 0
- **Unsorted edges**: edges provided out of order are sorted automatically
- **Sum aggregation with custom edges**: tax bracket example aggregating `tax_paid` per income bracket
- **Error cases**: fewer than 2 edges rejected, exceeding max bin count rejected
- **Check API integration**: full `CheckTest` with custom edges through `hasHistogramBinnedValues`
- **Constraint-level tests**: success and failure cases through `histogramBinnedConstraint`
- **Serialization round-trip**: custom edges survive serialize/deserialize via `AnalysisResultSerde`

##### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
