### PR TITLE
Emit nullCount in HistogramBinned flatten() for metrics output

### DIFF
--- a/src/main/scala/com/amazon/deequ/metrics/HistogramBinnedMetric.scala
+++ b/src/main/scala/com/amazon/deequ/metrics/HistogramBinnedMetric.scala
@@ -59,7 +59,13 @@ case class HistogramBinnedMetric(column: String, value: Try[DistributionBinned])
         val details = distribution.bins.zipWithIndex.map { case (binData, index) =>
           DoubleMetric(entity, s"$name.abs.bin$index", instance, Success(binData.frequency))
         }
-        numberOfBins +: details
+
+        val nulls = if (distribution.nullCount > 0) {
+          Seq(DoubleMetric(entity, s"$name.nullCount", instance,
+            Success(distribution.nullCount.toDouble)))
+        } else Seq.empty
+
+        numberOfBins +: (details ++ nulls)
       }
       .recover {
         case e: Exception => Seq(DoubleMetric(entity, s"$name.bins", instance, Failure(e)))

--- a/src/test/scala/com/amazon/deequ/analyzers/HistogramBinnedTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/HistogramBinnedTest.scala
@@ -194,6 +194,28 @@ class HistogramBinnedTest extends AnyWordSpec with Matchers with SparkContextSpe
       distribution.nullCount shouldBe 3
     }
 
+    "emit nullCount in flatten() when nulls exist" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(Some(1.0), None, Some(5.0), None).toDF("values")
+      val histogram = HistogramBinned("values", binCount = Some(3))
+      val metric = histogram.calculate(data)
+
+      val flattened = metric.flatten()
+      flattened.exists(m => m.name == "HistogramBinned.nullCount" && m.value.get == 2.0) shouldBe true
+    }
+
+    "not emit nullCount in flatten() when no nulls" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(1.0, 2.0, 3.0).toDF("values")
+      val histogram = HistogramBinned("values", binCount = Some(3))
+      val metric = histogram.calculate(data)
+
+      val flattened = metric.flatten()
+      flattened.exists(_.name == "HistogramBinned.nullCount") shouldBe false
+    }
+
     "aggregate sum works as expected" in withSparkSession { spark =>
       import spark.implicits._
 


### PR DESCRIPTION
### Description of changes

Fixes a gap in `HistogramBinnedMetric.flatten()` where `nullCount` was not emitted as a `DoubleMetric`. This meant `nullCount` was invisible in `successMetricsAsDataFrame` / `successMetricsAsJson` outputs. Users relying on those APIs couldn't see null counts for numeric histograms.

Caught by automated review in PR (#720)

> `HistogramMetric.flatten()` does not emit a `DoubleMetric` for `tailCount`, so the tail information is invisible in `successMetricsAsDataFrame/successMetricsAsJson` outputs.

The same pattern applied to `nullCount` in `HistogramBinnedMetric`. Introduced in the null-bin-refactor PR (#715) but missed in `flatten()`.

#### Changes

- **HistogramBinnedMetric.scala**: emit `HistogramBinned.nullCount` in `flatten()` when > 0

### Testing

- **Emit nullCount when nulls exist**: verifies `HistogramBinned.nullCount` appears in flattened output with correct value
- **No nullCount when no nulls**: verifies field is absent when `nullCount` is 0

##### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.