### PR TITLE
Drop out-of-range values for numeric histograms instead of mixing wit…

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/HistogramBinned.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/HistogramBinned.scala
@@ -149,7 +149,7 @@ case class HistogramBinned(
       // e.g. 100 bins x 1B rows = ~7 comparisons/row vs ~99 for linear scan.
       def buildBinaryCondition(binIndices: Seq[Int]): Column = {
         if (binIndices.isEmpty) {
-          lit(Histogram.NullFieldReplacement)
+          lit(HistogramBinned.OutOfRangeReplacement)
         } else if (binIndices.size == 1) {
           // Single bin, check if value falls in this bin
           val i = binIndices.head
@@ -165,7 +165,7 @@ case class HistogramBinned(
             // All other bins exclude upper bound [a, b)
             numericCol >= edges(i) && numericCol < edges(i + 1)
           }
-          when(condition, lit(i.toString)).otherwise(lit(Histogram.NullFieldReplacement))
+          when(condition, lit(i.toString)).otherwise(lit(HistogramBinned.OutOfRangeReplacement))
         } else {
           // Split bins in half and create decision tree
           val mid = binIndices.size / 2
@@ -299,6 +299,8 @@ case class HistogramBinned(
 object HistogramBinned {
   val DefaultBinCount = 10
   val MaximumAllowedDetailBins = 1000
+  // Out-of-range values get this label; ignored in computeMetricFrom (effectively dropped)
+  val OutOfRangeReplacement = "OutOfRange"
 
   // Note: Reuse Histogram.Count and Histogram.Sum for aggregation
   // since after binning, it is working with categorical bin indices

--- a/src/test/scala/com/amazon/deequ/analyzers/HistogramBinnedTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/HistogramBinnedTest.scala
@@ -943,10 +943,34 @@ class HistogramBinnedTest extends AnyWordSpec with Matchers with SparkContextSpe
       val histogram = HistogramBinned("values", customEdges = Some(customEdges))
       val result = histogram.calculate(data).value.get
 
-      // Only 2 data bins, out-of-range goes to nullCount
+      // Only 2 data bins, out-of-range values are dropped
       result.numberOfBins shouldBe 2
-      // -5.0 and 25.0 are out of range, counted as nullCount
-      result.nullCount shouldBe 2
+      result.bins(0).frequency shouldBe 1  // 5.0 in [0, 10)
+      result.bins(1).frequency shouldBe 0  // [10, 20] empty (25.0 dropped)
+      result.nullCount shouldBe 0  // no actual nulls
+    }
+
+    "drop out-of-range values separately from nulls when overflow disabled" in withSparkSession { spark =>
+      import spark.implicits._
+
+      // Mix of: in-range, out-of-range, and null values
+      val data = Seq(Some(-10.0), Some(5.0), None, Some(15.0), Some(50.0), None).toDF("values")
+      val customEdges = Array(0.0, 10.0, 20.0)
+
+      val histogram = HistogramBinned("values", customEdges = Some(customEdges))
+      val result = histogram.calculate(data).value.get
+
+      // Only data bins
+      result.numberOfBins shouldBe 2
+      result.bins(0).frequency shouldBe 1  // 5.0 in [0, 10)
+      result.bins(1).frequency shouldBe 1  // 15.0 in [10, 20]
+
+      // Only actual nulls in nullCount, not out-of-range
+      result.nullCount shouldBe 2  // two None values
+
+      // -10.0 and 50.0 are dropped (not counted anywhere)
+      val totalCounted = result.bins.map(_.frequency).sum + result.nullCount
+      totalCounted shouldBe 4  // 6 total rows - 2 dropped = 4
     }
 
     "throw when binCount < 3 with overflow enabled" in withSparkSession { spark =>


### PR DESCRIPTION
### Description of changes

When `includeOverflowBins = false` (default) with custom edges, values outside the specified range were previously counted in `nullCount`, making them indistinguishable from actual null values. Now they are dropped (not counted anywhere), matching NumPy/Spark Bucketizer behavior.

#### Before

```
val data = Seq(-10.0, 5.0, null, 50.0)  // edges [0, 10, 20]
result.nullCount  // 3 (mixed: 1 null + 2 out-of-range)
```
#### After

```
val data = Seq(-10.0, 5.0, null, 50.0)  // edges [0, 10, 20]
result.nullCount  // 1 (only actual null)
// -10.0 and 50.0 are dropped
```

When `includeOverflowBins = true`, out-of-range values land in the overflow bins (not dropped). This is unaffected by this change. The drop behavior only applies when overflow is disabled.

#### Changes

- **HistogramBinned.scala**: adds `OutOfRangeReplacement` sentinel used in binary search fallback. `computeMetricFrom` already ignores any label that isn't a bin index or `NullFieldReplacement`, so out-of-range values are effectively dropped.

### Testing

- **Out-of-range dropped separately from nulls**: mix of in-range, out-of-range, and null values; verifies each is handled independently
- **Default behavior (overflow disabled)**: out-of-range values no longer appear in `nullCount`

##### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.