### PR TITLE
fix: column escaping for special characters, bigint overflow, and ColumnProfiler performance

### DIFF
--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -37,6 +37,7 @@ import com.amazon.deequ.checks.ColumnCondition.isEachNotNull
 import com.amazon.deequ.constraints.Constraint._
 import com.amazon.deequ.constraints._
 import com.amazon.deequ.metrics.BucketDistribution
+import com.amazon.deequ.utilities.ColumnUtil.escapeColumn
 import com.amazon.deequ.metrics.Distribution
 import com.amazon.deequ.metrics.DistributionBinned
 import com.amazon.deequ.metrics.Metric
@@ -1182,8 +1183,7 @@ case class Check(
 
     satisfies(
       // coalescing column to not count NULL values as non-compliant
-      // NOTE: cast to DECIMAL(20, 10) is needed to handle scientific notations
-      s"COALESCE(CAST($column AS DECIMAL(20,10)), 0.0) >= 0",
+      s"COALESCE(CAST(${escapeColumn(column)} AS DOUBLE), 0.0) >= 0",
       s"$column is non-negative",
       assertion,
       hint = hint,
@@ -1205,9 +1205,8 @@ case class Check(
       hint: Option[String] = None)
     : CheckWithLastConstraintFilterable = {
     // coalescing column to not count NULL values as non-compliant
-    // NOTE: cast to DECIMAL(20, 10) is needed to handle scientific notations
     satisfies(
-      s"COALESCE(CAST($column AS DECIMAL(20,10)), 1.0) > 0",
+      s"COALESCE(CAST(${escapeColumn(column)} AS DOUBLE), 1.0) > 0",
       s"$column is positive",
       assertion,
       hint,
@@ -1232,7 +1231,7 @@ case class Check(
       hint: Option[String] = None)
     : CheckWithLastConstraintFilterable = {
 
-    satisfies(s"$columnA < $columnB", s"$columnA is less than $columnB", assertion,
+    satisfies(s"${escapeColumn(columnA)} < ${escapeColumn(columnB)}", s"$columnA is less than $columnB", assertion,
       hint = hint, columns = List(columnA, columnB))
   }
 
@@ -1252,7 +1251,7 @@ case class Check(
       hint: Option[String] = None)
     : CheckWithLastConstraintFilterable = {
 
-    satisfies(s"$columnA <= $columnB", s"$columnA is less than or equal to $columnB",
+    satisfies(s"${escapeColumn(columnA)} <= ${escapeColumn(columnB)}", s"$columnA is less than or equal to $columnB",
       assertion, hint = hint, columns = List(columnA, columnB))
   }
 
@@ -1272,7 +1271,7 @@ case class Check(
       hint: Option[String] = None)
     : CheckWithLastConstraintFilterable = {
 
-    satisfies(s"$columnA > $columnB", s"$columnA is greater than $columnB",
+    satisfies(s"${escapeColumn(columnA)} > ${escapeColumn(columnB)}", s"$columnA is greater than $columnB",
       assertion, hint = hint, columns = List(columnA, columnB))
   }
 
@@ -1293,7 +1292,7 @@ case class Check(
       hint: Option[String] = None)
     : CheckWithLastConstraintFilterable = {
 
-    satisfies(s"$columnA >= $columnB", s"$columnA is greater than or equal to $columnB",
+    satisfies(s"${escapeColumn(columnA)} >= ${escapeColumn(columnB)}", s"$columnA is greater than or equal to $columnB",
       assertion, hint = hint, columns = List(columnA, columnB))
   }
 

--- a/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
+++ b/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
@@ -404,19 +404,6 @@ object ColumnProfiler {
     }
   }
 
-  /* Cast string columns detected as numeric to their detected type */
-  private[profiles] def castColumn(
-      data: DataFrame,
-      name: String,
-      toType: SparkDataType)
-    : DataFrame = {
-
-    val originalName = removeEscapeColumn(name)
-
-    data.withColumn(s"${name}___CASTED", data(name).cast(toType))
-      .drop(originalName)
-      .withColumnRenamed(s"${name}___CASTED", originalName)
-  }
 
   private[this] def extractGenericStatistics(
       columns: Seq[String],
@@ -503,16 +490,21 @@ object ColumnProfiler {
       genericStatistics: GenericColumnStatistics)
     : DataFrame = {
 
-    var castedData = originalData
-
-    columns.foreach { name =>
-      castedData = genericStatistics.typeOf(name) match {
-        case Integral => castColumn(castedData, name, LongType)
-        case Fractional => castColumn(castedData, name, DoubleType)
-        case _ => castedData
-      }
-    }
-    castedData
+    val escapedToCast = columns.map(c => removeEscapeColumn(c) -> c).toMap
+    originalData.select(
+      originalData.columns.map { rawName =>
+        val escaped = escapeColumn(rawName)
+        escapedToCast.get(rawName) match {
+          case Some(escapedName) =>
+            genericStatistics.typeOf(escapedName) match {
+              case Integral => originalData(escaped).cast(LongType).as(rawName)
+              case Fractional => originalData(escaped).cast(DoubleType).as(rawName)
+              case _ => originalData(escaped)
+            }
+          case None => originalData(escaped)
+        }
+      }: _*
+    )
   }
 
 
@@ -858,7 +850,7 @@ object ColumnProfiler {
               histogram)
         }
 
-        name -> profile
+        removeEscapeColumn(name) -> profile
       }
       .toMap
 

--- a/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunner.scala
+++ b/src/main/scala/com/amazon/deequ/suggestions/ConstraintSuggestionRunner.scala
@@ -23,7 +23,7 @@ import com.amazon.deequ.io.DfsUtils
 import com.amazon.deequ.profiles.{ColumnProfile, ColumnProfilerRunner, ColumnProfiles}
 import com.amazon.deequ.repository.{MetricsRepository, ResultKey}
 import com.amazon.deequ.suggestions.rules._
-import com.amazon.deequ.utilities.ColumnUtil.escapeColumn
+import com.amazon.deequ.utilities.ColumnUtil.{escapeColumn, removeEscapeColumn}
 import org.apache.spark.annotation.Experimental
 import org.apache.spark.sql.types.StructType
 import org.apache.spark.sql.{DataFrame, SparkSession}
@@ -227,7 +227,7 @@ class ConstraintSuggestionRunner {
     columns
       .flatMap { column =>
 
-        val profile = profiles.profiles(column)
+        val profile = profiles.profiles(removeEscapeColumn(column))
 
         constraintRules
           .filter { _.shouldBeApplied(profile, profiles.numRecords) }

--- a/src/main/scala/com/amazon/deequ/utilities/ColumnUtil.scala
+++ b/src/main/scala/com/amazon/deequ/utilities/ColumnUtil.scala
@@ -32,7 +32,7 @@ object ColumnUtil {
     } else if (column.matches("^[a-zA-Z_][a-zA-Z0-9_]*$")) {
       column
     } else {
-      "`" + column + "`"
+      "`" + column.replace("`", "``") + "`"
     }
   }
 

--- a/src/main/scala/com/amazon/deequ/utilities/ColumnUtil.scala
+++ b/src/main/scala/com/amazon/deequ/utilities/ColumnUtil.scala
@@ -27,10 +27,12 @@ object ColumnUtil {
   }
 
   def escapeColumn(column: String): String = {
-    if (column.contains(".")) {
-      "`" + column + "`"
-    } else {
+    if (column.startsWith("`") && column.endsWith("`")) {
       column
+    } else if (column.matches("^[a-zA-Z_][a-zA-Z0-9_]*$")) {
+      column
+    } else {
+      "`" + column + "`"
     }
   }
 

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -479,6 +479,39 @@ class CheckTest extends AnyWordSpec with Matchers with SparkContextSpec with Fix
       assertEvaluatesTo(isPositiveCheck, results, CheckStatus.Success)
     }
 
+    "handle column names with spaces in isNonNegative" in withSparkSession { sparkSession =>
+      import sparkSession.implicits._
+      val df = Seq((1L, "a"), (2L, "b"), (3L, "c"), (-1L, "d")).toDF("my column", "other")
+      val check = Check(CheckLevel.Error, "space check").isNonNegative("my column")
+      val result = VerificationSuite().onData(df).addCheck(check).run()
+      assert(result.checkResults(check).status == CheckStatus.Error)
+    }
+
+    "detect negative bigint values in isNonNegative" in withSparkSession { sparkSession =>
+      import sparkSession.implicits._
+      val df = Seq(-99999999999L, 1L, 2L).toDF("val")
+      val check = Check(CheckLevel.Error, "bigint check").isNonNegative("val")
+      val result = VerificationSuite().onData(df).addCheck(check).run()
+      assert(result.checkResults(check).status == CheckStatus.Error)
+    }
+
+    "handle column names with spaces in isPositive" in withSparkSession { sparkSession =>
+      import sparkSession.implicits._
+      val df = Seq((1L, "a"), (2L, "b"), (0L, "c")).toDF("my column", "other")
+      val check = Check(CheckLevel.Error, "space check").isPositive("my column")
+      val result = VerificationSuite().onData(df).addCheck(check).run()
+      assert(result.checkResults(check).status == CheckStatus.Error)
+    }
+
+    "handle column names with spaces in comparison checks" in withSparkSession { sparkSession =>
+      import sparkSession.implicits._
+      val df = Seq((1, 2), (3, 4), (5, 0)).toDF("col a", "col b")
+      val check = Check(CheckLevel.Error, "comparison check")
+        .isLessThan("col a", "col b")
+      val result = VerificationSuite().onData(df).addCheck(check).run()
+      assert(result.checkResults(check).status == CheckStatus.Error)
+    }
+
     "correctly evaluate range constraints" in withSparkSession { sparkSession =>
       val rangeCheck = Check(CheckLevel.Error, "a")
         .isContainedIn("att1", Array("a", "b", "c"))


### PR DESCRIPTION
## Summary

Fixes three related issues where column names with special characters or large numeric values caused failures in Deequ checks and profiling.

## Issues Fixed

- **#607** — `isNonNegative` check doesn't work correctly with bigint data type
- **#319** — Verification suite fails if the column contains spaces with `.isNonNegative`
- **#396** — `ColumnProfiler` performance degradation with many columns (PR by @rli602)

## Changes

### 1. `ColumnUtil.escapeColumn` — Comprehensive escaping

**Before:** Only escaped column names containing dots.

**After:** Escapes any column name that isn't a simple identifier (`[a-zA-Z_][a-zA-Z0-9_]*`). Already-escaped names (wrapped in backticks) are returned as-is.

### 2. `Check.scala` — Fixed `isNonNegative`, `isPositive`, and all comparison checks

- All checks now use `escapeColumn(column)` in SQL expressions, fixing failures when column names contain spaces, dots, or other special characters.
- Changed `CAST(column AS DECIMAL(20,10))` to `CAST(column AS DOUBLE)` — `DECIMAL(20,10)` overflows for bigint values larger than 10^10 (e.g., `-99999999999` was silently truncated to a positive value, causing false negatives).
- `DOUBLE` preserves sign correctly for all numeric ranges. Sign detection (`>= 0`, `> 0`) doesn't require decimal precision.

### 3. `ColumnProfiler.castNumericStringColumns` — Performance fix

**Before:** Called `withColumn()` + `drop()` + `withColumnRenamed()` in a loop for each numeric column. Per [Spark documentation](https://spark.apache.org/docs/latest/api/python/reference/api/pyspark.sql.DataFrame.withColumn.html), repeated `withColumn` causes O(n²) plan growth.

**After:** Single `select()` call that casts all columns in one pass. References columns using escaped names to handle dots/spaces correctly.

### 4. `ConstraintSuggestionRunner` — Profile lookup fix

Profile map keys are now raw (unescaped) names for user-facing consistency. The `ConstraintSuggestionRunner` uses `removeEscapeColumn` before looking up profiles, keeping internal processing correct.

## Tests Added

| Test | What it verifies |
|------|-----------------|
| `handle column names with spaces in isNonNegative` | Spaces in column name don't break the check; negative value detected |
| `detect negative bigint values in isNonNegative` | Values like `-99999999999` are correctly identified as negative with DOUBLE cast |
| `handle column names with spaces in isPositive` | Spaces in column name don't break isPositive; zero correctly flagged |
| `handle column names with spaces in comparison checks` | `isLessThan` works with spaced column names |

## Existing Test Coverage

All 1151 tests pass including:
- 69 `CheckTest` tests (was 65)
- 16 `ColumnProfilerTest` tests (covers numeric casting with `select()`)
- 4 `ConstraintSuggestionResultTest` tests (covers dots in column names)
- 1 `SuggestionAndVerificationIntegrationTest` (covers end-to-end with dots)

## Verification

```
mvn clean verify → 1151 succeeded, 0 failed, BUILD SUCCESS
```