### PR TITLE
fix: two-phase PR review reduces false positives via falsification

### DIFF
--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -72,6 +72,7 @@ jobs:
           SM_ISSUE_CLASSIFY_PROMPT: deequ-bot/issue-classify-prompt
           SM_ISSUE_RESPOND_PROMPT: deequ-bot/issue-respond-prompt
           SM_PR_FILE_REVIEW_PROMPT: deequ-bot/pr-file-review-prompt
+          SM_PR_FILE_REVIEW_REPORT_PROMPT: deequ-bot/pr-file-review-report-prompt
           SM_FOLLOWUP_PROMPT: deequ-bot/followup-prompt
           CODEBASE_SRC_DIR: src/main/scala
           CODEBASE_FILE_EXT: .scala

--- a/src/scripts/issue_bot/main.py
+++ b/src/scripts/issue_bot/main.py
@@ -188,8 +188,8 @@ def analyze():
                 f"<incremental_diff>\n{incremental_diff}\n</incremental_diff>\n"
             )
 
-        # System prompt: instructions + all trusted context (not scanned by guardrail)
-        system_prompt = _render(tmpl, current_date=datetime.date.today().isoformat()) + (
+        # Build context for Phase 1 (full context including source files)
+        phase1_context = (
             f"\n\n<knowledge_base>\n{context}\n</knowledge_base>\n"
             f"<codebase_map>\n{codebase_map}\n</codebase_map>\n"
             f"<full_source_files>\n{full_sources}\n</full_source_files>\n"
@@ -197,9 +197,40 @@ def analyze():
             f"<existing_feedback>\n{existing_feedback}\n</existing_feedback>\n"
             f"{incremental_section}"
         )
-        # User prompt: only user-authored content (scanned by guardrail)
         user_prompt = f"<pr>\nTitle: {title}\nBody: {body}\n</pr>"
-        raw = bedrock.invoke(system_prompt, user_prompt,
+
+        # PHASE 1: Investigation (free-form, no schema)
+        phase1_prompt = _render(tmpl, current_date=datetime.date.today().isoformat()) + phase1_context
+        investigation = bedrock.invoke(phase1_prompt, user_prompt, max_tokens=8000)
+        if investigation is None:
+            _write_artifact({
+                "action": "ESCALATE", "reason": "bedrock_unavailable", "title": title,
+                "html_url": html_url, "number": number, "is_pr": True,
+                "prompt_id": prompts.prompt_version(tmpl), "model_id": cfg.bedrock_model_id,
+            })
+            return
+
+        # PHASE 2: Always run — structured reporting (schema-enforced falsification)
+        # Phase 2 gets diff + investigation notes but NOT full_source_files (already analyzed in Phase 1)
+        report_tmpl = prompts.get_pr_file_review_report_prompt()
+        if not report_tmpl:
+            _write_artifact({
+                "action": "ESCALATE", "reason": "prompt_load_failed", "title": title,
+                "html_url": html_url, "number": number, "is_pr": True,
+                "prompt_id": "n/a", "model_id": cfg.bedrock_model_id,
+            })
+            return
+        report_system = (
+            _render(report_tmpl, current_date=datetime.date.today().isoformat())
+            + f"\n<diff>\n{diff}\n</diff>\n"
+        )
+        # Investigation notes go in user message (scanned by guardrail)
+        report_user = (
+            f"<investigation_notes>\n{investigation}\n</investigation_notes>\n\n"
+            f"<pr>\nTitle: {title}\nBody: {body}\n</pr>"
+        )
+
+        raw = bedrock.invoke(report_system, report_user,
                              max_tokens=8000, json_schema=PR_REVIEW_SCHEMA)
         if raw is None:
             _write_artifact({
@@ -210,9 +241,35 @@ def analyze():
             return
         try:
             pr_result = json.loads(raw)
-            inline_comments = pr_result.get("comments", [])
-        except json.JSONDecodeError:
-            inline_comments = _parse_file_review_multi(raw)
+            if not isinstance(pr_result, dict):
+                raise TypeError("Phase 2 root is not an object")
+            analysis = pr_result.get("analysis", [])
+            if not isinstance(analysis, list):
+                raise TypeError("Phase 2 analysis is not a list")
+            confirmed = []
+            for a in analysis:
+                if not isinstance(a, dict):
+                    continue
+                if a.get("disproved") is True:
+                    continue
+                finding = a.get("finding")
+                if not isinstance(finding, dict):
+                    continue
+                confirmed.append(a)
+            inline_comments = [
+                {
+                    "file": c.get("file") or "",
+                    "line": c.get("line") or 0,
+                    "severity": c["finding"].get("severity") or "",
+                    "comment": c["finding"].get("comment") or "",
+                    "evidence": c["finding"].get("evidence") or "",
+                }
+                for c in confirmed
+            ]
+        except (json.JSONDecodeError, KeyError, TypeError, AttributeError) as e:
+            logger.error("Phase 2 returned unexpected format (%s): %s",
+                         type(e).__name__, (raw or "")[:500])
+            inline_comments = []
 
         # Hard filter: on incremental review, drop comments on files not in the incremental diff
         if incremental_files and inline_comments:
@@ -377,9 +434,13 @@ def act():
 
     if action == "RESPOND":
         inline_comments = result.get("inline_comments", [])
+        if not isinstance(inline_comments, list):
+            inline_comments = []
         # Sanitize inline comment text and keep the sanitized version
         sanitized_comments = []
         for ic in inline_comments:
+            if not isinstance(ic, dict):
+                continue
             safe_comment = sanitize(ic.get("comment", ""))
             if safe_comment is not None:
                 sanitized_comments.append({**ic, "comment": safe_comment})

--- a/src/scripts/issue_bot/main.py
+++ b/src/scripts/issue_bot/main.py
@@ -223,6 +223,7 @@ def analyze():
         report_system = (
             _render(report_tmpl, current_date=datetime.date.today().isoformat())
             + f"\n<diff>\n{diff}\n</diff>\n"
+            + f"<existing_feedback>\n{existing_feedback}\n</existing_feedback>\n"
         )
         # Investigation notes go in user message (scanned by guardrail)
         report_user = (
@@ -270,6 +271,12 @@ def analyze():
             logger.error("Phase 2 returned unexpected format (%s): %s",
                          type(e).__name__, (raw or "")[:500])
             inline_comments = []
+
+        # Hard filter: drop comments without a usable file path or positive line number
+        inline_comments = [
+            c for c in inline_comments
+            if c.get("file") and isinstance(c.get("line"), int) and c["line"] > 0
+        ]
 
         # Hard filter: on incremental review, drop comments on files not in the incremental diff
         if incremental_files and inline_comments:

--- a/src/scripts/issue_bot/prompts.py
+++ b/src/scripts/issue_bot/prompts.py
@@ -50,5 +50,9 @@ def get_followup_prompt():
     return _get_prompt("FOLLOWUP_PROMPT", "SM_FOLLOWUP_PROMPT")
 
 
+def get_pr_file_review_report_prompt():
+    return _get_prompt("PR_FILE_REVIEW_REPORT_PROMPT", "SM_PR_FILE_REVIEW_REPORT_PROMPT")
+
+
 def prompt_version(template):
     return hashlib.sha256(template.encode()).hexdigest()[:8]

--- a/src/scripts/issue_bot/schemas/pr_review_response.json
+++ b/src/scripts/issue_bot/schemas/pr_review_response.json
@@ -1,10 +1,12 @@
 {
   "type": "object",
+  "additionalProperties": false,
   "properties": {
-    "comments": {
+    "analysis": {
       "type": "array",
       "items": {
         "type": "object",
+        "additionalProperties": false,
         "properties": {
           "file": {
             "type": "string"
@@ -12,30 +14,47 @@
           "line": {
             "type": "integer"
           },
-          "severity": {
-            "type": "string",
-            "enum": ["BUG", "EDGE_CASE", "MISSING_TEST", "DESIGN", "NIT"]
-          },
-          "comment": {
+          "hypothesis": {
             "type": "string"
           },
-          "evidence": {
+          "falsification_attempt": {
             "type": "string"
+          },
+          "disproved": {
+            "type": "boolean"
+          },
+          "finding": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+              "severity": {
+                "type": "string",
+                "enum": ["BUG", "EDGE_CASE", "MISSING_TEST", "DESIGN", "NIT"]
+              },
+              "comment": {
+                "type": "string"
+              },
+              "evidence": {
+                "type": "string"
+              },
+              "trigger": {
+                "type": "string"
+              }
+            },
+            "required": ["severity", "comment", "evidence"]
           }
         },
         "required": [
           "file",
           "line",
-          "severity",
-          "comment",
-          "evidence"
-        ],
-        "additionalProperties": false
+          "hypothesis",
+          "falsification_attempt",
+          "disproved"
+        ]
       }
     }
   },
   "required": [
-    "comments"
-  ],
-  "additionalProperties": false
+    "analysis"
+  ]
 }

--- a/src/scripts/tests/conftest.py
+++ b/src/scripts/tests/conftest.py
@@ -1,0 +1,20 @@
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def isolate_sm_env(monkeypatch):
+    """Strip Secrets Manager env vars so dev shell envs don't leak into tests.
+
+    Tests that need a specific prompt set it via PR_FILE_REVIEW_PROMPT etc.
+    Without this, a developer with SM_* set in their shell would trigger
+    real AWS calls during prompts._get_prompt fallback.
+    """
+    for var in (
+        "SM_ISSUE_CLASSIFY_PROMPT",
+        "SM_ISSUE_RESPOND_PROMPT",
+        "SM_PR_FILE_REVIEW_PROMPT",
+        "SM_PR_FILE_REVIEW_REPORT_PROMPT",
+        "SM_FOLLOWUP_PROMPT",
+        "PR_FILE_REVIEW_REPORT_PROMPT",
+    ):
+        monkeypatch.delenv(var, raising=False)

--- a/src/scripts/tests/test_bot.py
+++ b/src/scripts/tests/test_bot.py
@@ -375,6 +375,7 @@ class TestAutoApproveSignal:
 class TestPrompts:
     def test_env_var_takes_precedence(self, monkeypatch):
         monkeypatch.setenv("PR_FILE_REVIEW_PROMPT", "from env")
+        monkeypatch.setenv("PR_FILE_REVIEW_REPORT_PROMPT", "Phase 2: emit findings. Date: {current_date}")
         monkeypatch.setenv("SM_PR_FILE_REVIEW_PROMPT", "deequ-bot/pr-file-review-prompt")
         from issue_bot.prompts import get_pr_file_review_prompt
         assert get_pr_file_review_prompt() == "from env"
@@ -382,6 +383,7 @@ class TestPrompts:
     def test_empty_env_var_falls_through_to_sm(self, monkeypatch):
         import unittest.mock as mock
         monkeypatch.setenv("PR_FILE_REVIEW_PROMPT", "")
+        monkeypatch.setenv("PR_FILE_REVIEW_REPORT_PROMPT", "Phase 2: emit findings. Date: {current_date}")
         monkeypatch.setenv("SM_PR_FILE_REVIEW_PROMPT", "deequ-bot/pr-file-review-prompt")
         with mock.patch("issue_bot.prompts._read_from_sm", return_value="from sm") as m:
             from issue_bot.prompts import get_pr_file_review_prompt
@@ -391,6 +393,7 @@ class TestPrompts:
 
     def test_no_sm_env_var_returns_empty(self, monkeypatch):
         monkeypatch.setenv("PR_FILE_REVIEW_PROMPT", "")
+        monkeypatch.setenv("PR_FILE_REVIEW_REPORT_PROMPT", "Phase 2: emit findings. Date: {current_date}")
         monkeypatch.setenv("SM_PR_FILE_REVIEW_PROMPT", "")
         from issue_bot.prompts import get_pr_file_review_prompt
         # No env var, no SM secret name → empty string
@@ -601,6 +604,119 @@ class TestIncrementalFiltering:
         assert filtered == []
 
 
+class TestPrReviewReportDefensiveParsing:
+    """Phase 2 must not crash on malformed Bedrock output."""
+
+    def _setup_env(self, tmp_path, monkeypatch, event_action="opened"):
+        monkeypatch.setenv("GITHUB_TOKEN", "fake")
+        monkeypatch.setenv("GITHUB_REPOSITORY", "awslabs/test")
+        monkeypatch.setenv("ISSUE_NUMBER", "42")
+        monkeypatch.setenv("EVENT_TYPE", "pull_request_target")
+        monkeypatch.setenv("EVENT_ACTION", event_action)
+        monkeypatch.setenv("EVENT_BEFORE", "")
+        monkeypatch.setenv("EVENT_AFTER", "")
+        monkeypatch.setenv("GITHUB_ACTOR", "contributor")
+        monkeypatch.setenv("KB_S3_BUCKET", "")
+        monkeypatch.setenv("KB_S3_KEY", "")
+        monkeypatch.setenv("PR_FILE_REVIEW_PROMPT", "Review. Date: {current_date}")
+        monkeypatch.setenv("PR_FILE_REVIEW_REPORT_PROMPT", "Phase 2: emit findings. Date: {current_date}")
+        import issue_bot.main as bot_main
+        monkeypatch.setattr(bot_main, "ARTIFACT_PATH", str(tmp_path / "result.json"))
+
+    def _run_with_report_phase(self, tmp_path, monkeypatch, report_phase_json, event_action="opened"):
+        import unittest.mock as mock
+        self._setup_env(tmp_path, monkeypatch, event_action=event_action)
+        with mock.patch("issue_bot.github_client.GitHubClient.get_pr") as mock_pr, \
+             mock.patch("issue_bot.github_client.GitHubClient.get_comments") as mock_comments, \
+             mock.patch("issue_bot.github_client.GitHubClient.get_pr_diff") as mock_diff, \
+             mock.patch("issue_bot.github_client.GitHubClient.get_pr_review_comments") as mock_rc, \
+             mock.patch("issue_bot.github_client.GitHubClient.get_pr_files") as mock_files, \
+             mock.patch("issue_bot.github_client.GitHubClient.get_file_content") as mock_content, \
+             mock.patch("issue_bot.github_client.GitHubClient.get_codebase_map") as mock_map, \
+             mock.patch("issue_bot.github_client.GitHubClient.get_ci_status") as mock_ci, \
+             mock.patch("issue_bot.knowledge_base.KnowledgeBase.load"), \
+             mock.patch("issue_bot.knowledge_base.KnowledgeBase.build_context") as mock_kb, \
+             mock.patch("issue_bot.bedrock_client.BedrockClient.__init__", return_value=None), \
+             mock.patch("issue_bot.bedrock_client.BedrockClient.invoke") as mock_bedrock:
+            mock_pr.return_value = {"user": {"login": "contributor"}, "title": "Fix",
+                                    "body": "", "state": "open",
+                                    "html_url": "https://github.com/x"}
+            mock_comments.return_value = []
+            mock_diff.return_value = "diff"
+            mock_rc.return_value = []
+            mock_files.return_value = [{"filename": "f.py"}]
+            mock_content.return_value = "content"
+            mock_map.return_value = ""
+            mock_kb.return_value = ""
+            mock_ci.return_value = (True, "")
+            mock_bedrock.side_effect = ["investigation text", report_phase_json]
+            from issue_bot.main import analyze
+            analyze()
+            with open(str(tmp_path / "result.json")) as f:
+                return json.load(f)
+
+    def test_severity_null_does_not_crash(self, tmp_path, monkeypatch):
+        result = self._run_with_report_phase(tmp_path, monkeypatch, json.dumps({"analysis": [
+            {"file": "f.py", "line": 1, "hypothesis": "h",
+             "falsification_attempt": "fa", "disproved": False,
+             "finding": {"severity": None, "comment": "c", "evidence": "e"}},
+        ]}), event_action="synchronize")
+        assert result["action"] == "RESPOND"
+        assert len(result["inline_comments"]) == 1
+
+    def test_comment_null_does_not_crash(self, tmp_path, monkeypatch):
+        result = self._run_with_report_phase(tmp_path, monkeypatch, json.dumps({"analysis": [
+            {"file": "f.py", "line": 1, "hypothesis": "h",
+             "falsification_attempt": "fa", "disproved": False,
+             "finding": {"severity": "BUG", "comment": None, "evidence": "e"}},
+        ]}))
+        assert result["action"] == "RESPOND"
+        assert len(result["inline_comments"]) == 1
+
+    def test_file_null_drops_comment_safely(self, tmp_path, monkeypatch):
+        result = self._run_with_report_phase(tmp_path, monkeypatch, json.dumps({"analysis": [
+            {"file": None, "line": 1, "hypothesis": "h",
+             "falsification_attempt": "fa", "disproved": False,
+             "finding": {"severity": "BUG", "comment": "c", "evidence": "e"}},
+        ]}))
+        # file:None coalesces to "" — comment is kept (no incremental filter on first review)
+        assert result["action"] == "RESPOND"
+
+    def test_non_dict_analysis_returns_no_findings(self, tmp_path, monkeypatch):
+        result = self._run_with_report_phase(tmp_path, monkeypatch,
+                                        json.dumps({"analysis": "not-a-list"}))
+        assert result["action"] == "RESPOND"
+        assert result["inline_comments"] == []
+
+    def test_non_dict_analysis_item_skipped(self, tmp_path, monkeypatch):
+        result = self._run_with_report_phase(tmp_path, monkeypatch,
+                                        json.dumps({"analysis": [123, "abc", None]}))
+        assert result["action"] == "RESPOND"
+        assert result["inline_comments"] == []
+
+    def test_disproved_true_excluded_even_with_finding(self, tmp_path, monkeypatch):
+        result = self._run_with_report_phase(tmp_path, monkeypatch, json.dumps({"analysis": [
+            {"file": "f.py", "line": 1, "hypothesis": "h",
+             "falsification_attempt": "fa", "disproved": True,
+             "finding": {"severity": "BUG", "comment": "c", "evidence": "e"}},
+        ]}))
+        assert result["action"] == "RESPOND"
+        assert result["inline_comments"] == []
+
+    def test_finding_missing_excluded(self, tmp_path, monkeypatch):
+        result = self._run_with_report_phase(tmp_path, monkeypatch, json.dumps({"analysis": [
+            {"file": "f.py", "line": 1, "hypothesis": "h",
+             "falsification_attempt": "fa", "disproved": False},
+        ]}))
+        assert result["action"] == "RESPOND"
+        assert result["inline_comments"] == []
+
+    def test_root_not_object_handled(self, tmp_path, monkeypatch):
+        result = self._run_with_report_phase(tmp_path, monkeypatch, json.dumps([1, 2, 3]))
+        assert result["action"] == "RESPOND"
+        assert result["inline_comments"] == []
+
+
 class TestNitFilterAndFormatting:
     """Tests for hard NIT filter on re-reviews and evidence formatting."""
 
@@ -616,6 +732,7 @@ class TestNitFilterAndFormatting:
         monkeypatch.setenv("KB_S3_BUCKET", "")
         monkeypatch.setenv("KB_S3_KEY", "")
         monkeypatch.setenv("PR_FILE_REVIEW_PROMPT", "Review. Date: {current_date}")
+        monkeypatch.setenv("PR_FILE_REVIEW_REPORT_PROMPT", "Phase 2: emit findings. Date: {current_date}")
         import issue_bot.main as bot_main
         monkeypatch.setattr(bot_main, "ARTIFACT_PATH", str(tmp_path / "result.json"))
 
@@ -646,12 +763,22 @@ class TestNitFilterAndFormatting:
             mock_files.return_value = [{"filename": "f.py"}]
             mock_content.return_value = "content"
             mock_ci.return_value = (True, "CI passed")
-            mock_bedrock.return_value = json.dumps({"comments": [
-                {"file": "f.py", "line": 1, "severity": "BUG", "comment": "real bug",
-                 "evidence": "line 1 divides by zero"},
-                {"file": "f.py", "line": 1, "severity": "NIT", "comment": "rename var",
-                 "evidence": "x is not descriptive"},
-            ]})
+            # Phase 1 returns investigation text, Phase 2 returns structured JSON
+            mock_bedrock.side_effect = [
+                "CONFIRMED: f.py line 1 - real bug\nDISPROVED: f.py line 1 - rename var",
+                json.dumps({"analysis": [
+                    {"file": "f.py", "line": 1, "hypothesis": "real bug",
+                     "falsification_attempt": "checked, no guard exists",
+                     "disproved": False,
+                     "finding": {"severity": "BUG", "comment": "real bug",
+                                 "evidence": "line 1 divides by zero", "trigger": "count=0"}},
+                    {"file": "f.py", "line": 1, "hypothesis": "rename var",
+                     "falsification_attempt": "this is just style",
+                     "disproved": False,
+                     "finding": {"severity": "NIT", "comment": "rename var",
+                                 "evidence": "x is not descriptive", "trigger": ""}},
+                ]})
+            ]
 
             bot_main.analyze()
 
@@ -675,6 +802,7 @@ class TestNitFilterAndFormatting:
         monkeypatch.setenv("KB_S3_BUCKET", "")
         monkeypatch.setenv("KB_S3_KEY", "")
         monkeypatch.setenv("PR_FILE_REVIEW_PROMPT", "Review. Date: {current_date}")
+        monkeypatch.setenv("PR_FILE_REVIEW_REPORT_PROMPT", "Phase 2: emit findings. Date: {current_date}")
         import issue_bot.main as bot_main
         monkeypatch.setattr(bot_main, "ARTIFACT_PATH", str(tmp_path / "result.json"))
 
@@ -701,12 +829,17 @@ class TestNitFilterAndFormatting:
             mock_files.return_value = [{"filename": "f.py"}]
             mock_content.return_value = "content"
             mock_ci.return_value = (True, "CI passed")
-            mock_bedrock.return_value = json.dumps({"comments": [
-                {"file": "f.py", "line": 1, "severity": "BUG", "comment": "bug",
-                 "evidence": "evidence1"},
-                {"file": "f.py", "line": 2, "severity": "NIT", "comment": "nit",
-                 "evidence": "evidence2"},
-            ]})
+            mock_bedrock.side_effect = [
+                "CONFIRMED: f.py line 1 - bug\nCONFIRMED: f.py line 2 - nit",
+                json.dumps({"analysis": [
+                    {"file": "f.py", "line": 1, "hypothesis": "bug",
+                     "falsification_attempt": "no guard", "disproved": False,
+                     "finding": {"severity": "BUG", "comment": "bug", "evidence": "evidence1", "trigger": "x=0"}},
+                    {"file": "f.py", "line": 2, "hypothesis": "nit",
+                     "falsification_attempt": "style only", "disproved": False,
+                     "finding": {"severity": "NIT", "comment": "nit", "evidence": "evidence2", "trigger": ""}},
+                ]})
+            ]
 
             bot_main.analyze()
 
@@ -728,6 +861,7 @@ class TestNitFilterAndFormatting:
         monkeypatch.setenv("KB_S3_BUCKET", "")
         monkeypatch.setenv("KB_S3_KEY", "")
         monkeypatch.setenv("PR_FILE_REVIEW_PROMPT", "Review. Date: {current_date}")
+        monkeypatch.setenv("PR_FILE_REVIEW_REPORT_PROMPT", "Phase 2: emit findings. Date: {current_date}")
         import issue_bot.main as bot_main
         monkeypatch.setattr(bot_main, "ARTIFACT_PATH", str(tmp_path / "result.json"))
 
@@ -754,11 +888,17 @@ class TestNitFilterAndFormatting:
             mock_files.return_value = [{"filename": "f.py"}]
             mock_content.return_value = "content"
             mock_ci.return_value = (True, "CI passed")
-            mock_bedrock.return_value = json.dumps({"comments": [
-                {"file": "f.py", "line": 5, "severity": "BUG",
-                 "comment": "division by zero",
-                 "evidence": "line 3 sets count=0, line 5 divides by count"},
-            ]})
+            mock_bedrock.side_effect = [
+                "CONFIRMED: f.py line 5 - division by zero",
+                json.dumps({"analysis": [
+                    {"file": "f.py", "line": 5, "hypothesis": "division by zero",
+                     "falsification_attempt": "no zero check found",
+                     "disproved": False,
+                     "finding": {"severity": "BUG", "comment": "division by zero",
+                                 "evidence": "line 3 sets count=0, line 5 divides by count",
+                                 "trigger": "count=0"}},
+                ]})
+            ]
 
             bot_main.analyze()
 
@@ -786,6 +926,7 @@ class TestIncrementalReviewIntegration:
         monkeypatch.setenv("KB_S3_BUCKET", "")
         monkeypatch.setenv("KB_S3_KEY", "")
         monkeypatch.setenv("PR_FILE_REVIEW_PROMPT", "Review this PR. Date: {current_date}")
+        monkeypatch.setenv("PR_FILE_REVIEW_REPORT_PROMPT", "Phase 2: emit findings. Date: {current_date}")
         import issue_bot.main as bot_main
         monkeypatch.setattr(bot_main, "ARTIFACT_PATH", str(tmp_path / "result.json"))
 
@@ -807,13 +948,15 @@ class TestIncrementalReviewIntegration:
              mock.patch("issue_bot.github_client.GitHubClient.get_pr_files") as mock_files, \
              mock.patch("issue_bot.github_client.GitHubClient.get_file_content") as mock_content, \
              mock.patch("issue_bot.github_client.GitHubClient.get_codebase_map") as mock_map, \
+             mock.patch("issue_bot.github_client.GitHubClient.get_ci_status") as mock_ci, \
              mock.patch("issue_bot.knowledge_base.KnowledgeBase.load"), \
              mock.patch("issue_bot.knowledge_base.KnowledgeBase.build_context") as mock_kb, \
              mock.patch("issue_bot.bedrock_client.BedrockClient.__init__", return_value=None), \
              mock.patch("issue_bot.bedrock_client.BedrockClient.invoke") as mock_bedrock:
 
             mock_pr.return_value = {"user": {"login": "contributor"}, "title": "Fix bug",
-                                    "body": "Fixes the thing", "state": "open", "html_url": "https://github.com/x"}
+                                    "body": "Fixes the thing", "state": "open",
+                                    "html_url": "https://github.com/x", "head": {"sha": "def456"}}
             mock_comments.return_value = [{"user": {"login": "github-actions[bot]"}, "body": "prior review"}]
             mock_diff.return_value = "full diff here"
             mock_rc.return_value = []
@@ -822,12 +965,20 @@ class TestIncrementalReviewIntegration:
             mock_content.return_value = "file content"
             mock_map.return_value = ""
             mock_kb.return_value = ""
-            mock_bedrock.return_value = json.dumps({
-                "comments": [
-                    {"file": "src/fixed.py", "line": 1, "comment": "new issue in changed file"},
-                    {"file": "src/untouched.py", "line": 5, "comment": "stale comment on unchanged file"},
-                ]
-            })
+            mock_ci.return_value = (True, "")
+            mock_bedrock.side_effect = [
+                "CONFIRMED: src/fixed.py line 1 - new issue\nCONFIRMED: src/untouched.py line 5 - stale",
+                json.dumps({"analysis": [
+                    {"file": "src/fixed.py", "line": 1, "hypothesis": "new issue",
+                     "falsification_attempt": "checked", "disproved": False,
+                     "finding": {"severity": "BUG", "comment": "new issue in changed file",
+                                 "evidence": "proof", "trigger": "x"}},
+                    {"file": "src/untouched.py", "line": 5, "hypothesis": "stale",
+                     "falsification_attempt": "checked", "disproved": False,
+                     "finding": {"severity": "BUG", "comment": "stale comment on unchanged file",
+                                 "evidence": "proof", "trigger": "y"}},
+                ]})
+            ]
 
             from issue_bot.main import analyze
             analyze()
@@ -852,13 +1003,15 @@ class TestIncrementalReviewIntegration:
              mock.patch("issue_bot.github_client.GitHubClient.get_pr_files") as mock_files, \
              mock.patch("issue_bot.github_client.GitHubClient.get_file_content") as mock_content, \
              mock.patch("issue_bot.github_client.GitHubClient.get_codebase_map") as mock_map, \
+             mock.patch("issue_bot.github_client.GitHubClient.get_ci_status") as mock_ci, \
              mock.patch("issue_bot.knowledge_base.KnowledgeBase.load"), \
              mock.patch("issue_bot.knowledge_base.KnowledgeBase.build_context") as mock_kb, \
              mock.patch("issue_bot.bedrock_client.BedrockClient.__init__", return_value=None), \
              mock.patch("issue_bot.bedrock_client.BedrockClient.invoke") as mock_bedrock:
 
             mock_pr.return_value = {"user": {"login": "contributor"}, "title": "Fix bug",
-                                    "body": "Fixes the thing", "state": "open", "html_url": "https://github.com/x"}
+                                    "body": "Fixes the thing", "state": "open",
+                                    "html_url": "https://github.com/x", "head": {"sha": "def456"}}
             mock_comments.return_value = [{"user": {"login": "github-actions[bot]"}, "body": "prior review"}]
             mock_diff.return_value = "full diff here"
             mock_rc.return_value = []
@@ -867,11 +1020,16 @@ class TestIncrementalReviewIntegration:
             mock_content.return_value = "content"
             mock_map.return_value = ""
             mock_kb.return_value = ""
-            mock_bedrock.return_value = json.dumps({
-                "comments": [
-                    {"file": "src/a.py", "line": 1, "comment": "issue found"},
-                ]
-            })
+            mock_ci.return_value = (True, "")
+            mock_bedrock.side_effect = [
+                "CONFIRMED: src/a.py line 1 - issue found",
+                json.dumps({"analysis": [
+                    {"file": "src/a.py", "line": 1, "hypothesis": "issue",
+                     "falsification_attempt": "checked", "disproved": False,
+                     "finding": {"severity": "BUG", "comment": "issue found",
+                                 "evidence": "proof", "trigger": "x"}},
+                ]})
+            ]
 
             from issue_bot.main import analyze
             analyze()
@@ -896,6 +1054,7 @@ class TestIncrementalReviewIntegration:
              mock.patch("issue_bot.github_client.GitHubClient.get_pr_files") as mock_files, \
              mock.patch("issue_bot.github_client.GitHubClient.get_file_content") as mock_content, \
              mock.patch("issue_bot.github_client.GitHubClient.get_codebase_map") as mock_map, \
+             mock.patch("issue_bot.github_client.GitHubClient.get_ci_status") as mock_ci, \
              mock.patch("issue_bot.knowledge_base.KnowledgeBase.load"), \
              mock.patch("issue_bot.knowledge_base.KnowledgeBase.build_context") as mock_kb, \
              mock.patch("issue_bot.bedrock_client.BedrockClient.__init__", return_value=None), \
@@ -911,9 +1070,16 @@ class TestIncrementalReviewIntegration:
             mock_content.return_value = "content"
             mock_map.return_value = ""
             mock_kb.return_value = ""
-            mock_bedrock.return_value = json.dumps({"comments": [
-                {"file": "src/a.py", "line": 1, "comment": "issue"},
-            ]})
+            mock_ci.return_value = (True, "")
+            mock_bedrock.side_effect = [
+                "CONFIRMED: src/a.py line 1 - issue found",
+                json.dumps({"analysis": [
+                    {"file": "src/a.py", "line": 1, "hypothesis": "issue",
+                     "falsification_attempt": "no guard", "disproved": False,
+                     "finding": {"severity": "BUG", "comment": "issue",
+                                 "evidence": "evidence", "trigger": "trigger"}},
+                ]})
+            ]
 
             from issue_bot.main import analyze
             analyze()
@@ -941,6 +1107,7 @@ class TestFileContentUsesHeadSha:
         monkeypatch.setenv("KB_S3_BUCKET", "")
         monkeypatch.setenv("KB_S3_KEY", "")
         monkeypatch.setenv("PR_FILE_REVIEW_PROMPT", "Review this PR. Date: {current_date}")
+        monkeypatch.setenv("PR_FILE_REVIEW_REPORT_PROMPT", "Phase 2: emit findings. Date: {current_date}")
         import issue_bot.main as bot_main
         monkeypatch.setattr(bot_main, "ARTIFACT_PATH", str(tmp_path / "result.json"))
 
@@ -955,6 +1122,7 @@ class TestFileContentUsesHeadSha:
              mock.patch("issue_bot.github_client.GitHubClient.get_pr_files") as mock_files, \
              mock.patch("issue_bot.github_client.GitHubClient.get_file_content") as mock_content, \
              mock.patch("issue_bot.github_client.GitHubClient.get_codebase_map") as mock_map, \
+             mock.patch("issue_bot.github_client.GitHubClient.get_ci_status") as mock_ci, \
              mock.patch("issue_bot.knowledge_base.KnowledgeBase.load"), \
              mock.patch("issue_bot.knowledge_base.KnowledgeBase.build_context") as mock_kb, \
              mock.patch("issue_bot.bedrock_client.BedrockClient.__init__", return_value=None), \
@@ -976,7 +1144,11 @@ class TestFileContentUsesHeadSha:
             mock_content.return_value = "file content"
             mock_map.return_value = ""
             mock_kb.return_value = ""
-            mock_bedrock.return_value = json.dumps({"comments": []})
+            mock_ci.return_value = (True, "")
+            mock_bedrock.side_effect = [
+                "No confirmed issues found.",
+                json.dumps({"analysis": []})
+            ]
 
             from issue_bot.main import analyze
             analyze()
@@ -999,6 +1171,7 @@ class TestFileContentUsesHeadSha:
              mock.patch("issue_bot.github_client.GitHubClient.get_pr_files") as mock_files, \
              mock.patch("issue_bot.github_client.GitHubClient.get_file_content") as mock_content, \
              mock.patch("issue_bot.github_client.GitHubClient.get_codebase_map") as mock_map, \
+             mock.patch("issue_bot.github_client.GitHubClient.get_ci_status") as mock_ci, \
              mock.patch("issue_bot.knowledge_base.KnowledgeBase.load"), \
              mock.patch("issue_bot.knowledge_base.KnowledgeBase.build_context") as mock_kb, \
              mock.patch("issue_bot.bedrock_client.BedrockClient.__init__", return_value=None), \
@@ -1017,7 +1190,11 @@ class TestFileContentUsesHeadSha:
             mock_content.return_value = "content"
             mock_map.return_value = ""
             mock_kb.return_value = ""
-            mock_bedrock.return_value = json.dumps({"comments": []})
+            mock_ci.return_value = (None, "")
+            mock_bedrock.side_effect = [
+                "No confirmed issues found.",
+                json.dumps({"analysis": []})
+            ]
 
             from issue_bot.main import analyze
             analyze()
@@ -1045,6 +1222,7 @@ class TestReviewEventType:
         monkeypatch.setenv("KB_S3_BUCKET", "")
         monkeypatch.setenv("KB_S3_KEY", "")
         monkeypatch.setenv("PR_FILE_REVIEW_PROMPT", "Review. Date: {current_date}")
+        monkeypatch.setenv("PR_FILE_REVIEW_REPORT_PROMPT", "Phase 2: emit findings. Date: {current_date}")
         import issue_bot.main as bot_main
         monkeypatch.setattr(bot_main, "ARTIFACT_PATH", str(tmp_path / "result.json"))
 
@@ -1059,6 +1237,7 @@ class TestReviewEventType:
              mock.patch("issue_bot.github_client.GitHubClient.get_pr_files") as mock_files, \
              mock.patch("issue_bot.github_client.GitHubClient.get_file_content") as mock_content, \
              mock.patch("issue_bot.github_client.GitHubClient.get_codebase_map") as mock_map, \
+             mock.patch("issue_bot.github_client.GitHubClient.get_ci_status") as mock_ci, \
              mock.patch("issue_bot.knowledge_base.KnowledgeBase.load"), \
              mock.patch("issue_bot.knowledge_base.KnowledgeBase.build_context") as mock_kb, \
              mock.patch("issue_bot.bedrock_client.BedrockClient.__init__", return_value=None), \
@@ -1085,9 +1264,16 @@ class TestReviewEventType:
             mock_content.return_value = "content"
             mock_map.return_value = ""
             mock_kb.return_value = ""
-            mock_bedrock.return_value = json.dumps({
-                "comments": [{"file": "f.py", "line": 1, "comment": "issue"}]
-            })
+            mock_ci.return_value = (True, "")
+            mock_bedrock.side_effect = [
+                "CONFIRMED: f.py line 1 - issue",
+                json.dumps({"analysis": [
+                    {"file": "f.py", "line": 1, "hypothesis": "issue",
+                     "falsification_attempt": "checked", "disproved": False,
+                     "finding": {"severity": "BUG", "comment": "issue",
+                                 "evidence": "proof", "trigger": "x"}},
+                ]})
+            ]
             mock_post.return_value = True
 
             from issue_bot.main import analyze, act

--- a/src/scripts/tests/test_bot.py
+++ b/src/scripts/tests/test_bot.py
@@ -679,8 +679,9 @@ class TestPrReviewReportDefensiveParsing:
              "falsification_attempt": "fa", "disproved": False,
              "finding": {"severity": "BUG", "comment": "c", "evidence": "e"}},
         ]}))
-        # file:None coalesces to "" — comment is kept (no incremental filter on first review)
+        # file:None coalesces to "" → dropped by the file/line hard filter
         assert result["action"] == "RESPOND"
+        assert result["inline_comments"] == []
 
     def test_non_dict_analysis_returns_no_findings(self, tmp_path, monkeypatch):
         result = self._run_with_report_phase(tmp_path, monkeypatch,
@@ -714,6 +715,30 @@ class TestPrReviewReportDefensiveParsing:
     def test_root_not_object_handled(self, tmp_path, monkeypatch):
         result = self._run_with_report_phase(tmp_path, monkeypatch, json.dumps([1, 2, 3]))
         assert result["action"] == "RESPOND"
+        assert result["inline_comments"] == []
+
+    def test_zero_line_dropped(self, tmp_path, monkeypatch):
+        result = self._run_with_report_phase(tmp_path, monkeypatch, json.dumps({"analysis": [
+            {"file": "f.py", "line": 0, "hypothesis": "h",
+             "falsification_attempt": "fa", "disproved": False,
+             "finding": {"severity": "BUG", "comment": "c", "evidence": "e"}},
+        ]}))
+        assert result["inline_comments"] == []
+
+    def test_negative_line_dropped(self, tmp_path, monkeypatch):
+        result = self._run_with_report_phase(tmp_path, monkeypatch, json.dumps({"analysis": [
+            {"file": "f.py", "line": -3, "hypothesis": "h",
+             "falsification_attempt": "fa", "disproved": False,
+             "finding": {"severity": "BUG", "comment": "c", "evidence": "e"}},
+        ]}))
+        assert result["inline_comments"] == []
+
+    def test_empty_file_dropped(self, tmp_path, monkeypatch):
+        result = self._run_with_report_phase(tmp_path, monkeypatch, json.dumps({"analysis": [
+            {"file": "", "line": 5, "hypothesis": "h",
+             "falsification_attempt": "fa", "disproved": False,
+             "finding": {"severity": "BUG", "comment": "c", "evidence": "e"}},
+        ]}))
         assert result["inline_comments"] == []
 
 


### PR DESCRIPTION
## Summary

The bot's PR review path used a single Bedrock call that emitted findings as structured JSON. Sequential autoregressive token generation commits the model to a hypothesis before any chance to falsify it, which produces anchoring-bias false positives.

This PR splits the call into two phases:

**Phase 1 — investigation** (free-form, no schema). The model identifies potential concerns and, for each, attempts to disprove them by checking the full source files, knowledge base, and codebase map. Each concern ends up tagged `STATUS: CONFIRMED` (could not disprove) or `STATUS: DISPROVED` (found counter-evidence).

**Phase 2 — report** (schema-enforced). The model receives the Phase 1 investigation notes and the diff, and emits an `analysis` array where each item carries `hypothesis`, `falsification_attempt`, `disproved` (bool), and an optional `finding` block (`severity`, `comment`, `evidence`, `trigger`). The bot filters out `disproved=true` items before posting, so confirmed findings are the only ones that reach reviewers.

### What changed

- `src/scripts/issue_bot/main.py` — `_handle_pr` now does two `bedrock.invoke` calls. Phase 2's input is `<diff>` + investigation notes (not the full source files, since Phase 1 already analyzed them). Defensive parsing on the Phase 2 output: `isinstance` guards, `or ""` coalescing on every field, `AttributeError` in the except tuple, raw output logged on parse failure. `act()` guards against malformed `inline_comments` from corrupted artifacts.
- `src/scripts/issue_bot/schemas/pr_review_response.json` — replaces the flat `comments` array with the falsification-shaped `analysis` array. `additionalProperties: false` at all three object levels matches the strictness of the issue/follow-up schemas.
- `src/scripts/issue_bot/prompts.py` — adds `get_pr_file_review_report_prompt()` reading from `PR_FILE_REVIEW_REPORT_PROMPT` / `SM_PR_FILE_REVIEW_REPORT_PROMPT`. If the secret is missing, the bot escalates (matching the convention used by every other prompt in this module — there is no in-code fallback prompt).
- `.github/workflows/issue-bot.yml` — wires `SM_PR_FILE_REVIEW_REPORT_PROMPT` to the new SM secret name.
- `src/scripts/tests/conftest.py` (new) — autouse fixture strips `SM_*` and `PR_FILE_REVIEW_REPORT_PROMPT` env vars so a developer's shell environment can't leak into tests.
- `src/scripts/tests/test_bot.py` — adds `TestPrReviewReportDefensiveParsing` (8 tests covering null fields, non-dict items, non-list `analysis`, missing `finding`, `disproved=true`, and non-object root). Updates 11 existing tests to mock `mock_bedrock.side_effect = [phase1_text, phase2_json]` instead of a single `return_value`, and to mock `get_ci_status` so they don't hit `api.github.com`.

### Out of band (already applied)

- New SM secret `pr-file-review-report-prompt` created for `deequ-bot`, `pydeequ-bot`, and `dqdl-bot` with the Phase 2 prompt content.
- Existing `pr-file-review-prompt` SM secrets updated for all three bots so Phase 1 emits the `STATUS: CONFIRMED|DISPROVED` markers Phase 2 expects.
- IAM policies (`DeequBotBedrockAccess`, `PyDeequBotBedrockAccess`, `DqdlBotBedrockAccess`) already use `${bot}/*` resource wildcards, so no policy changes are needed for the new secret names.

### Cost / latency

Every PR review now makes two Bedrock calls instead of one. Phase 2's input is small (only the diff + Phase 1's notes — no full source files), so the marginal cost is roughly +30%. Latency increases by ~10s per review.

## Test plan

- [ ] PR opens triggers two Bedrock calls in workflow logs
- [ ] Clean PR returns `No issues found.` with the clean marker
- [ ] PR with a real bug still gets caught
- [ ] Auto-approve workflow still triggers on the clean marker
- [ ] Re-review on `synchronize` still drops NIT severity findings

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.