### PR TITLE
Add overflow bins support to HistogramBinned

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/HistogramBinned.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/HistogramBinned.scala
@@ -50,6 +50,7 @@ case class HistogramBinned(
                             override val column: String,
                             binCount: Option[Int] = None,
                             customEdges: Option[Array[Double]] = None,
+                            includeOverflowBins: Boolean = false,
                             override val where: Option[String] = None,
                             override val computeFrequenciesAsRatio: Boolean = true,
                             // Reuse Histogram's AggregateFunction implementations since just grouping
@@ -71,6 +72,7 @@ case class HistogramBinned(
       column == other.column &&
         binCount == other.binCount &&
         customEdges.map(_.toSeq) == other.customEdges.map(_.toSeq) &&
+        includeOverflowBins == other.includeOverflowBins &&
         where == other.where &&
         computeFrequenciesAsRatio == other.computeFrequenciesAsRatio &&
         aggregateFunction == other.aggregateFunction
@@ -78,21 +80,30 @@ case class HistogramBinned(
   }
 
   override def hashCode(): Int = {
-    (column, binCount, customEdges.map(_.toSeq), where,
-      computeFrequenciesAsRatio, aggregateFunction).hashCode()
+    (column, binCount, customEdges.map(_.toSeq), includeOverflowBins,
+      where, computeFrequenciesAsRatio, aggregateFunction).hashCode()
   }
 
   private var storedEdges: Array[Double] = _
 
   protected[this] val PARAM_CHECK: StructType => Unit = { _ =>
     binCount.foreach { count =>
+      if (includeOverflowBins && count < 3) {
+        throw new IllegalAnalyzerParameterException(
+          "binCount must be at least 3 when includeOverflowBins is true (2 overflow + 1 interior)")
+      }
       if (count > HistogramBinned.MaximumAllowedDetailBins) {
         throw new IllegalAnalyzerParameterException(s"Cannot return histogram values for more " +
           s"than ${HistogramBinned.MaximumAllowedDetailBins} bins")
       }
     }
     customEdges.foreach { edges =>
-      val numBins = edges.length - 1
+      // Count overflow bins that will actually be added (only if not already present)
+      val overflowExtra = if (includeOverflowBins) {
+        (if (edges.sorted.head != Double.NegativeInfinity) 1 else 0) +
+        (if (edges.sorted.last != Double.PositiveInfinity) 1 else 0)
+      } else 0
+      val numBins = edges.length - 1 + overflowExtra
       if (numBins > HistogramBinned.MaximumAllowedDetailBins) {
         throw new IllegalAnalyzerParameterException(s"Cannot return histogram values for more " +
           s"than ${HistogramBinned.MaximumAllowedDetailBins} bins")
@@ -128,7 +139,7 @@ case class HistogramBinned(
     // Create binned data using DataFrame operations
     val binnedData = if (storedEdges.isEmpty) {
       filteredData.withColumn(column, lit(Histogram.NullFieldReplacement))
-    } else if (customEdges.isDefined) {
+    } else if (customEdges.isDefined || includeOverflowBins) {
       val edges = storedEdges
 
       // Builds a balanced binary decision tree of when/otherwise expressions,
@@ -142,8 +153,13 @@ case class HistogramBinned(
         } else if (binIndices.size == 1) {
           // Single bin, check if value falls in this bin
           val i = binIndices.head
-          val condition = if (i == edges.length - 2) {
-            // Last bin includes upper bound [a, b]
+          val isLastBin = i == edges.length - 2
+          // Last interior bin is inclusive [a, b] when overflow is enabled,
+          // so data max stays in interior. Identified by: next bin ends at +Inf.
+          val isLastInterior = includeOverflowBins && i < edges.length - 2 &&
+            edges(i + 2) == Double.PositiveInfinity
+          val condition = if (isLastBin || isLastInterior) {
+            // Last bin and last interior bin are inclusive [a, b]
             numericCol >= edges(i) && numericCol <= edges(i + 1)
           } else {
             // All other bins exclude upper bound [a, b)
@@ -156,8 +172,17 @@ case class HistogramBinned(
           val (leftBins, rightBins) = binIndices.splitAt(mid)
           val splitEdge = edges(rightBins.head)
 
-          when(numericCol < splitEdge, buildBinaryCondition(leftBins))
-            .otherwise(buildBinaryCondition(rightBins))
+          // When the right branch starts with the overflow bin, use <= so that
+          // values on the boundary stay in the last interior bin (left side)
+          val isOverflowSplit = includeOverflowBins &&
+            edges(rightBins.head + 1) == Double.PositiveInfinity
+          if (isOverflowSplit) {
+            when(numericCol <= splitEdge, buildBinaryCondition(leftBins))
+              .otherwise(buildBinaryCondition(rightBins))
+          } else {
+            when(numericCol < splitEdge, buildBinaryCondition(leftBins))
+              .otherwise(buildBinaryCondition(rightBins))
+          }
         }
       }
 
@@ -188,7 +213,15 @@ case class HistogramBinned(
   }
 
   private def computeCustomEdges(): Array[Double] = {
-    customEdges.get.sorted
+    val sorted = customEdges.get.sorted
+    addOverflowEdges(sorted)
+  }
+
+  private def addOverflowEdges(edges: Array[Double]): Array[Double] = {
+    if (!includeOverflowBins) return edges
+    val withLeft = if (edges.head != Double.NegativeInfinity) Double.NegativeInfinity +: edges else edges
+    val withBoth = if (withLeft.last != Double.PositiveInfinity) withLeft :+ Double.PositiveInfinity else withLeft
+    withBoth.toArray
   }
 
   private def computeEqualWidthEdges(filteredData: DataFrame,
@@ -207,9 +240,11 @@ case class HistogramBinned(
 
     val minDouble = minVal.doubleValue()
     val maxDouble = maxVal.doubleValue()
-    val binWidth = (maxDouble - minDouble) / binCount.get
+    val interiorBins = if (includeOverflowBins) binCount.get - 2 else binCount.get
+    val binWidth = (maxDouble - minDouble) / interiorBins
 
-    Array.tabulate(binCount.get + 1)(i => minDouble + i * binWidth)
+    val edges = Array.tabulate(interiorBins + 1)(i => minDouble + i * binWidth)
+    addOverflowEdges(edges)
   }
 
   override def computeMetricFrom(state: Option[FrequenciesAndNumRows]): HistogramBinnedMetric = {

--- a/src/main/scala/com/amazon/deequ/metrics/HistogramBinnedMetric.scala
+++ b/src/main/scala/com/amazon/deequ/metrics/HistogramBinnedMetric.scala
@@ -32,11 +32,15 @@ case class DistributionBinned(
 
   def getInterval(index: Int): String = {
     val bin = bins(index)
-    if (index == bins.length - 1) {
-      f"[${bin.binStart}%.2f, ${bin.binEnd}%.2f]"
-    } else {
-      f"[${bin.binStart}%.2f, ${bin.binEnd}%.2f)"
+    val leftBracket = if (bin.binStart.isNegInfinity) "(" else "["
+    val isLastInterior = index < bins.length - 1 &&
+      bins(index + 1).binEnd.isPosInfinity
+    val rightBracket = if (bin.binEnd.isPosInfinity) ")" else {
+      if (index == bins.length - 1 || isLastInterior) "]" else ")"
     }
+    val startStr = if (bin.binStart.isNegInfinity) "-Inf" else f"${bin.binStart}%.2f"
+    val endStr = if (bin.binEnd.isPosInfinity) "Inf" else f"${bin.binEnd}%.2f"
+    s"$leftBracket$startStr, $endStr$rightBracket"
   }
 }
 

--- a/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
+++ b/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
@@ -372,6 +372,9 @@ private[deequ] object AnalyzerSerializer
         if (histogramBinned.customEdges.isDefined) {
           result.add("customEdges", context.serialize(histogramBinned.customEdges.get))
         }
+        if (histogramBinned.includeOverflowBins) {
+          result.addProperty("includeOverflowBins", true)
+        }
         result.addProperty(WHERE_FIELD, histogramBinned.where.orNull)
 
       case _ : Histogram =>
@@ -601,10 +604,14 @@ private[deequ] object AnalyzerDeserializer
         val customEdges = if (json.has("customEdges")) {
           Some(context.deserialize(json.get("customEdges"), classOf[Array[Double]]))
         } else None
+        val includeOverflowBins = if (json.has("includeOverflowBins")) {
+          json.get("includeOverflowBins").getAsBoolean
+        } else false
         HistogramBinned(
           json.get(COLUMN_FIELD).getAsString,
           binCount,
           customEdges,
+          includeOverflowBins,
           getOptionalWhereParam(json))
 
       case "DataType" =>

--- a/src/test/scala/com/amazon/deequ/analyzers/HistogramBinnedTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/HistogramBinnedTest.scala
@@ -648,6 +648,343 @@ class HistogramBinnedTest extends AnyWordSpec with Matchers with SparkContextSpe
     }
   }
 
+  "HistogramBinned (overflow bins)" should {
+    "add overflow bins to custom edges" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(1.0, 5.0, 15.0, 25.0).toDF("values")
+      val customEdges = Array(0.0, 10.0, 20.0)
+
+      val histogram = HistogramBinned("values", customEdges = Some(customEdges), includeOverflowBins = true)
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      distribution.numberOfBins shouldBe 4
+
+      distribution(0).binStart shouldBe Double.NegativeInfinity
+      distribution(0).binEnd shouldBe 0.0
+      distribution(0).frequency shouldBe 0
+
+      distribution(1).binStart shouldBe 0.0
+      distribution(1).binEnd shouldBe 10.0
+      distribution(1).frequency shouldBe 2
+
+      distribution(2).binStart shouldBe 10.0
+      distribution(2).binEnd shouldBe 20.0
+      distribution(2).frequency shouldBe 1
+
+      distribution(3).binStart shouldBe 20.0
+      distribution(3).binEnd shouldBe Double.PositiveInfinity
+      distribution(3).frequency shouldBe 1
+    }
+
+    "add overflow bins to auto-computed edges" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(1.0, 2.0, 3.0, 4.0, 5.0).toDF("values")
+
+      // binCount = 5 with overflow: 3 interior + 2 overflow = 5 total
+      val histogram = HistogramBinned("values", binCount = Some(5), includeOverflowBins = true)
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      distribution.numberOfBins shouldBe 5
+      distribution(0).binStart shouldBe Double.NegativeInfinity
+      distribution(0).binEnd shouldBe 1.0
+      distribution(0).frequency shouldBe 0  // nothing below min
+
+      // Max value (5.0) stays in last interior bin (inclusive)
+      // Right overflow is empty on first run
+      distribution(4).binStart shouldBe 5.0
+      distribution(4).binEnd shouldBe Double.PositiveInfinity
+      distribution(4).frequency shouldBe 0
+    }
+
+    "not duplicate infinity edges if already present" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(1.0, 5.0, 20.0, 25.0).toDF("values")
+      val customEdges = Array(Double.NegativeInfinity, 0.0, 10.0, 20.0, Double.PositiveInfinity)
+
+      val histogram = HistogramBinned("values", customEdges = Some(customEdges), includeOverflowBins = true)
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      distribution.numberOfBins shouldBe 4
+      distribution(0).binStart shouldBe Double.NegativeInfinity
+      distribution(3).binEnd shouldBe Double.PositiveInfinity
+
+      // 20.0 stays in last interior bin [10, 20] not overflow [20, Inf)
+      distribution(2).frequency shouldBe 1  // 20.0
+      distribution(3).frequency shouldBe 1  // 25.0 in overflow
+    }
+
+    "separate nulls from overflow" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(Some(-5.0), None, Some(5.0), Some(25.0), None).toDF("values")
+      val customEdges = Array(0.0, 10.0, 20.0)
+
+      val histogram = HistogramBinned("values", customEdges = Some(customEdges), includeOverflowBins = true)
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      // 4 data/overflow bins, nulls separate
+      distribution.numberOfBins shouldBe 4
+
+      distribution(0).binStart shouldBe Double.NegativeInfinity
+      distribution(0).binEnd shouldBe 0.0
+      distribution(0).frequency shouldBe 1
+
+      distribution(3).binStart shouldBe 20.0
+      distribution(3).binEnd shouldBe Double.PositiveInfinity
+      distribution(3).frequency shouldBe 1
+
+      // Nulls in separate field
+      distribution.nullCount shouldBe 2
+    }
+
+    "handle unsorted custom edges with overflow" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(-1.0, 5.0, 15.0).toDF("values")
+      val customEdges = Array(10.0, 0.0) // unsorted
+
+      val histogram = HistogramBinned("values", customEdges = Some(customEdges), includeOverflowBins = true)
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      // Sorted to [0.0, 10.0], then overflow added: [-Inf, 0.0, 10.0, Inf]
+      distribution.numberOfBins shouldBe 3
+      distribution(0).binStart shouldBe Double.NegativeInfinity
+      distribution(0).binEnd shouldBe 0.0
+      distribution(0).frequency shouldBe 1  // -1.0
+
+      distribution(1).binStart shouldBe 0.0
+      distribution(1).binEnd shouldBe 10.0
+      distribution(1).frequency shouldBe 1  // 5.0
+
+      distribution(2).binStart shouldBe 10.0
+      distribution(2).binEnd shouldBe Double.PositiveInfinity
+      distribution(2).frequency shouldBe 1  // 15.0
+    }
+
+    "format overflow intervals correctly" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(5.0).toDF("values")
+      val customEdges = Array(0.0, 10.0)
+
+      val histogram = HistogramBinned("values", customEdges = Some(customEdges), includeOverflowBins = true)
+      val result = histogram.calculate(data).value.get
+
+      result.getInterval(0) shouldBe "(-Inf, 0.00)"
+      result.getInterval(1) shouldBe "[0.00, 10.00]"
+      result.getInterval(2) shouldBe "[10.00, Inf)"
+    }
+
+    "put all data in overflow bins when outside custom range" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(-100.0, -50.0, 200.0, 300.0).toDF("values")
+      val customEdges = Array(0.0, 10.0, 20.0)
+
+      val histogram = HistogramBinned("values", customEdges = Some(customEdges), includeOverflowBins = true)
+      val result = histogram.calculate(data).value.get
+
+      result.bins(0).frequency shouldBe 2  // -100, -50 in left overflow
+      result.bins(1).frequency shouldBe 0  // [0, 10) empty
+      result.bins(2).frequency shouldBe 0  // [10, 20) empty
+      result.bins(3).frequency shouldBe 2  // 200, 300 in right overflow
+    }
+
+    "route values exactly on first/last custom edge correctly with overflow" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(0.0, 10.0, 20.0).toDF("values")
+      val customEdges = Array(0.0, 10.0, 20.0)
+
+      val histogram = HistogramBinned("values", customEdges = Some(customEdges), includeOverflowBins = true)
+      val result = histogram.calculate(data).value.get
+
+      // Edges after overflow: [-Inf, 0.0, 10.0, 20.0, Inf]
+      // Bin 0: (-Inf, 0.0) - empty (0.0 excluded)
+      // Bin 1: [0.0, 10.0) - contains 0.0
+      // Bin 2: [10.0, 20.0] - contains 10.0, 20.0 (last interior bin inclusive)
+      // Bin 3: [20.0, Inf] - empty (20.0 captured by last interior)
+      result.bins(0).frequency shouldBe 0
+      result.bins(1).frequency shouldBe 1  // 0.0
+      result.bins(2).frequency shouldBe 2  // 10.0, 20.0
+      result.bins(3).frequency shouldBe 0
+    }
+
+    "work with single custom edge pair and overflow" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(-1.0, 5.0, 15.0).toDF("values")
+      val customEdges = Array(0.0, 10.0)
+
+      val histogram = HistogramBinned("values", customEdges = Some(customEdges), includeOverflowBins = true)
+      val result = histogram.calculate(data).value.get
+
+      result.numberOfBins shouldBe 3
+      result.bins(0).frequency shouldBe 1  // -1.0 in left overflow
+      result.bins(1).frequency shouldBe 1  // 5.0 in [0, 10]
+      result.bins(2).frequency shouldBe 1  // 15.0 in right overflow
+    }
+
+    "work with Sum aggregation and overflow" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(
+        (-5.0, 100), (5.0, 200), (15.0, 300), (25.0, 400)
+      ).toDF("values", "amount")
+
+      val customEdges = Array(0.0, 10.0, 20.0)
+      val histogram = HistogramBinned(
+        "values",
+        customEdges = Some(customEdges),
+        includeOverflowBins = true,
+        aggregateFunction = Histogram.Sum("amount")
+      )
+      val result = histogram.calculate(data).value.get
+
+      result.bins(0).frequency shouldBe 100  // left overflow sum
+      result.bins(1).frequency shouldBe 200  // [0, 10) sum
+      result.bins(2).frequency shouldBe 300  // [10, 20) sum
+      result.bins(3).frequency shouldBe 400  // right overflow sum
+    }
+
+    "work with where filter and overflow" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(
+        (1, -5.0), (2, 5.0), (3, 15.0), (4, 25.0)
+      ).toDF("id", "values")
+
+      val customEdges = Array(0.0, 10.0, 20.0)
+      val histogram = HistogramBinned(
+        "values",
+        customEdges = Some(customEdges),
+        includeOverflowBins = true,
+        where = Some("id <= 2")
+      )
+      val result = histogram.calculate(data).value.get
+
+      result.bins(0).frequency shouldBe 1  // -5.0 (id=1)
+      result.bins(1).frequency shouldBe 1  // 5.0 (id=2)
+      result.bins(2).frequency shouldBe 0  // filtered out
+      result.bins(3).frequency shouldBe 0  // filtered out
+    }
+
+    "handle empty data with overflow" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq.empty[Double].toDF("values")
+      val customEdges = Array(0.0, 10.0, 20.0)
+
+      val histogram = HistogramBinned("values", customEdges = Some(customEdges), includeOverflowBins = true)
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+      distribution.numberOfBins shouldBe 4
+      distribution.bins.foreach(_.frequency shouldBe 0)
+    }
+
+    "handle all nulls with overflow" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(Option.empty[Double], None, None).toDF("values")
+      val customEdges = Array(0.0, 10.0, 20.0)
+
+      val histogram = HistogramBinned("values", customEdges = Some(customEdges), includeOverflowBins = true)
+      val result = histogram.calculate(data).value.get
+
+      // 4 data/overflow bins all empty, nulls separate
+      result.numberOfBins shouldBe 4
+      result.bins(0).frequency shouldBe 0
+      result.bins(1).frequency shouldBe 0
+      result.bins(2).frequency shouldBe 0
+      result.bins(3).frequency shouldBe 0
+      result.nullCount shouldBe 3
+    }
+
+    "handle extreme values in overflow bins" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(Double.MinValue, -1e308, 5.0, 1e308, Double.MaxValue).toDF("values")
+      val customEdges = Array(0.0, 10.0)
+
+      val histogram = HistogramBinned("values", customEdges = Some(customEdges), includeOverflowBins = true)
+      val result = histogram.calculate(data).value.get
+
+      result.bins(0).frequency shouldBe 2  // MinValue, -1e308 in left overflow
+      result.bins(1).frequency shouldBe 1  // 5.0 in [0, 10]
+      result.bins(2).frequency shouldBe 2  // 1e308, MaxValue in right overflow
+    }
+
+    "not add overflow bins when includeOverflowBins is false (default)" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(-5.0, 5.0, 25.0).toDF("values")
+      val customEdges = Array(0.0, 10.0, 20.0)
+
+      val histogram = HistogramBinned("values", customEdges = Some(customEdges))
+      val result = histogram.calculate(data).value.get
+
+      // Only 2 data bins, out-of-range goes to nullCount
+      result.numberOfBins shouldBe 2
+      // -5.0 and 25.0 are out of range, counted as nullCount
+      result.nullCount shouldBe 2
+    }
+
+    "throw when binCount < 3 with overflow enabled" in withSparkSession { spark =>
+      import spark.implicits._
+      import com.amazon.deequ.analyzers.runners.AnalysisRunner
+
+      val data = Seq(1.0, 2.0, 3.0).toDF("values")
+      val histogram = HistogramBinned("values", binCount = Some(2), includeOverflowBins = true)
+
+      val analysis = AnalysisRunner.onData(data).addAnalyzer(histogram)
+      val result = analysis.run()
+
+      val metric = result.metricMap(histogram)
+      metric.value.isFailure shouldBe true
+    }
+
+    "handle values exactly on overflow boundary edges" in withSparkSession { spark =>
+      import spark.implicits._
+
+      // Values exactly on the min and max (which become interior/overflow boundaries)
+      val data = Seq(0.0, 5.0, 10.0, 15.0, 20.0).toDF("values")
+      val customEdges = Array(0.0, 10.0, 20.0)
+
+      val histogram = HistogramBinned("values", customEdges = Some(customEdges), includeOverflowBins = true)
+      val result = histogram.calculate(data).value.get
+
+      // Edges after overflow: [-Inf, 0.0, 10.0, 20.0, Inf]
+      // Bin 0: (-Inf, 0.0) - empty (0.0 excluded from left overflow)
+      // Bin 1: [0.0, 10.0) - contains 0.0, 5.0
+      // Bin 2: [10.0, 20.0] - contains 10.0, 15.0, 20.0 (last interior inclusive)
+      // Bin 3: (20.0, Inf] - empty
+      result.bins(0).frequency shouldBe 0
+      result.bins(1).frequency shouldBe 2  // 0.0, 5.0
+      result.bins(2).frequency shouldBe 3  // 10.0, 15.0, 20.0
+      result.bins(3).frequency shouldBe 0
+    }
+  }
+
   "HistogramBinned parameter validation" should {
     "throw IllegalArgumentException when neither binCount nor customEdges is provided" in {
       val exception = intercept[IllegalArgumentException] {

--- a/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
@@ -81,7 +81,7 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
       HistogramBinned("ColumnA", Some(3)) ->
         HistogramBinnedMetric("ColumnA", Success(DistributionBinned(
           Vector(BinData(0.0, 15.0, 4, 0.4), BinData(15.0, 30.0, 4, 0.4)), 2, 2))),
-      HistogramBinned("ColumnA", Some(5), None, Some("id > 3")) ->
+      HistogramBinned("ColumnA", Some(5), None, includeOverflowBins = false, where = Some("id > 3")) ->
         HistogramBinnedMetric("ColumnA", Success(DistributionBinned(
           Vector(BinData(0.0, 10.0, 3, 0.6), BinData(10.0, 20.0, 2, 0.4)), 2))),
       Entropy("ColumnA") ->
@@ -572,6 +572,24 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
     val context = AnalyzerContext(Map(analyzer -> metric))
     val expected = new AnalysisResult(ResultKey(0), context)
     assert(deserialize(histogramBinnedCustomEdgesJson) == List(expected))
+  }
+
+  "HistogramBinned with overflow" should "round-trip serialize and deserialize" in {
+    val customEdges = Array(0.0, 10.0, 20.0)
+    val analyzer = HistogramBinned("values", customEdges = Some(customEdges), includeOverflowBins = true)
+    val metric = HistogramBinnedMetric("values", Success(DistributionBinned(
+      Vector(
+        BinData(Double.NegativeInfinity, 0.0, 1, 0.25),
+        BinData(0.0, 10.0, 1, 0.25),
+        BinData(10.0, 20.0, 1, 0.25),
+        BinData(20.0, Double.PositiveInfinity, 1, 0.25)
+      ), 4)))
+    val context = AnalyzerContext(Map(analyzer -> metric))
+    val result = new AnalysisResult(ResultKey(0), context)
+
+    val serialized = serialize(List(result))
+    val deserialized = deserialize(serialized)
+    assert(deserialized == List(result))
   }
 
   def assertCorrectlyConvertsAnalysisResults(


### PR DESCRIPTION
### Description of changes

Adds overflow bin support to `HistogramBinned`. When `includeOverflowBins = true`, the analyzer prepends `-Infinity` and appends `+Infinity` to the bin edges, creating dedicated bins for out-of-range values instead of lumping them with nulls.

#### API

```
// Auto-compute with overflow
HistogramBinned("age", binCount = Some(10), includeOverflowBins = true)
// Result: 8 interior bins + 2 overflow = 10 total + optional null
```
```
// Custom edges with overflow
HistogramBinned("income", customEdges = Some(Array(0.0, 40000.0, 100000.0)), includeOverflowBins = true)
// Result: [-Inf, 0) + [0, 40k) + [40k, 100k) + [100k, Inf] + optional null bin
```

#### Behavior

- `includeOverflowBins = false` (default): current behavior unchanged. Out-of-range values go to null bin (this is being _fixed_ in a followup).
- `includeOverflowBins = true`: prepends `-Inf` and appends `+Inf` to edges (skips if already present). Out-of-range values land in overflow bins, null bin only contains actual nulls.
- Overflow bins are included in the count for auto-compute: `binCount = 10` gives 8 interior + 2 overflow = 10 total. `binCount` must be at least 3 when overflow is enabled. For custom edges, overflow is additional (prepended/appended to whatever the user provides).
- When overflow is enabled, the last interior bin is inclusive `[a, b]` so that auto-computed data stays entirely in interior bins on the first run (overflow bins start empty). Matches NumPy/ROOT behavior.
- When overflow is enabled with auto-compute, the binary search path is used instead of the floor formula (which breaks with infinity arithmetic).

#### Interval formatting

- Left overflow: `(-Inf, 0.00)`
- Interior bins: `[0.00, 10.00)`, `[10.00, 20.00]`
- Right overflow: `[20.00, Inf)`

#### Changes

- `HistogramBinned.scala`: adds `includeOverflowBins` parameter, `addOverflowEdges` helper, routes to binary search path when overflow enabled, `updates equals`/`hashCode`
- `HistogramBinnedMetric.scala`: infinity-aware interval string formatting
- `AnalysisResultSerde.scala`: serialize/deserialize `includeOverflowBins`

### Testing

- **Custom edges with overflow**: verifies 2 overflow + 2 data bins, correct routing
- **Auto-computed edges with overflow**: verifies overflow bins added, max value lands in right overflow
- **No duplicate infinity edges**: passing edges that already have `-Inf`/`Inf` doesn't double them
- **Nulls separated from overflow**: nulls go to null bin, out-of-range goes to overflow bins
- **Unsorted edges with overflow**: sort + overflow applied correctly
- **Boundary values with overflow**: values exactly on custom edges route correctly when overflow changes last-bin semantics
- **Single edge pair with overflow**: minimal config (2 edges + overflow = 3 bins)
- **Sum aggregation with overflow**: aggregate function works with overflow bins
- **Where filter with overflow**: filtered data routes correctly
- **Empty data with overflow**: all bins have frequency 0
- **All nulls with overflow**: only null bin populated
- **Extreme values (`Double.MinValue`/`MaxValue`)**: land in overflow bins
- **Default behavior unchanged**: `includeOverflowBins = false` still sends out-of-range to null bin
- **Interval formatting**: `(-Inf, 0.00), [0.00, 10.00), [10.00, Inf)` verified
- **Serde round-trip**: `includeOverflowBins = true` survives serialize/deserialize

##### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.