### PR TITLE
fix: Histogram column name collision and Uniqueness toString display

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/Histogram.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Histogram.scala
@@ -24,7 +24,7 @@ import com.amazon.deequ.metrics.Distribution
 import com.amazon.deequ.metrics.DistributionValue
 import com.amazon.deequ.metrics.HistogramMetric
 import org.apache.spark.sql.expressions.UserDefinedFunction
-import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions.{col, count, sum => spark_sum}
 import org.apache.spark.sql.types.LongType
 import org.apache.spark.sql.types.StringType
 import org.apache.spark.sql.types.StructType
@@ -165,8 +165,7 @@ object Histogram {
         .select(col(column).cast(StringType))
         .na.fill(Histogram.NullFieldReplacement)
         .groupBy(column)
-        .count()
-        .withColumnRenamed("count", Analyzers.COUNT_COL)
+        .agg(count("*").as(Analyzers.COUNT_COL))
     }
 
     override def aggregateColumn(): Option[String] = None
@@ -184,8 +183,7 @@ object Histogram {
         .select(col(column).cast(StringType), col(aggColumn).cast(LongType))
         .na.fill(Histogram.NullFieldReplacement)
         .groupBy(column)
-        .sum(aggColumn)
-        .withColumnRenamed("count", Analyzers.COUNT_COL)
+        .agg(spark_sum(col(aggColumn)).as(Analyzers.COUNT_COL))
     }
 
     override def total(data: DataFrame): Long = {

--- a/src/main/scala/com/amazon/deequ/analyzers/Uniqueness.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Uniqueness.scala
@@ -34,7 +34,7 @@ import org.apache.spark.sql.types.DoubleType
   * values that occur exactly once. */
 case class Uniqueness(columns: Seq[String], where: Option[String] = None,
                       analyzerOptions: Option[AnalyzerOptions] = None)
-  extends ScanShareableFrequencyBasedAnalyzer("Uniqueness", columns)
+  extends ScanShareableFrequencyBasedAnalyzer("Uniqueness", columns.toList)
   with FilterableAnalyzer {
 
   override def aggregationFunctions(numRows: Long): Seq[Column] = {

--- a/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
+++ b/src/test/scala/com/amazon/deequ/checks/CheckTest.scala
@@ -655,6 +655,27 @@ class CheckTest extends AnyWordSpec with Matchers with SparkContextSpec with Fix
         assertEvaluatesTo(check8, context1, CheckStatus.Error)
       }
 
+    "handle DataFrame with column named 'count' in hasNumberOfDistinctValues" in
+      withSparkSession { sparkSession =>
+        import sparkSession.implicits._
+        val df = Seq(("id_0", 1), ("id_1", 2), ("id_2", 3)).toDF("id", "count")
+        val check = Check(CheckLevel.Error, "count column check")
+          .hasNumberOfDistinctValues("count", _ == 3)
+        val result = VerificationSuite().onData(df).addCheck(check).run()
+        assert(result.checkResults(check).status == CheckStatus.Success)
+      }
+
+    "handle DataFrame with column named 'count' in Histogram with Sum aggregation" in
+      withSparkSession { sparkSession =>
+        import sparkSession.implicits._
+        import com.amazon.deequ.analyzers.runners.AnalysisRunner
+        val df = Seq(("a", 10, 1), ("a", 20, 2), ("b", 30, 3)).toDF("category", "value", "count")
+        val analyzer = Histogram("category", aggregateFunction = Histogram.Sum("value"))
+        val result = AnalysisRunner.onData(df).addAnalyzer(analyzer).run()
+        val metric = result.metricMap(analyzer)
+        assert(metric.value.isSuccess)
+      }
+
     "return the correct check status for histogram binned constraints" in
       withSparkSession { sparkSession =>
 


### PR DESCRIPTION
## Summary

Fixes two bugs:

**#647 — `hasNumberOfDistinctValues` breaks when DataFrame has a column named `count`**

The Histogram analyzer used `.groupBy(column).count()` which creates an output column named `count`. When the user's column is also named `count`, the subsequent `.withColumnRenamed("count", ...)` is ambiguous and Spark throws `UNRESOLVED_COLUMN.WITH_SUGGESTION`.

Fix: Use `.agg(count("*").as(Analyzers.COUNT_COL))` instead of `.count().withColumnRenamed(...)`. This directly names the aggregation result with no ambiguity. Same fix applied to `Sum` aggregate function which had a copy-paste bug (was renaming `"count"` instead of the sum column).

**#650 — `hasUniqueness` shows `Stream(a, ?)` in constraint toString**

When `hasUniqueness(Seq("a", "b", "c"), ...)` is called, the `Seq` may be a lazy `Stream` internally. The `toString` renders as `Stream(a, ?)` instead of `List(a, b, c)`.

Fix: Normalize `columns` to `List` in the `ScanShareableFrequencyBasedAnalyzer` super call via `.toList`.

## Test

- [x] New test: `handle DataFrame with column named 'count' in hasNumberOfDistinctValues`
- [x] Full suite: 1152 tests passed, 0 failed

## Closes

- Closes #647
- Closes #650