### PR TITLE
Fix NPE: encode bin edges in BinnedFrequencies state instead of mutab…

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/HistogramBinned.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/HistogramBinned.scala
@@ -42,6 +42,19 @@ import org.apache.spark.sql.types.StructType
 import scala.util.Failure
 import scala.util.Try
 
+/** State for HistogramBinned that carries bin edges alongside frequencies. */
+case class BinnedFrequencies(
+  frequencies: DataFrame,
+  numRows: Long,
+  edges: Array[Double]
+) extends State[BinnedFrequencies] {
+
+  override def sum(other: BinnedFrequencies): BinnedFrequencies = {
+    throw new UnsupportedOperationException(
+      "BinnedFrequencies states cannot be merged. Use calculate() on the full dataset.")
+  }
+}
+
 /**
  * Histogram analyzer for numerical data with binning support.
  * Currently supports equal-width bins.
@@ -57,7 +70,7 @@ case class HistogramBinned(
                             // by bin index (which becomes categorical data)
                             override val aggregateFunction: AggregateFunction = Histogram.Count)
   extends HistogramBase(column, where, computeFrequenciesAsRatio, aggregateFunction)
-    with Analyzer[FrequenciesAndNumRows, HistogramBinnedMetric] {
+    with Analyzer[BinnedFrequencies, HistogramBinnedMetric] {
 
   require(binCount.isDefined ^ customEdges.isDefined,
     "Must specify either binCount (equal-width) or customEdges (custom)")
@@ -112,7 +125,7 @@ case class HistogramBinned(
   }
 
   override def computeStateFrom(data: DataFrame,
-                                filterCondition: Option[String] = None): Option[FrequenciesAndNumRows] = {
+                                filterCondition: Option[String] = None): Option[BinnedFrequencies] = {
 
     val totalCount = if (computeFrequenciesAsRatio) {
       aggregateFunction.total(data)
@@ -209,7 +222,7 @@ case class HistogramBinned(
 
     val frequencies = aggregateFunction.query(column, binnedData)
 
-    Some(FrequenciesAndNumRows(frequencies, totalCount))
+    Some(BinnedFrequencies(frequencies, totalCount, storedEdges))
   }
 
   private def computeCustomEdges(): Array[Double] = {
@@ -247,7 +260,7 @@ case class HistogramBinned(
     addOverflowEdges(edges)
   }
 
-  override def computeMetricFrom(state: Option[FrequenciesAndNumRows]): HistogramBinnedMetric = {
+  override def computeMetricFrom(state: Option[BinnedFrequencies]): HistogramBinnedMetric = {
     state match {
       case Some(theState) =>
         val value: Try[DistributionBinned] = Try {
@@ -266,10 +279,12 @@ case class HistogramBinned(
               binValue -> DistributionValue(absolute, ratio)
             }.toMap
 
+          val edges = theState.edges
+
           // Convert to BinData objects
-          val binDataSeq = (0 until storedEdges.length - 1).map { binIndex =>
-            val binStart = storedEdges(binIndex)
-            val binEnd = storedEdges(binIndex + 1)
+          val binDataSeq = (0 until edges.length - 1).map { binIndex =>
+            val binStart = edges(binIndex)
+            val binEnd = edges(binIndex + 1)
             val distValue = histogramDetails.get(binIndex.toString).getOrElse(DistributionValue(0, 0.0))
             BinData(binStart, binEnd, distValue.absolute, distValue.ratio)
           }.toVector

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -238,7 +238,7 @@ object Constraint {
     val actualBinCount = if (customEdges.isDefined) None else binCount
     val histogramBinned = HistogramBinned(column, actualBinCount, customEdges, where = where)
 
-    val constraint = AnalysisBasedConstraint[FrequenciesAndNumRows, DistributionBinned, DistributionBinned](
+    val constraint = AnalysisBasedConstraint[BinnedFrequencies, DistributionBinned, DistributionBinned](
       histogramBinned, assertion, hint = hint)
 
     new NamedConstraint(constraint, s"HistogramBinnedConstraint($histogramBinned)")
@@ -261,7 +261,7 @@ object Constraint {
     val actualBinCount = if (customEdges.isDefined) None else binCount
     val histogramBinned = HistogramBinned(column, actualBinCount, customEdges, where = where)
 
-    val constraint = AnalysisBasedConstraint[FrequenciesAndNumRows, DistributionBinned, Long](
+    val constraint = AnalysisBasedConstraint[BinnedFrequencies, DistributionBinned, Long](
       histogramBinned, assertion, Some(_.numberOfBins), hint)
 
     new NamedConstraint(constraint, s"HistogramBinnedBinConstraint($histogramBinned)")

--- a/src/test/scala/com/amazon/deequ/analyzers/HistogramBinnedTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/HistogramBinnedTest.scala
@@ -1031,6 +1031,29 @@ class HistogramBinnedTest extends AnyWordSpec with Matchers with SparkContextSpe
     }
   }
 
+  "HistogramBinned state" should {
+    "compute metric from state without calling computeStateFrom (no NPE)" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val edges = Array(0.0, 10.0, 20.0)
+      val data = Seq("0" -> 3L, "1" -> 5L).toDF("values", "count")
+      val frequencies = data.withColumnRenamed("count", Analyzers.COUNT_COL)
+
+      val state = BinnedFrequencies(frequencies, 8L, edges)
+      val analyzer = HistogramBinned("values", customEdges = Some(edges))
+      val metric = analyzer.computeMetricFrom(Some(state))
+
+      metric.value.isSuccess shouldBe true
+      val dist = metric.value.get
+      dist.bins(0).binStart shouldBe 0.0
+      dist.bins(0).binEnd shouldBe 10.0
+      dist.bins(0).frequency shouldBe 3
+      dist.bins(1).binStart shouldBe 10.0
+      dist.bins(1).binEnd shouldBe 20.0
+      dist.bins(1).frequency shouldBe 5
+    }
+  }
+
   "HistogramBinned parameter validation" should {
     "throw IllegalArgumentException when neither binCount nor customEdges is provided" in {
       val exception = intercept[IllegalArgumentException] {


### PR DESCRIPTION
### Description of changes

Fixes a `NullPointerException` in `HistogramBinned.computeMetricFrom` when called on a loaded state without a preceding `computeStateFrom` call (e.g., incremental profiling with state persistence).

Flagged by automated review on #716:
> `storedEdges` is a mutable var initialized to null. If `computeMetricFrom` is called before `computeStateFrom` (e.g., when loading from a state provider), accessing `storedEdges` will throw a `NullPointerException`.

#### Problem

`computeMetricFrom` read bin edges from a private var `storedEdges` on the class instance. This var was only set during `computeStateFrom`. If a user loaded a saved state and called `computeMetricFrom` directly, `storedEdges` was null (leading to a NPE).

#### Fix

Introduces `BinnedFrequencies`: a new state type that carries `edges: Array[Double]` alongside the frequencies DataFrame. `computeMetricFrom` now reads edges from the state parameter, not from a class-level var.

```
// Before: edges on the class instance (null if computeStateFrom not called)
private var storedEdges: Array[Double] = _
override def computeMetricFrom(state: Option[FrequenciesAndNumRows]) = {
  storedEdges.length  // NPE
}
```
```
// After: edges in the state
override def computeMetricFrom(state: Option[BinnedFrequencies]) = {
  theState.edges.length  // always available
}
```

#### Changes

- **HistogramBinned.scala**: adds `BinnedFrequencies` state class, changes analyzer type from `Analyzer[FrequenciesAndNumRows, ...]` to `Analyzer[BinnedFrequencies, ...]`, reads edges from state in `computeMetricFrom`
- **Constraint.scala**: updates `AnalysisBasedConstraint` type parameters to `BinnedFrequencies`

### Testing

Unit.

##### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
