### PR TITLE
fix: remove secret_id from log to satisfy CodeQL

### DIFF
--- a/src/scripts/issue_bot/prompts.py
+++ b/src/scripts/issue_bot/prompts.py
@@ -23,7 +23,7 @@ def _read_from_sm(secret_id):
         resp = _get_sm_client().get_secret_value(SecretId=secret_id)
         return resp["SecretString"]
     except Exception as e:
-        logger.error(f"SM read failed for {secret_id}: {e}")
+        logger.error("Failed to read prompt from Secrets Manager: %s", type(e).__name__)
         return ""
 
 


### PR DESCRIPTION
CodeQL in `dqdl` repo, flags `secret_id` being logged as 'clear-text-logging-sensitive-data'. The secret name is not actually sensitive (it's a public path visible in the workflow YAML), but the exception message could contain sensitive data. Removed `secret_id` from the log message to satisfy CodeQL.