### PR TITLE
Add tail support to categorical Histogram

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/Histogram.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/Histogram.scala
@@ -62,6 +62,9 @@ case class Histogram(
     with Analyzer[FrequenciesAndNumRows, HistogramMetric] {
 
   protected[this] val PARAM_CHECK: StructType => Unit = { _ =>
+    if (maxDetailBins < 1) {
+      throw new IllegalAnalyzerParameterException("maxDetailBins must be at least 1")
+    }
     if (maxDetailBins > Histogram.MaximumAllowedDetailBins) {
       throw new IllegalAnalyzerParameterException(s"Cannot return histogram values for more " +
         s"than ${Histogram.MaximumAllowedDetailBins} values")
@@ -104,19 +107,19 @@ case class Histogram(
             .map(_.name)
             .getOrElse(throw new IllegalStateException(s"Count column not found in the frequencies DataFrame"))
 
+          val binCount = theState.frequencies.count()
+
           // sort in descending frequency
-          val topNRowsDF = theState.frequencies
+          val topNRows = theState.frequencies
             .orderBy(col(countColumnName).desc, col(column).asc)
             .limit(maxDetailBins)
             .collect()
-
-          val binCount = theState.frequencies.count()
 
           val columnName = theState.frequencies.columns
             .find(_ == column)
             .getOrElse(throw new IllegalStateException(s"Column $column not found"))
 
-          val histogramDetails = topNRowsDF
+          val histogramDetails = topNRows
             .map { row =>
               val discreteValue = row.getAs[String](columnName)
               val absolute = row.getAs[Long](countColumnName)
@@ -124,7 +127,14 @@ case class Histogram(
               discreteValue -> DistributionValue(absolute, ratio)
             }(collection.breakOut): ListMap[String, DistributionValue]
 
-          Distribution(histogramDetails, binCount)
+          val tailCount = if (binCount > maxDetailBins) {
+            val topNSum = histogramDetails.values.map(_.absolute).sum
+            val totalSum = theState.frequencies.agg(
+              spark_sum(countColumnName)).collect()(0).getAs[Long](0)
+            totalSum - topNSum
+          } else 0L
+
+          Distribution(histogramDetails, binCount, tailCount)
         }
 
         HistogramMetric(column, value)

--- a/src/main/scala/com/amazon/deequ/metrics/HistogramMetric.scala
+++ b/src/main/scala/com/amazon/deequ/metrics/HistogramMetric.scala
@@ -20,7 +20,8 @@ import scala.util.{Failure, Success, Try}
 
 case class DistributionValue(absolute: Long, ratio: Double)
 
-case class Distribution(values: Map[String, DistributionValue], numberOfBins: Long) {
+case class Distribution(values: Map[String, DistributionValue], numberOfBins: Long,
+                        tailCount: Long = 0) {
 
   def apply(key: String): DistributionValue = {
     values(key)
@@ -50,7 +51,13 @@ case class HistogramMetric(column: String, value: Try[Distribution]) extends Met
             DoubleMetric(entity, s"$name.abs.$key", instance, Success(distValue.absolute)) ::
               DoubleMetric(entity, s"$name.ratio.$key", instance, Success(distValue.ratio)) :: Nil
           }
-        numberOfBins ++ details
+
+        val tail = if (distribution.tailCount > 0) {
+          Seq(DoubleMetric(entity, s"$name.tailCount", instance,
+            Success(distribution.tailCount.toDouble)))
+        } else Seq.empty
+
+        numberOfBins ++ details ++ tail
       }
       .recover {
         case e: Exception => Seq(DoubleMetric(entity, s"$name.bins", instance, Failure(e)))

--- a/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
+++ b/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
@@ -904,6 +904,10 @@ private[deequ] object DistributionSerializer extends JsonSerializer[Distribution
 
     result.add("values", values)
 
+    if (distribution.tailCount > 0) {
+      result.addProperty("tailCount", distribution.tailCount)
+    }
+
     result
   }
 }
@@ -924,7 +928,8 @@ private[deequ] object DistributionDeserializer extends JsonDeserializer[Distribu
       }
       .toMap
 
-    Distribution(values, jsonObject.get("numberOfBins").getAsLong)
+    Distribution(values, jsonObject.get("numberOfBins").getAsLong,
+      if (jsonObject.has("tailCount")) jsonObject.get("tailCount").getAsLong else 0L)
   }
 }
 

--- a/src/test/scala/com/amazon/deequ/analyzers/HistogramTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/HistogramTest.scala
@@ -345,4 +345,278 @@ class HistogramTest extends AnyWordSpec with Matchers with SparkContextSpec with
       distribution.values("NullValue").absolute shouldBe 4
     }
   }
+
+  "Histogram (tail)" should {
+    "compute tailCount when categories exceed maxDetailBins" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(
+        "A", "A", "A", "A", "A",  // 5
+        "B", "B", "B", "B",       // 4
+        "C", "C", "C",            // 3
+        "D", "D",                 // 2
+        "E"                       // 1
+      ).toDF("category")
+
+      val histogram = Histogram("category", maxDetailBins = 3)
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      // Top 3 by frequency: A=5, B=4, C=3
+      distribution.values.size shouldBe 3
+      distribution.values("A").absolute shouldBe 5
+      distribution.values("B").absolute shouldBe 4
+      distribution.values("C").absolute shouldBe 3
+
+      // Tail: D=2 + E=1 = 3
+      distribution.tailCount shouldBe 3
+
+      // Total categories
+      distribution.numberOfBins shouldBe 5
+    }
+
+    "have zero tailCount when categories fit within maxDetailBins" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq("A", "A", "B", "B", "C").toDF("category")
+
+      val histogram = Histogram("category", maxDetailBins = 10)
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      distribution.values.size shouldBe 3
+      distribution.tailCount shouldBe 0
+    }
+
+    "have zero tailCount when categories exactly equal maxDetailBins" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq("A", "A", "B", "C").toDF("category")
+
+      val histogram = Histogram("category", maxDetailBins = 3)
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      distribution.values.size shouldBe 3
+      distribution.tailCount shouldBe 0
+    }
+
+    "compute tailCount with maxDetailBins = 1" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq("A", "A", "A", "B", "B", "C").toDF("category")
+
+      val histogram = Histogram("category", maxDetailBins = 1)
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      distribution.values.size shouldBe 1
+      distribution.values("A").absolute shouldBe 3
+      // Tail: B=2 + C=1 = 3
+      distribution.tailCount shouldBe 3
+    }
+
+    "compute tailCount with nulls present" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(Some("A"), Some("A"), Some("B"), None, Some("C"), None).toDF("category")
+
+      val histogram = Histogram("category", maxDetailBins = 2)
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      // Top 2: A=2, NullValue=2 (sorted by freq desc, then name asc)
+      distribution.values.size shouldBe 2
+      // Tail: B=1 + C=1 = 2
+      distribution.tailCount shouldBe 2
+    }
+
+    "compute tailCount with Sum aggregation" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(
+        ("A", 100), ("A", 200),
+        ("B", 50), ("B", 75),
+        ("C", 10), ("D", 5)
+      ).toDF("category", "amount")
+
+      val histogram = Histogram("category", maxDetailBins = 2,
+        aggregateFunction = Histogram.Sum("amount"))
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      // Top 2 by sum: A=300, B=125
+      distribution.values.size shouldBe 2
+      distribution.values("A").absolute shouldBe 300
+      distribution.values("B").absolute shouldBe 125
+      // Tail: C=10 + D=5 = 15
+      distribution.tailCount shouldBe 15
+    }
+
+    "compute tailCount larger than any individual top bin" in withSparkSession { spark =>
+      import spark.implicits._
+
+      // 50 rare categories with 2 each = 100 in tail
+      // Top 3 categories have 10, 8, 6
+      val topData = Seq.fill(10)("Top1") ++ Seq.fill(8)("Top2") ++ Seq.fill(6)("Top3")
+      val tailData = (1 to 50).flatMap(i => Seq.fill(2)(s"Rare$i"))
+      val data = (topData ++ tailData).toDF("category")
+
+      val histogram = Histogram("category", maxDetailBins = 3)
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      distribution.values.size shouldBe 3
+      distribution.values("Top1").absolute shouldBe 10
+      // Tail = 100, larger than any single top bin
+      distribution.tailCount shouldBe 100
+      distribution.tailCount should be > distribution.values("Top1").absolute
+    }
+
+    "break ties alphabetically when frequencies are equal" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(
+        "Banana", "Banana",
+        "Apple", "Apple",
+        "Cherry", "Cherry",
+        "Date", "Date"
+      ).toDF("category")
+
+      val histogram = Histogram("category", maxDetailBins = 2)
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      // All have frequency 2, tie-broken alphabetically ascending
+      distribution.values.size shouldBe 2
+      val keys = distribution.values.keys.toSeq
+      keys should contain("Apple")
+      keys should contain("Banana")
+      // Cherry and Date go to tail
+      distribution.tailCount shouldBe 4
+    }
+
+    "have correct ratios relative to total including tail" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(
+        "A", "A", "A", "A", "A",  // 5
+        "B", "B", "B",            // 3
+        "C", "C"                  // 2
+      ).toDF("category")
+
+      val histogram = Histogram("category", maxDetailBins = 2)
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      // Ratios should be relative to total (10), not just top N
+      distribution.values("A").ratio shouldBe 0.5 +- 0.001
+      distribution.values("B").ratio shouldBe 0.3 +- 0.001
+      distribution.tailCount shouldBe 2
+    }
+
+    "throw when maxDetailBins is 0" in withSparkSession { spark =>
+      import spark.implicits._
+      import com.amazon.deequ.analyzers.runners.AnalysisRunner
+
+      val data = Seq("A", "B").toDF("category")
+      val histogram = Histogram("category", maxDetailBins = 0)
+
+      val analysis = AnalysisRunner.onData(data).addAnalyzer(histogram)
+      val result = analysis.run()
+
+      val metric = result.metricMap(histogram)
+      metric.value.isFailure shouldBe true
+    }
+
+    "compute tailCount with where filter" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(
+        (1, "A"), (2, "A"), (3, "A"),
+        (4, "B"), (5, "B"),
+        (6, "C"), (7, "C"),
+        (8, "D")
+      ).toDF("id", "category")
+
+      val histogram = Histogram("category", maxDetailBins = 2, where = Some("id <= 6"))
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      // Filtered data: A=3, B=2, C=1 (id 6 has C, id 7 excluded)
+      distribution.values.size shouldBe 2
+      distribution.values("A").absolute shouldBe 3
+      distribution.values("B").absolute shouldBe 2
+      distribution.tailCount shouldBe 1  // C=1
+    }
+
+    "compute tailCount with binningUdf" in withSparkSession { spark =>
+      import spark.implicits._
+      import org.apache.spark.sql.functions.udf
+
+      val data = Seq("US", "USA", "UK", "GB", "France", "Germany", "Italy").toDF("country")
+
+      // UDF groups US/USA and UK/GB together
+      val normalize = udf((s: String) => s match {
+        case "US" | "USA" => "US"
+        case "UK" | "GB" => "UK"
+        case other => other
+      })
+
+      val histogram = Histogram("country", binningUdf = Some(normalize), maxDetailBins = 2)
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      // After UDF: US=2, UK=2, France=1, Germany=1, Italy=1
+      distribution.values.size shouldBe 2
+      // Tail: remaining categories after UDF grouping
+      distribution.tailCount shouldBe 3  // France + Germany + Italy
+    }
+
+    "emit tailCount in flatten() when tail exists" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq("A", "A", "A", "B", "B", "C").toDF("category")
+
+      val histogram = Histogram("category", maxDetailBins = 1)
+      val metric = histogram.calculate(data)
+
+      val flattened = metric.flatten()
+      flattened.exists(m => m.name == "Histogram.tailCount" && m.value.get == 3.0) shouldBe true
+    }
+
+    "not emit tailCount in flatten() when no tail" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq("A", "B").toDF("category")
+
+      val histogram = Histogram("category", maxDetailBins = 10)
+      val metric = histogram.calculate(data)
+
+      val flattened = metric.flatten()
+      flattened.exists(_.name == "Histogram.tailCount") shouldBe false
+    }
+  }
 }

--- a/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
@@ -592,6 +592,37 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
     assert(deserialized == List(result))
   }
 
+  "Distribution with tailCount" should "round-trip serialize and deserialize" in {
+    val analyzer = Histogram("category", maxDetailBins = 3)
+    val metric = HistogramMetric("category", Success(Distribution(
+      Map("A" -> DistributionValue(5, 0.5), "B" -> DistributionValue(3, 0.3)),
+      5, 2)))
+    val context = AnalyzerContext(Map(analyzer -> metric))
+    val result = new AnalysisResult(ResultKey(0), context)
+
+    val serialized = serialize(List(result))
+    val deserialized = deserialize(serialized)
+    assert(deserialized == List(result))
+
+    // Verify tailCount is in the JSON
+    serialized should include("tailCount")
+  }
+
+  "Distribution without tail" should "not include tailCount in JSON" in {
+    val analyzer = Histogram("category")
+    val metric = HistogramMetric("category", Success(Distribution(
+      Map("A" -> DistributionValue(5, 0.5), "B" -> DistributionValue(5, 0.5)),
+      2, 0)))
+    val context = AnalyzerContext(Map(analyzer -> metric))
+    val result = new AnalysisResult(ResultKey(0), context)
+
+    val serialized = serialize(List(result))
+    serialized should not include("tailCount")
+
+    val deserialized = deserialize(serialized)
+    assert(deserialized == List(result))
+  }
+
   def assertCorrectlyConvertsAnalysisResults(
       analysisResults: Seq[AnalysisResult],
       shouldFail: Boolean = false)


### PR DESCRIPTION
### Description of changes

Adds `tailCount` to the categorical `Distribution` class. When `maxDetailBins` truncates the histogram (more categories than the limit), the frequencies of the dropped categories are now summed into `tailCount` instead of being silently lost.

#### Before

```
// 50 categories, maxDetailBins = 5
val dist = Histogram("department", maxDetailBins = 5).calculate(df).value.get
dist.values.size      // 5 (top 5 by frequency)
dist.numberOfBins     // 50 (total distinct)
// The other 45 categories' counts? Gone.
```

#### After

```
val dist = Histogram("department", maxDetailBins = 5).calculate(df).value.get
dist.values.size      // 5 (top 5 by frequency)
dist.numberOfBins     // 50 (total distinct)
dist.tailCount        // 312 (sum of frequencies for the other 45 categories)
```

#### Why

- Enables drift detection: if `tailCount / total > threshold`, the distribution is shifting away from the top categories
- No data loss: total is always recoverable as `sum(values) + tailCount`
- Backward compatible: `tailCount` defaults to 0, not serialized when 0

#### Changes

- **HistogramMetric.scala**: adds `tailCount: Long = 0` to `Distribution`
- **Histogram.scala**: computes `tailCount` as `totalSum - topNSum` when categories exceed `maxDetailBins`. Adds `maxDetailBins >= 1` validation.
- **AnalysisResultSerde.scala**: serialize `tailCount` when > 0, deserialize with fallback to 0

### Testing

- **Tail when categories exceed maxDetailBins**: top 3 of 5 categories, tail = sum of remaining 2
- **Zero tail when categories fit**: no truncation, tailCount = 0
- **Zero tail when categories exactly equal maxDetailBins**: boundary case
- **Tail with maxDetailBins = 1**: single category shown, rest in tail
- **Tail with nulls**: NullValue category participates in top-N ranking, tail computed correctly
- **Tail with Sum aggregation**: tail reflects summed aggregate, not row count
- **Tail larger than any top bin**: many rare categories produce large tail
- **Tie-breaking**: equal frequencies broken alphabetically (deterministic)
- **Ratio correctness**: ratios relative to total (including tail), not just top N
- **maxDetailBins = 0 throws**: validation enforced
- **Tail with where filter**: filtered data computes tail correctly
- **Tail with binningUdf**: UDF groups values first, tail applies to grouped result
- **Serde round-trip with tailCount**: serialize/deserialize preserves tailCount
- **Tail = 0 not serialized**: JSON omits field when 0 (backward compat)

##### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.