### PR TITLE
add support for duplicateRowCount

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/DuplicateRowCount.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/DuplicateRowCount.scala
@@ -1,0 +1,117 @@
+/**
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.analyzers
+
+import com.amazon.deequ.analyzers.Analyzers.COUNT_COL
+import com.amazon.deequ.metrics.DoubleMetric
+import com.amazon.deequ.metrics.Entity
+import org.apache.spark.sql.Column
+import org.apache.spark.sql.DataFrame
+import org.apache.spark.sql.Row
+import org.apache.spark.sql.functions.col
+import org.apache.spark.sql.functions.expr
+import org.apache.spark.sql.functions.lit
+import org.apache.spark.sql.functions.not
+import org.apache.spark.sql.functions.sum
+import org.apache.spark.sql.functions.when
+import org.apache.spark.sql.types.DoubleType
+import org.apache.spark.sql.types.StructType
+
+/** DuplicateRowCount counts the number of rows that appear more than once
+  * across the specified columns. If columns is empty, all columns are used. */
+case class DuplicateRowCount(columns: Seq[String], where: Option[String] = None,
+                             analyzerOptions: Option[AnalyzerOptions] = None)
+  extends ScanShareableFrequencyBasedAnalyzer("DuplicateRowCount", columns)
+  with FilterableAnalyzer {
+
+  override def aggregationFunctions(numRows: Long): Seq[Column] = {
+    sum(when(col(COUNT_COL) > lit(1), col(COUNT_COL)).otherwise(lit(0)).cast(DoubleType)) :: Nil
+  }
+
+  override def fromAggregationResult(result: Row, offset: Int, fullColumn: Option[Column]): DoubleMetric = {
+    if (result.isNullAt(offset)) {
+      // WHERE clause matched zero rows — return 0 (no duplicates) instead of empty metric
+      toSuccessMetric(0.0, fullColumn)
+    } else {
+      val conditionColumn = where.map { expression => expr(expression) }
+      val fullColumnDuplicate = fullColumn.map { rowLevelColumn =>
+        conditionColumn.map { condition =>
+          when(not(condition), getRowLevelFilterTreatment(analyzerOptions).getExpression)
+            .when(rowLevelColumn > lit(1), true).otherwise(false)
+        }.getOrElse(when(rowLevelColumn > lit(1), true).otherwise(false))
+      }
+      super.fromAggregationResult(result, offset, fullColumnDuplicate)
+    }
+  }
+
+  override def computeStateFrom(data: DataFrame,
+                                filterCondition: Option[String] = None): Option[FrequenciesAndNumRows] = {
+    if (columns.isEmpty) {
+      val allColumns = data.columns.toSeq
+      DuplicateRowCount(allColumns, where, analyzerOptions).computeStateFrom(data, filterCondition)
+    } else {
+      super.computeStateFrom(data, filterCondition)
+    }
+  }
+
+  override def computeMetricFrom(state: Option[FrequenciesAndNumRows]): DoubleMetric = {
+    state match {
+      case Some(theState) if theState.numRows == 0 =>
+        // Empty data or WHERE matched nothing — 0 duplicates
+        toSuccessMetric(0.0, theState.fullColumn)
+      case _ =>
+        super.computeMetricFrom(state)
+    }
+  }
+
+  /** For empty columns, resolve all DataFrame columns at calculation time */
+  override def calculate(
+      data: DataFrame,
+      aggregateWith: Option[StateLoader] = None,
+      saveStatesWith: Option[StatePersister] = None,
+      filterCondition: Option[String] = None): DoubleMetric = {
+    val effectiveFilter = filterCondition.orElse(where)
+    if (columns.isEmpty) {
+      val resolved = DuplicateRowCount(data.columns.toSeq, None, analyzerOptions)
+      val metric = resolved.calculate(data, aggregateWith, saveStatesWith, effectiveFilter)
+      // Re-wrap with Dataset.* entity to match DQDL metric mapping
+      metric.copy(entity = Entity.Dataset, instance = "*")
+    } else {
+      super.calculate(data, aggregateWith, saveStatesWith, effectiveFilter)
+    }
+  }
+
+  override def preconditions: Seq[StructType => Unit] = {
+    if (columns.isEmpty) {
+      Seq.empty
+    } else {
+      super.preconditions
+    }
+  }
+
+  override def filterCondition: Option[String] = where
+}
+
+object DuplicateRowCount {
+  def apply(column: String): DuplicateRowCount = {
+    new DuplicateRowCount(column :: Nil)
+  }
+
+  def apply(column: String, where: Option[String]): DuplicateRowCount = {
+    new DuplicateRowCount(column :: Nil, where)
+  }
+}

--- a/src/main/scala/com/amazon/deequ/analyzers/GroupingAnalyzers.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/GroupingAnalyzers.scala
@@ -67,10 +67,11 @@ object FrequencyBasedAnalyzer {
       where: Option[String] = None)
     : FrequenciesAndNumRows = {
 
-    val columnsToGroupBy = groupingColumns.map { name => col(name) }.toArray
+    val resolvedColumns = if (groupingColumns.isEmpty) data.columns.toSeq else groupingColumns
+    val columnsToGroupBy = resolvedColumns.map { name => col(name) }.toArray
     val projectionColumns = columnsToGroupBy :+ col(COUNT_COL)
 
-    val atLeastOneNonNullGroupingColumn = groupingColumns
+    val atLeastOneNonNullGroupingColumn = resolvedColumns
       .foldLeft(expr(false.toString)) { case (condition, name) =>
         condition.or(col(name).isNotNull)
       }

--- a/src/main/scala/com/amazon/deequ/checks/Check.scala
+++ b/src/main/scala/com/amazon/deequ/checks/Check.scala
@@ -157,6 +157,25 @@ case class Check(
   }
 
   /**
+    * Creates a constraint that asserts on the number of duplicate rows.
+    *
+    * @param columns Columns to check for duplicates
+    * @param assertion Function that receives a long input parameter (duplicate row count)
+    *                  and returns a boolean
+    * @param hint A hint to provide additional context why a constraint could have failed
+    * @return
+    */
+  def hasDuplicateRowCount(
+      columns: Seq[String],
+      assertion: Long => Boolean,
+      hint: Option[String] = None)
+    : CheckWithLastConstraintFilterable = {
+
+    addFilterableConstraint { filter =>
+      duplicateRowCountConstraint(columns, assertion, filter, hint) }
+  }
+
+  /**
     * Creates a constraint that asserts on a column completion.
     *
     * @param column Column to run the assertion on

--- a/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
+++ b/src/main/scala/com/amazon/deequ/constraints/Constraint.scala
@@ -145,10 +145,6 @@ object Constraint {
 
   /**
     * Runs zeros count analysis on the given column and executes the assertion
-    *
-    * @param column Column to run the assertion on
-    * @param assertion Function that receives a long input parameter and returns a boolean
-    * @param hint    A hint to provide additional context why a constraint could have failed
     */
   def zerosCountConstraint(
       column: String,
@@ -162,6 +158,23 @@ object Constraint {
       zerosCount, assertion, Some(_.toLong), hint)
 
     new NamedConstraint(constraint, s"ZerosCountConstraint($zerosCount)")
+  }
+
+  /**
+    * Runs DuplicateRowCount analysis on the given columns and executes the assertion
+    */
+  def duplicateRowCountConstraint(
+      columns: Seq[String],
+      assertion: Long => Boolean,
+      where: Option[String] = None,
+      hint: Option[String] = None)
+    : Constraint = {
+
+    val duplicateRowCount = DuplicateRowCount(columns, where)
+    val constraint = AnalysisBasedConstraint[FrequenciesAndNumRows, Double, Long](
+      duplicateRowCount, assertion, Some(_.toLong), hint)
+
+    new NamedConstraint(constraint, s"DuplicateRowCountConstraint($duplicateRowCount)")
   }
 
   /**

--- a/src/main/scala/com/amazon/deequ/dqdl/translation/DQDLRuleTranslator.scala
+++ b/src/main/scala/com/amazon/deequ/dqdl/translation/DQDLRuleTranslator.scala
@@ -32,6 +32,7 @@ import com.amazon.deequ.dqdl.translation.rules.MeanRule
 import com.amazon.deequ.dqdl.translation.rules.ColumnCountRule
 import com.amazon.deequ.dqdl.translation.rules.RowCountRule
 import com.amazon.deequ.dqdl.translation.rules.RangeRule
+import com.amazon.deequ.dqdl.translation.rules.DuplicateRowCountRule
 import com.amazon.deequ.dqdl.translation.rules.SkewnessRule
 import com.amazon.deequ.dqdl.translation.rules.StandardDeviationRule
 import com.amazon.deequ.dqdl.translation.rules.SumRule
@@ -89,7 +90,8 @@ object DQDLRuleTranslator {
     "IsPrimaryKey" -> new IsPrimaryKeyRule,
     "ColumnLength" -> new ColumnLengthRule,
     "ColumnExists" -> new ColumnExistsRule,
-    "ColumnValues" -> new ColumnValuesRule
+    "ColumnValues" -> new ColumnValuesRule,
+    "DuplicateRowCount" -> new DuplicateRowCountRule
   )
 
   /**

--- a/src/main/scala/com/amazon/deequ/dqdl/translation/rules/DuplicateRowCountRule.scala
+++ b/src/main/scala/com/amazon/deequ/dqdl/translation/rules/DuplicateRowCountRule.scala
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ * http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ.dqdl.translation.rules
+
+import com.amazon.deequ.checks.{Check, CheckLevel}
+import com.amazon.deequ.dqdl.model.DeequMetricMapping
+import com.amazon.deequ.dqdl.translation.DQDLRuleConverter
+import com.amazon.deequ.dqdl.util.DQDLUtility.addWhereClause
+import software.amazon.glue.dqdl.model.DQRule
+import software.amazon.glue.dqdl.model.condition.number.NumberBasedCondition
+
+import scala.collection.JavaConverters._
+
+case class DuplicateRowCountRule() extends DQDLRuleConverter {
+  override def convert(rule: DQRule): Either[String, (Check, Seq[DeequMetricMapping])] = {
+    val columns = rule.getParameters.asScala.collect { case (k, v) if k.startsWith("TargetColumn") => v }.toSeq
+    val doubleAssertion = assertionAsScala(rule, rule.getCondition.asInstanceOf[NumberBasedCondition])
+    val longAssertion: Long => Boolean = (v: Long) => doubleAssertion(v.toDouble)
+
+    // For no-column variant, use a placeholder column name that will be resolved at execution time
+    // The DuplicateRowCount analyzer handles Seq.empty by resolving all columns from the DataFrame
+    val check = Check(CheckLevel.Error, java.util.UUID.randomUUID.toString)
+      .hasDuplicateRowCount(columns, longAssertion)
+
+    val (entity, instance) = columns match {
+      case Nil => ("Dataset", "*")
+      case cols => ("Multicolumn", cols.mkString(","))
+    }
+
+    Right(
+      addWhereClause(rule, check),
+      Seq(DeequMetricMapping(entity, instance, "DuplicateRowCount", "DuplicateRowCount", None, rule = rule)))
+  }
+}

--- a/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
+++ b/src/main/scala/com/amazon/deequ/repository/AnalysisResultSerde.scala
@@ -351,6 +351,12 @@ private[deequ] object AnalyzerSerializer
           new TypeToken[JList[String]]() {}.getType))
         result.add(ANALYZER_OPTIONS_FIELD, context.serialize(uniqueness.analyzerOptions.orNull))
 
+      case duplicateRowCount: DuplicateRowCount =>
+        result.addProperty(ANALYZER_NAME_FIELD, "DuplicateRowCount")
+        result.add(COLUMNS_FIELD, context.serialize(duplicateRowCount.columns.asJava,
+          new TypeToken[JList[String]]() {}.getType))
+        result.addProperty(WHERE_FIELD, duplicateRowCount.where.orNull)
+
       case histogram: Histogram if histogram.binningUdf.isEmpty =>
         result.addProperty(ANALYZER_NAME_FIELD, "Histogram")
         result.addProperty(COLUMN_FIELD, histogram.column)
@@ -585,6 +591,11 @@ private[deequ] object AnalyzerDeserializer
         Uniqueness(
           getColumnsAsSeq(context, json),
           analyzerOptions = getOptionalAnalyzerOptions(json))
+
+      case "DuplicateRowCount" =>
+        DuplicateRowCount(
+          getColumnsAsSeq(context, json),
+          getOptionalWhereParam(json))
 
       case "Histogram" =>
         Histogram(

--- a/src/test/scala/com/amazon/deequ/analyzers/DuplicateRowCountTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/DuplicateRowCountTest.scala
@@ -1,0 +1,154 @@
+/**
+ * Copyright 2026 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"). You may not
+ * use this file except in compliance with the License. A copy of the License
+ * is located at
+ *
+ *     http://aws.amazon.com/apache2.0/
+ *
+ * or in the "license" file accompanying this file. This file is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ *
+ */
+
+package com.amazon.deequ
+package analyzers
+
+import com.amazon.deequ.utils.FixtureSupport
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.wordspec.AnyWordSpec
+
+import scala.util.Success
+
+class DuplicateRowCountTest extends AnyWordSpec with Matchers with SparkContextSpec
+  with FixtureSupport {
+
+  "DuplicateRowCount" should {
+
+    "count duplicate rows correctly" in withSparkSession { session =>
+      import session.implicits._
+      val df = Seq(
+        ("a", 1), ("b", 2), ("a", 1), ("c", 3), ("a", 1)
+      ).toDF("col1", "col2")
+      // ("a", 1) appears 3 times -> 3 duplicate rows
+      val result = DuplicateRowCount(Seq("col1", "col2")).calculate(df)
+      result.value shouldBe Success(3.0)
+    }
+
+    "return 0 when no duplicates exist" in withSparkSession { session =>
+      import session.implicits._
+      val df = Seq(
+        ("a", 1), ("b", 2), ("c", 3)
+      ).toDF("col1", "col2")
+      val result = DuplicateRowCount(Seq("col1", "col2")).calculate(df)
+      result.value shouldBe Success(0.0)
+    }
+
+    "return total row count when all rows are identical" in withSparkSession { session =>
+      import session.implicits._
+      val df = Seq(
+        ("a", 1), ("a", 1), ("a", 1)
+      ).toDF("col1", "col2")
+      val result = DuplicateRowCount(Seq("col1", "col2")).calculate(df)
+      result.value shouldBe Success(3.0)
+    }
+
+    "return 0 for a single row" in withSparkSession { session =>
+      import session.implicits._
+      val df = Seq(("a", 1)).toDF("col1", "col2")
+      val result = DuplicateRowCount(Seq("col1", "col2")).calculate(df)
+      result.value shouldBe Success(0.0)
+    }
+
+    "handle multiple duplicate groups" in withSparkSession { session =>
+      import session.implicits._
+      val df = Seq(
+        ("a", 1), ("b", 2), ("a", 1), ("b", 2), ("c", 3)
+      ).toDF("col1", "col2")
+      // ("a",1) x2 + ("b",2) x2 = 4 duplicate rows
+      val result = DuplicateRowCount(Seq("col1", "col2")).calculate(df)
+      result.value shouldBe Success(4.0)
+    }
+
+    "treat NULLs as equal for grouping" in withSparkSession { session =>
+      import session.implicits._
+      val df = Seq(
+        (Some("a"), Some(1)),
+        (Some("a"), None),
+        (Some("a"), None)
+      ).toDF("col1", "col2")
+      // ("a", null) appears twice -> 2 duplicate rows
+      val result = DuplicateRowCount(Seq("col1", "col2")).calculate(df)
+      result.value shouldBe Success(2.0)
+    }
+
+    "exclude rows where all grouping columns are NULL" in withSparkSession { session =>
+      import session.implicits._
+      val df = Seq(
+        (None: Option[String], None: Option[Int]),
+        (None: Option[String], None: Option[Int]),
+        (Some("a"), Some(1))
+      ).toDF("col1", "col2")
+      // All-null rows are excluded, ("a",1) appears once -> 0 duplicates
+      val result = DuplicateRowCount(Seq("col1", "col2")).calculate(df)
+      result.value shouldBe Success(0.0)
+    }
+
+    "work with subset of columns" in withSparkSession { session =>
+      import session.implicits._
+      val df = Seq(
+        ("a", 1, "x"), ("a", 2, "y"), ("b", 3, "z")
+      ).toDF("col1", "col2", "col3")
+      // Checking only col1: "a" appears twice -> 2 duplicate rows
+      val result = DuplicateRowCount(Seq("col1")).calculate(df)
+      result.value shouldBe Success(2.0)
+    }
+
+    "apply where clause correctly" in withSparkSession { session =>
+      import session.implicits._
+      val df = Seq(
+        ("a", 1, "active"), ("a", 1, "inactive"), ("a", 1, "active"), ("b", 2, "active")
+      ).toDF("col1", "col2", "status")
+      // With where "status = 'active'": ("a", 1, "active") appears twice -> 2 duplicates
+      val result = DuplicateRowCount(Seq("col1", "col2", "status"),
+        where = Some("status = 'active'")).calculate(df)
+      result.value shouldBe Success(2.0)
+    }
+
+    "return 0 when where clause matches no rows" in withSparkSession { session =>
+      import session.implicits._
+      val df = Seq(
+        ("a", 1, "active"), ("a", 1, "active"), ("b", 2, "active")
+      ).toDF("col1", "col2", "status")
+      val result = DuplicateRowCount(Seq("col1", "col2", "status"),
+        where = Some("status = 'nonexistent'")).calculate(df)
+      result.value shouldBe Success(0.0)
+    }
+
+    "use all columns when columns list is empty" in withSparkSession { session =>
+      import session.implicits._
+      val df = Seq(
+        ("a", 1), ("b", 2), ("a", 1), ("c", 3)
+      ).toDF("col1", "col2")
+      // ("a", 1) appears twice -> 2 duplicate rows
+      val result = DuplicateRowCount(Seq.empty).calculate(df)
+      result.value shouldBe Success(2.0)
+    }
+
+    "return 0 for empty DataFrame" in withSparkSession { session =>
+      import session.implicits._
+      val df = session.createDataFrame(
+        session.sparkContext.emptyRDD[org.apache.spark.sql.Row],
+        org.apache.spark.sql.types.StructType(Seq(
+          org.apache.spark.sql.types.StructField("col1", org.apache.spark.sql.types.StringType),
+          org.apache.spark.sql.types.StructField("col2", org.apache.spark.sql.types.IntegerType)
+        ))
+      )
+      val result = DuplicateRowCount(Seq("col1", "col2")).calculate(df)
+      result.value shouldBe scala.util.Success(0.0)
+    }
+  }
+}

--- a/src/test/scala/com/amazon/deequ/constraints/ConstraintsTest.scala
+++ b/src/test/scala/com/amazon/deequ/constraints/ConstraintsTest.scala
@@ -51,6 +51,22 @@ class ConstraintsTest extends WordSpec with Matchers with SparkContextSpec with 
     }
   }
 
+  "DuplicateRowCount constraint" should {
+    "assert on duplicate row count" in withSparkSession { sparkSession =>
+      import sparkSession.implicits._
+      val df = Seq(("a", 1), ("b", 2), ("a", 1), ("c", 3)).toDF("col1", "col2")
+      calculate(Constraint.duplicateRowCountConstraint(Seq("col1", "col2"), _ == 2), df)
+        .status shouldBe ConstraintStatus.Success
+    }
+
+    "fail when assertion is not met" in withSparkSession { sparkSession =>
+      import sparkSession.implicits._
+      val df = Seq(("a", 1), ("b", 2), ("a", 1), ("c", 3)).toDF("col1", "col2")
+      calculate(Constraint.duplicateRowCountConstraint(Seq("col1", "col2"), _ == 0), df)
+        .status shouldBe ConstraintStatus.Failure
+    }
+  }
+
   "Histogram constraints" should {
     "assert on bin number" in withSparkSession { sparkSession =>
       val df = getDfMissing(sparkSession)

--- a/src/test/scala/com/amazon/deequ/dqdl/EvaluateDataQualitySpec.scala
+++ b/src/test/scala/com/amazon/deequ/dqdl/EvaluateDataQualitySpec.scala
@@ -572,6 +572,14 @@ class EvaluateDataQualitySpec extends AnyWordSpec with Matchers with SparkContex
 
     // TODO: Enable DQDL tests for Variance, Range, InterquartileRange, ZerosCount, Skewness, Kurtosis
 
+    // DuplicateRowCount DQDL tests require dqdl >= 1.0.7 (Java 11).
+    // Tested on release/3.0.3-spark-3.5 branch. Ignored here due to Java 8 / dqdl version constraint.
+    "support DuplicateRowCount rule with explicit columns" ignore {}
+    "support DuplicateRowCount rule failure with explicit columns" ignore {}
+    "support DuplicateRowCount rule without columns (all columns)" ignore {}
+    "support DuplicateRowCount with less-than operator" ignore {}
+    "support DuplicateRowCount with between operator" ignore {}
+
     "support Sum rule" in withSparkSession { sparkSession =>
       // given
       val df = getDfWithNumericValues(sparkSession)

--- a/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
+++ b/src/test/scala/com/amazon/deequ/repository/AnalysisResultSerdeTest.scala
@@ -37,6 +37,8 @@ class AnalysisResultSerdeTest extends FlatSpec with Matchers {
       Size() -> DoubleMetric(Entity.Column, "Size", "*", Success(5.0)),
       ZerosCount("ColumnA") ->
         DoubleMetric(Entity.Column, "ZerosCount", "ColumnA", Success(0.0)),
+      DuplicateRowCount(Seq("ColumnA", "ColumnB")) ->
+        DoubleMetric(Entity.Multicolumn, "DuplicateRowCount", "ColumnA,ColumnB", Success(5.0)),
       Completeness("ColumnA", analyzerOptions = Some(AnalyzerOptions(
         nullBehavior = NullBehavior.Ignore
       ))) ->


### PR DESCRIPTION
## Description
  
  Adds a new `DuplicateRowCount` analyzer that counts rows appearing more than once in a dataset.
  
  ### Changes
  - New `DuplicateRowCount` analyzer (extends `ScanShareableFrequencyBasedAnalyzer`)
  - Check API: `hasDuplicateRowCount(columns, assertion)`
  - Constraint: `duplicateRowCountConstraint`
  - DQDL rule translator supporting both table-level and column-level syntax
  - Serde support for metrics repository
  - Fixed `computeFrequencies` to resolve empty columns from DataFrame
  - WHERE clause matching zero rows returns 0 (not failure)
  
  ### DQDL Syntax
  ```
  DuplicateRowCount = 0
  DuplicateRowCount < 10
  DuplicateRowCount between 0 and 10
  DuplicateRowCount < 10 where 'state = active'
  DuplicateRowCount "col1" "col2" = 0
  DuplicateRowCount "col1" "col2" < 10
  DuplicateRowCount "col1" "col2" between 0 and 10
  DuplicateRowCount "col1" "col2" < 10 where 'state = active'
  ```
  ### Testing
  12 unit tests covering: 
- basic duplicates
- NULL handling
- WHERE clause
- empty columns
- empty DataFrame, serde, constraints
