### PR TITLE
Add overflow bins support to HistogramBinned

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/HistogramBinned.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/HistogramBinned.scala
@@ -239,19 +239,10 @@ case class HistogramBinned(
             BinData(binStart, binEnd, distValue.absolute, distValue.ratio)
           }.toVector
 
-          // Add NullValue bin if it exists
-          val finalBins = if (histogramDetails.contains(Histogram.NullFieldReplacement)) {
-            val nullDistValue = histogramDetails(Histogram.NullFieldReplacement)
-            val nullBin = BinData(Double.NegativeInfinity, Double.PositiveInfinity,
-                                 nullDistValue.absolute, nullDistValue.ratio)
-            binDataSeq :+ nullBin
-          } else {
-            binDataSeq
-          }
+          val nullCount = histogramDetails.get(Histogram.NullFieldReplacement)
+            .map(_.absolute).getOrElse(0L)
 
-          // Total bins including empty bins and null bin, not just non-empty row count
-          val totalBins = finalBins.size
-          DistributionBinned(finalBins, totalBins)
+          DistributionBinned(binDataSeq, binDataSeq.size, nullCount)
         }
 
         HistogramBinnedMetric(column, value)

--- a/src/main/scala/com/amazon/deequ/metrics/HistogramBinnedMetric.scala
+++ b/src/main/scala/com/amazon/deequ/metrics/HistogramBinnedMetric.scala
@@ -24,7 +24,8 @@ case class BinData(binStart: Double, binEnd: Double, frequency: Long, ratio: Dou
 
 case class DistributionBinned(
   bins: Vector[BinData],
-  numberOfBins: Long
+  numberOfBins: Long,
+  nullCount: Long = 0
 ) {
 
   def apply(index: Int): BinData = bins(index)

--- a/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
+++ b/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
@@ -940,6 +940,11 @@ private[deequ] object DistributionBinnedSerializer extends JsonSerializer[Distri
     }
 
     result.add("bins", bins)
+
+    if (distributionBinned.nullCount > 0) {
+      result.addProperty("nullCount", distributionBinned.nullCount)
+    }
+
     result
   }
 }
@@ -963,7 +968,11 @@ private[deequ] object DistributionBinnedDeserializer extends JsonDeserializer[Di
       }
       .toVector
 
-    DistributionBinned(bins, jsonObject.get("numberOfBins").getAsLong)
+    val nullCount = if (jsonObject.has("nullCount")) {
+      jsonObject.get("nullCount").getAsLong
+    } else 0L
+
+    DistributionBinned(bins, jsonObject.get("numberOfBins").getAsLong, nullCount)
   }
 }
 

--- a/src/test/scala/com/amazon/deequ/analyzers/HistogramBinnedTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/HistogramBinnedTest.scala
@@ -171,8 +171,8 @@ class HistogramBinnedTest extends AnyWordSpec with Matchers with SparkContextSpe
       result.value.isSuccess shouldBe true
       val distribution = result.value.get
 
-      distribution.numberOfBins shouldBe 4 // 3 numeric bins + 1 NullValue bin
-      distribution.bins.size shouldBe 4
+      distribution.numberOfBins shouldBe 3 // only data bins
+      distribution.bins.size shouldBe 3
 
       // Check numeric bins (non-null values: 1, 3, 5, 7, 9)
       distribution(0).binStart shouldBe 1.0
@@ -190,11 +190,8 @@ class HistogramBinnedTest extends AnyWordSpec with Matchers with SparkContextSpe
       distribution(2).frequency shouldBe 2 // values 7.0, 9.0
       distribution(2).ratio shouldBe 2.0 / 8.0 +- 0.001
 
-      // Check NullValue bin
-      distribution(3).binStart shouldBe Double.NegativeInfinity
-      distribution(3).binEnd shouldBe Double.PositiveInfinity
-      distribution(3).frequency shouldBe 3 // 3 null values
-      distribution(3).ratio shouldBe 3.0 / 8.0 +- 0.001
+      // Null count is separate
+      distribution.nullCount shouldBe 3
     }
 
     "aggregate sum works as expected" in withSparkSession { spark =>
@@ -253,20 +250,17 @@ class HistogramBinnedTest extends AnyWordSpec with Matchers with SparkContextSpe
       result.value.isSuccess shouldBe true
       val distribution = result.value.get
 
-      distribution.numberOfBins shouldBe 4 // 3 numeric bins + 1 NullValue bin
-      distribution.bins.size shouldBe 4
+      distribution.numberOfBins shouldBe 3 // only data bins
+      distribution.bins.size shouldBe 3
 
       // Verify sum aggregation with nulls handled
-      // Null prices go to NullValue bin
       // Null revenues are treated as 0 in the sum
       distribution(0).frequency shouldBe 125 // 50 + 75 (prices 100, 150)
       distribution(1).frequency shouldBe 125 // 0 + 125 (price 250 has null revenue, price 300 has 125)
       distribution(2).frequency shouldBe 200 // 200 (price 450)
 
-      // NullValue bin gets sum of revenues for null prices
-      distribution(3).frequency shouldBe 1887 // 999 + 888 (null prices)
-      distribution(3).binStart shouldBe Double.NegativeInfinity
-      distribution(3).binEnd shouldBe Double.PositiveInfinity
+      // NullValue tracked separately
+      distribution.nullCount shouldBe 1887 // 999 + 888 (null prices)
 
       // Verify bin ranges (based only on non-null prices: 100, 150, 250, 300, 450)
       distribution(0).binStart shouldBe 100.0
@@ -290,15 +284,12 @@ class HistogramBinnedTest extends AnyWordSpec with Matchers with SparkContextSpe
       result.value.isSuccess shouldBe true
       val distribution = result.value.get
 
-      // Should have 1 bin for the "NullValue" category (like Histogram does)
-      distribution.numberOfBins shouldBe 1
-      distribution.bins.size shouldBe 1
+      // No data bins when all values are null
+      distribution.numberOfBins shouldBe 0
+      distribution.bins.size shouldBe 0
 
-      // All nulls become "NullValue" bin - verify it's the special infinity-range bin
-      val nullBin = distribution.bins.head
-      nullBin.binStart shouldBe Double.NegativeInfinity
-      nullBin.binEnd shouldBe Double.PositiveInfinity
-      nullBin.frequency shouldBe 4
+      // All nulls tracked in nullCount
+      distribution.nullCount shouldBe 4
     }
 
     "numberOfBins should reflect total bins including empty ones for equal width" in withSparkSession { spark =>
@@ -310,26 +301,23 @@ class HistogramBinnedTest extends AnyWordSpec with Matchers with SparkContextSpe
       val histogram = HistogramBinned("values", binCount = Some(5)) // Creates 5 equal-width bins
       val result = histogram.calculate(data).value.get
 
-      // numberOfBins should include all bins (regular + null)
-      result.numberOfBins shouldBe 6
+      // numberOfBins is only data bins
+      result.numberOfBins shouldBe 5
 
-      // bins collection should include all bins (empty, non-empty, and null)
-      result.bins.length shouldBe 6
+      // bins collection has only data bins
+      result.bins.length shouldBe 5
 
       // Bin 0: [1.0, 2.6) contains 1.0
-      // Bins 1-3: empty.
+      // Bins 1-3: empty
       // Bin 4: [7.4, 9.0] contains 9.0
-      // Bin 5: null bin contains 2 null values
       result.bins(0).frequency shouldBe 1 // Contains 1.0
       result.bins(1).frequency shouldBe 0 // Empty
       result.bins(2).frequency shouldBe 0 // Empty
       result.bins(3).frequency shouldBe 0 // Empty
       result.bins(4).frequency shouldBe 1 // Contains 9.0
-      result.bins(5).frequency shouldBe 2 // Contains 2 null values
 
-      // Total values should include nulls for consistency with Histogram
-      val totalValues = result.bins.map(_.frequency).sum
-      totalValues shouldBe 4 // 2 non-null + 2 null values
+      // Nulls tracked separately
+      result.nullCount shouldBe 2
     }
   }
 
@@ -449,8 +437,8 @@ class HistogramBinnedTest extends AnyWordSpec with Matchers with SparkContextSpe
       result.value.isSuccess shouldBe true
       val distribution = result.value.get
 
-      distribution.numberOfBins shouldBe 4 // 3 numeric bins + 1 NullValue bin
-      distribution.bins.size shouldBe 4
+      distribution.numberOfBins shouldBe 3 // only data bins
+      distribution.bins.size shouldBe 3
 
       // Check numeric bins (non-null values: 1, 3, 5, 7, 9)
       distribution(0).binStart shouldBe 0.0
@@ -465,10 +453,8 @@ class HistogramBinnedTest extends AnyWordSpec with Matchers with SparkContextSpe
       distribution(2).binEnd shouldBe 10.0
       distribution(2).frequency shouldBe 1 // value 9.0
 
-      // Check NullValue bin
-      distribution(3).binStart shouldBe Double.NegativeInfinity
-      distribution(3).binEnd shouldBe Double.PositiveInfinity
-      distribution(3).frequency shouldBe 3 // 3 null values
+      // Null count is separate
+      distribution.nullCount shouldBe 3
     }
 
     "handle duplicate values at bin boundaries correctly" in withSparkSession { spark =>

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -695,10 +695,9 @@ class CheckTest extends AnyWordSpec with Matchers with SparkContextSpec with Fix
 
         // Null handling
         val check2 = Check(CheckLevel.Error, "null-handling-tests")
-          // Null bin exists and has one value
-          .hasHistogramBinnedValues("value", _.bins.exists(_.binStart == Double.NegativeInfinity), Some(5))
-          .hasHistogramBinnedValues("value",
-            _.bins.filter(_.binStart == Double.NegativeInfinity).head.frequency == 1, Some(5))
+          // Null count exists and has one value
+          .hasHistogramBinnedValues("value", _.nullCount > 0, Some(5))
+          .hasHistogramBinnedValues("value", _.nullCount == 1, Some(5))
 
         // Distribution shape tests
         val check3 = Check(CheckLevel.Error, "distribution-shape-tests")
@@ -731,8 +730,7 @@ class CheckTest extends AnyWordSpec with Matchers with SparkContextSpec with Fix
         val check6 = Check(CheckLevel.Error, "bin-structure-tests")
           .hasHistogramBinnedBins("value", _ >= 5, Some(5))                 // Expected number of bins
           .hasHistogramBinnedValues("value", _.numberOfBins >= 5, Some(5))  // numberOfBins matches
-          .hasHistogramBinnedValues("value", _.bins.filter(_.binStart != Double.NegativeInfinity)
-            .forall(b => b.binEnd > b.binStart), Some(5)) // Valid bin ranges
+          .hasHistogramBinnedValues("value", _.bins.forall(b => b.binEnd > b.binStart), Some(5)) // Valid bin ranges
 
         // Filtered constraint tests (WHERE clauses)
         val check7 = Check(CheckLevel.Error, "filtered-binned-tests")
@@ -799,12 +797,12 @@ class CheckTest extends AnyWordSpec with Matchers with SparkContextSpec with Fix
         val check2 = Check(CheckLevel.Error, "custom-edges-null-tests")
           .hasHistogramBinnedValues(
             "income",
-            _.bins.exists(_.binStart == Double.NegativeInfinity),
+            _.nullCount > 0,
             customEdges = Some(incomeEdges)
           )
           .hasHistogramBinnedValues(
             "income",
-            _.bins.filter(_.binStart == Double.NegativeInfinity).head.frequency == 1,
+            _.nullCount == 1,
             customEdges = Some(incomeEdges)
           )
 
@@ -844,7 +842,7 @@ class CheckTest extends AnyWordSpec with Matchers with SparkContextSpec with Fix
           ) // Peak in middle/high bracket
           .hasHistogramBinnedValues(
             "income",
-            _.bins.filter(_.binStart != Double.NegativeInfinity).forall(_.frequency >= 0),
+            _.bins.forall(_.frequency >= 0),
             customEdges = Some(incomeEdges)
           )
           .hasHistogramBinnedValues(
@@ -859,8 +857,8 @@ class CheckTest extends AnyWordSpec with Matchers with SparkContextSpec with Fix
           .hasHistogramBinnedValues(
             "income", _.numberOfBins >= 3, customEdges = Some(incomeEdges)
           ) // numberOfBins matches
-          .hasHistogramBinnedValues("income", _.bins.filter(_.binStart != Double.NegativeInfinity)
-            .forall(b => b.binEnd > b.binStart), customEdges = Some(incomeEdges)) // Valid bin ranges
+          .hasHistogramBinnedValues("income", _.bins.forall(b => b.binEnd > b.binStart),
+            customEdges = Some(incomeEdges)) // Valid bin ranges
 
         // Filtered constraint tests with custom edges
         val check7 = Check(CheckLevel.Error, "custom-edges-filtered-tests")

--- a/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
@@ -387,16 +387,10 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
         |          "metric": {
         |            "metricName": "HistogramBinnedMetric",
         |            "column": "columnA",
-        |            "numberOfBins": 3,
+        |            "numberOfBins": 2,
         |            "value": {
-        |              "numberOfBins": 3,
+        |              "numberOfBins": 2,
         |              "bins": [
-        |                {
-        |                  "binStart": -Infinity,
-        |                  "binEnd": -Infinity,
-        |                  "frequency": 2,
-        |                  "ratio": 0.2
-        |                },
         |                {
         |                  "binStart": 0.0,
         |                  "binEnd": 15.0,
@@ -409,7 +403,8 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
         |                  "frequency": 4,
         |                  "ratio": 0.4
         |                }
-        |              ]
+        |              ],
+        |              "nullCount": 2
         |            }
         |          }
         |        }
@@ -476,10 +471,9 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
     val analyzer = HistogramBinned("columnA", Some(3))
     val metric = HistogramBinnedMetric("columnA", Success(DistributionBinned(
       Vector(
-        BinData(Double.NegativeInfinity, Double.NegativeInfinity, 2, 0.2),
         BinData(0.0, 15.0, 4, 0.4),
         BinData(15.0, 30.0, 4, 0.4)
-      ), 3)))
+      ), 2, 2)))
     val context = AnalyzerContext(Map(analyzer -> metric))
     val result = new AnalysisResult(ResultKey(0), context)
     assert(serialize(Seq(result)) == expected)
@@ -489,10 +483,9 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
     val analyzer = HistogramBinned("columnA", Some(3))
     val metric = HistogramBinnedMetric("columnA", Success(DistributionBinned(
       Vector(
-        BinData(Double.NegativeInfinity, Double.NegativeInfinity, 2, 0.2),
         BinData(0.0, 15.0, 4, 0.4),
         BinData(15.0, 30.0, 4, 0.4)
-      ), 3)))
+      ), 2, 2)))
     val context = AnalyzerContext(Map(analyzer -> metric))
     val expected = new AnalysisResult(ResultKey(0), context)
     assert(deserialize(histogramBinnedWithNullsJson) == List(expected))


### PR DESCRIPTION
### Description of changes

Adds overflow bin support to `HistogramBinned`. When `includeOverflowBins = true`, the analyzer prepends `-Infinity` and appends `+Infinity` to the bin edges, creating dedicated bins for out-of-range values instead of lumping them with nulls.

#### API

```
// Auto-compute with overflow
HistogramBinned("age", binCount = Some(10), includeOverflowBins = true)
// Result: 10 data bins + 2 overflow + optional null bin
```
```
// Custom edges with overflow
HistogramBinned("income", customEdges = Some(Array(0.0, 40000.0, 100000.0)), includeOverflowBins = true)
// Result: [-Inf, 0) + [0, 40k) + [40k, 100k) + [100k, Inf] + optional null bin
```

#### Behavior

- `includeOverflowBins = false` (default): current behavior unchanged. Out-of-range values go to null bin.
- `includeOverflowBins = true`: prepends `-Inf` and appends `+`Inf to edges (skips if already present). Out-of-range values land in overflow bins, null bin only contains actual nulls.
- Overflow bins are additional, `binCount = 10` gives 10 data bins + 2 overflow, not 8 + 2.
- When overflow is enabled with auto-compute, the binary search path is used instead of the floor formula (which breaks with infinity arithmetic).

#### Interval formatting

- Left overflow: `(-Inf, 0.00)`
- Data bins: `[0.00, 10.00)`
- Right overflow: `[20.00, Inf)`

#### Changes

- `HistogramBinned.scala`: adds `includeOverflowBins` parameter, `addOverflowEdges` helper, routes to binary search path when overflow enabled, `updates equals`/`hashCode`
- `HistogramBinnedMetric.scala`: infinity-aware interval string formatting
- `AnalysisResultSerde.scala`: serialize/deserialize `includeOverflowBins`

### Testing

- **Custom edges with overflow**: verifies 2 overflow + 2 data bins, correct routing
- **Auto-computed edges with overflow**: verifies overflow bins added, max value lands in right overflow
- **No duplicate infinity edges**: passing edges that already have `-Inf`/`Inf` doesn't double them
- **Nulls separated from overflow**: nulls go to null bin, out-of-range goes to overflow bins
- **Unsorted edges with overflow**: sort + overflow applied correctly
- **Boundary values with overflow**: values exactly on custom edges route correctly when overflow changes last-bin semantics
- **Single edge pair with overflow**: minimal config (2 edges + overflow = 3 bins)
- **Sum aggregation with overflow**: aggregate function works with overflow bins
- **Where filter with overflow**: filtered data routes correctly
- **Empty data with overflow**: all bins have frequency 0
- **All nulls with overflow**: only null bin populated
- **Extreme values (Double.MinValue/MaxValue)**: land in overflow bins
- **Default behavior unchanged**: `includeOverflowBins = false` still sends out-of-range to null bin
- **Interval formatting**: (-Inf, 0.00), [0.00, 10.00), [10.00, Inf) verified
- **Serde round-trip**: `includeOverflowBins = true` survives serialize/deserialize

##### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.