### PR TITLE
fix: serialize Histogram where filter in MetricsRepository (#271)

### DIFF
--- a/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
+++ b/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
@@ -355,6 +355,7 @@ private[deequ] object AnalyzerSerializer
         result.addProperty(ANALYZER_NAME_FIELD, "Histogram")
         result.addProperty(COLUMN_FIELD, histogram.column)
         result.addProperty("maxDetailBins", histogram.maxDetailBins)
+        result.addProperty(WHERE_FIELD, histogram.where.orNull)
         // Count is initial and default implementation for Histogram
         // We don't include fields below in json to preserve json backward compatibility.
         if (histogram.aggregateFunction != Histogram.Count) {
@@ -371,6 +372,7 @@ private[deequ] object AnalyzerSerializer
         if (histogramBinned.customEdges.isDefined) {
           result.add("customEdges", context.serialize(histogramBinned.customEdges.get))
         }
+        result.addProperty(WHERE_FIELD, histogramBinned.where.orNull)
 
       case _ : Histogram =>
         throw new IllegalArgumentException("Unable to serialize Histogram with binningUdf!")
@@ -589,6 +591,7 @@ private[deequ] object AnalyzerDeserializer
           json.get(COLUMN_FIELD).getAsString,
           None,
           json.get("maxDetailBins").getAsInt,
+          getOptionalWhereParam(json),
           aggregateFunction = createAggregateFunction(
             getOptionalStringParam(json, "aggregateFunction").getOrElse(Histogram.count_function),
             getOptionalStringParam(json, "aggregateColumn").getOrElse("")))
@@ -601,7 +604,8 @@ private[deequ] object AnalyzerDeserializer
         HistogramBinned(
           json.get(COLUMN_FIELD).getAsString,
           binCount,
-          customEdges)
+          customEdges,
+          getOptionalWhereParam(json))
 
       case "DataType" =>
         DataType(

--- a/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
@@ -72,6 +72,9 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
       Histogram("ColumnA", None, 5) ->
         HistogramMetric("ColumnA", Success(Distribution(
           Map("some" -> DistributionValue(10, 0.5)), 10))),
+      Histogram("ColumnA", None, Histogram.MaximumAllowedDetailBins, Some("id > 5")) ->
+        HistogramMetric("ColumnA", Success(Distribution(
+          Map("filtered" -> DistributionValue(3, 0.6)), 5))),
       HistogramBinned("ColumnA", Some(5)) ->
         HistogramBinnedMetric("ColumnA", Success(DistributionBinned(
           Vector(BinData(0.0, 10.0, 5, 0.5), BinData(10.0, 20.0, 5, 0.5)), 2))),
@@ -79,6 +82,9 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
         HistogramBinnedMetric("ColumnA", Success(DistributionBinned(
           Vector(BinData(Double.NegativeInfinity, Double.NegativeInfinity, 2, 0.2),
                  BinData(0.0, 15.0, 4, 0.4), BinData(15.0, 30.0, 4, 0.4)), 3))),
+      HistogramBinned("ColumnA", Some(5), None, Some("id > 3")) ->
+        HistogramBinnedMetric("ColumnA", Success(DistributionBinned(
+          Vector(BinData(0.0, 10.0, 3, 0.6), BinData(10.0, 20.0, 2, 0.4)), 2))),
       Entropy("ColumnA") ->
         DoubleMetric(Entity.Column, "Completeness", "ColumnA", Success(5.0)),
       MutualInformation(Seq("ColumnA", "ColumnB")) ->


### PR DESCRIPTION
### Description of changes

Fixes #271. 

The `where` filter was not being serialized/deserialized for `Histogram` and `HistogramBinned` in `AnalysisResultSerde`, causing filtered metrics to lose their filter when stored in a MetricsRepository.

### Changes

- Serialize: add `WHERE_FIELD` to `Histogram` and `HistogramBinned`case in `AnalyzerSerializer`
- Deserialize: add `getOptionalWhereParam(json)` to Histogram and `HistogramBinned` case in `AnalyzerDeserializer`
- Test: add Histogram  and `HistogramBinned`with `where` filter to serde round-trip test

### Testing

1129/1129 tests pass. TDD red-green cycle verified: test fails without fix, passes with fix.

### Backward compatibility

Old JSON without `where` field deserializes correctly (defaults to `None`).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.