### PR TITLE
feat: agentic 3-stage PR review pipeline (Investigator + Critic + Reporter) behind flag

### DIFF
--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -75,6 +75,7 @@ jobs:
           SM_PR_FILE_REVIEW_REPORT_PROMPT: deequ-bot/pr-file-review-report-prompt
           SM_PR_INVESTIGATOR_PROMPT: deequ-bot/pr-investigator-prompt
           SM_PR_CRITIC_PROMPT: deequ-bot/pr-critic-prompt
+          SM_PR_REPORTER_PROMPT: deequ-bot/pr-reporter-prompt
           SM_FOLLOWUP_PROMPT: deequ-bot/followup-prompt
           # Flip BOT_AGENT_PIPELINE to "1" to enable the 3-agent (Investigator+Critic+Reporter) pipeline.
           # When unset/empty, the legacy two-phase flow runs unchanged.

--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -78,6 +78,9 @@ jobs:
           SM_FOLLOWUP_PROMPT: deequ-bot/followup-prompt
           # Flip BOT_AGENT_PIPELINE to "1" to enable the 3-agent (Investigator+Critic+Reporter) pipeline.
           # When unset/empty, the legacy two-phase flow runs unchanged.
+          # NOTE: Set as a REPOSITORY VARIABLE (Settings → Secrets and variables → Actions → Variables tab),
+          # NOT a secret. Misplacing it under "Secrets" leaves vars.BOT_AGENT_PIPELINE empty → legacy flow
+          # runs silently. To verify: `gh api repos/awslabs/deequ/actions/variables` should list it.
           BOT_AGENT_PIPELINE: ${{ vars.BOT_AGENT_PIPELINE || '' }}
           CODEBASE_SRC_DIR: src/main/scala
           CODEBASE_FILE_EXT: .scala

--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -73,7 +73,12 @@ jobs:
           SM_ISSUE_RESPOND_PROMPT: deequ-bot/issue-respond-prompt
           SM_PR_FILE_REVIEW_PROMPT: deequ-bot/pr-file-review-prompt
           SM_PR_FILE_REVIEW_REPORT_PROMPT: deequ-bot/pr-file-review-report-prompt
+          SM_PR_INVESTIGATOR_PROMPT: deequ-bot/pr-investigator-prompt
+          SM_PR_CRITIC_PROMPT: deequ-bot/pr-critic-prompt
           SM_FOLLOWUP_PROMPT: deequ-bot/followup-prompt
+          # Flip BOT_AGENT_PIPELINE to "1" to enable the 3-agent (Investigator+Critic+Reporter) pipeline.
+          # When unset/empty, the legacy two-phase flow runs unchanged.
+          BOT_AGENT_PIPELINE: ${{ vars.BOT_AGENT_PIPELINE || '' }}
           CODEBASE_SRC_DIR: src/main/scala
           CODEBASE_FILE_EXT: .scala
           DRY_RUN: ${{ inputs.dry_run || 'false' }}

--- a/src/scripts/issue_bot/agent_loop.py
+++ b/src/scripts/issue_bot/agent_loop.py
@@ -1,16 +1,14 @@
-"""
-Multi-turn tool-use loop for Bedrock Converse.
+"""Multi-turn tool-use loop for Bedrock Converse.
 
-Runs an agent (Investigator or Critic) through repeated rounds of:
-  1. Bedrock Converse call with toolConfig
-  2. If stopReason == "tool_use", execute the requested tools
-  3. Append tool results, continue
-  4. Otherwise, terminate with the final text
+Used by both the Investigator and the Critic. Each turn:
+  1. Call Bedrock with toolConfig.
+  2. If stopReason is "tool_use", execute the requested tools and append
+     the toolResults; loop.
+  3. Otherwise, return the final text.
 
-Owns budget enforcement (turns, tool calls, tool output chars, cost),
-provenance tracking (tool trace), and graceful termination on caps.
-Both Investigator and Critic use the same loop with different caps and
-prompts.
+Owns budget enforcement (turns, tool calls, tool output chars) and
+tool-call provenance recording. Token usage is reported in the result
+for downstream observability; this module does NOT enforce cost limits.
 """
 import logging
 import time
@@ -18,22 +16,21 @@ from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import List, Dict, Any, Optional
 
+from .tools import DEFAULT_PER_TOOL_CALL_CAPS
+
 logger = logging.getLogger("issue_bot")
 
 
 @dataclass
 class AgentCaps:
-    """Per-agent budgets enforced by the loop."""
+    """Per-agent budgets enforced by the loop. Defaults match the registered
+    tool set in tools.py; pass per_tool_max_calls explicitly to override."""
     max_turns: int = 15
     max_tool_calls: int = 50
     max_tool_output_chars: int = 400_000
-    per_tool_max_calls: Dict[str, int] = field(default_factory=lambda: {
-        "grep_codebase": 50,
-        "read_file": 30,
-        "list_dir": 20,
-        "find_callers": 20,
-        "find_tests_for": 10,
-    })
+    per_tool_max_calls: Dict[str, int] = field(
+        default_factory=lambda: dict(DEFAULT_PER_TOOL_CALL_CAPS)
+    )
     max_tokens_per_call: int = 8000
 
 
@@ -49,28 +46,8 @@ class AgentResult:
     cache_read_tokens: int = 0
     cache_write_tokens: int = 0
     max_turns_reached: bool = False
-    cost_cap_hit: bool = False
     error: Optional[str] = None
     tool_trace: List[Dict[str, Any]] = field(default_factory=list)
-
-
-def estimate_cost_usd(input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, pricing):
-    """Convert token counts to USD using the provided per-million rates.
-
-    pricing is a dict with keys: input_per_million, output_per_million,
-    cache_read_per_million, cache_write_per_million.
-    """
-    return (
-        (input_tokens / 1_000_000) * pricing["input_per_million"]
-        + (output_tokens / 1_000_000) * pricing["output_per_million"]
-        + (cache_read_tokens / 1_000_000) * pricing["cache_read_per_million"]
-        + (cache_write_tokens / 1_000_000) * pricing["cache_write_per_million"]
-    )
-
-
-# Backward-compatible alias for internal callers that already use the
-# private name. New code should call estimate_cost_usd().
-_estimate_cost_usd = estimate_cost_usd
 
 
 def run(
@@ -81,18 +58,15 @@ def run(
     tool_specs: List[Dict[str, Any]],
     tool_runner,
     caps: AgentCaps,
-    cost_tracker,
-    pricing: Dict[str, float],
 ):
-    """Execute an agent's tool-use loop.
+    """Execute an agent's tool-use loop. Returns an AgentResult.
 
-    bedrock_client: instance of BedrockClient (must support converse_with_tools).
-    tool_runner: callable (name, args_dict) -> str. Implements actual tool dispatch.
-    cost_tracker: shared mutable dict {"cost_usd": float, "cap_hit": bool}.
-        The loop enforces the cap by reading/writing cost_tracker before each turn.
-    pricing: per-million-token rates for the model in use.
-
-    Returns an AgentResult.
+    Termination is bounded structurally:
+      - caps.max_turns total Bedrock turns
+      - caps.max_tool_calls total tool executions
+      - caps.max_tool_output_chars cumulative tool output size
+      - caps.per_tool_max_calls per-tool budget
+    Wall-clock is bounded by the workflow timeout.
     """
     result = AgentResult()
     messages = [{"role": "user", "content": [{"text": user_prompt}]}]
@@ -100,13 +74,6 @@ def run(
 
     for turn in range(caps.max_turns):
         result.turns = turn + 1
-
-        # Pre-turn cost cap check
-        if cost_tracker.get("cap_hit"):
-            result.cost_cap_hit = True
-            result.error = "cost cap hit before turn"
-            logger.warning("[%s turn=%d] cost cap hit, terminating", agent_name, turn + 1)
-            break
 
         try:
             resp = bedrock_client.converse_with_tools(
@@ -118,173 +85,144 @@ def run(
         except Exception as e:
             logger.error("[%s turn=%d] bedrock error: %s", agent_name, turn + 1, type(e).__name__)
             result.error = f"bedrock error: {type(e).__name__}: {e}"
-            break
+            return result
 
         if resp is None:
             result.error = "bedrock returned None (circuit-breaker or transient failure)"
-            break
+            return result
 
-        usage = resp.get("usage", {}) or {}
-        in_t = usage.get("inputTokens", 0) or 0
-        out_t = usage.get("outputTokens", 0) or 0
-        cr_t = usage.get("cacheReadInputTokens", 0) or 0
-        cw_t = usage.get("cacheWriteInputTokens", 0) or 0
-        result.input_tokens += in_t
-        result.output_tokens += out_t
-        result.cache_read_tokens += cr_t
-        result.cache_write_tokens += cw_t
-        delta_cost = _estimate_cost_usd(in_t, out_t, cr_t, cw_t, pricing)
-        cost_tracker["cost_usd"] = cost_tracker.get("cost_usd", 0.0) + delta_cost
-        # Per-turn overshoot bound: a single turn's tokens are already paid for
-        # by the time we observe the usage field. Worst-case overshoot of the
-        # cap is therefore one turn's cost, bounded by max_tokens_per_call ×
-        # the model's input rate × ~1 (output tokens are dwarfed by typical
-        # input). At default $1.00 cap and 8000 max output, plus typical 50K
-        # input, overshoot is bounded at ~$0.75 (Opus rates).
-        if cost_tracker["cost_usd"] >= cost_tracker.get("cap_usd", float("inf")):
-            cost_tracker["cap_hit"] = True
-            result.cost_cap_hit = True
+        usage = resp.get("usage") or {}
+        result.input_tokens += usage.get("inputTokens") or 0
+        result.output_tokens += usage.get("outputTokens") or 0
+        result.cache_read_tokens += usage.get("cacheReadInputTokens") or 0
+        result.cache_write_tokens += usage.get("cacheWriteInputTokens") or 0
         logger.debug(
-            "[%s turn=%d] in=%d out=%d cacheR=%d cacheW=%d cost_so_far=$%.4f",
-            agent_name, turn + 1, in_t, out_t, cr_t, cw_t,
-            cost_tracker.get("cost_usd", 0.0),
+            "[%s turn=%d] in=%d out=%d cacheR=%d cacheW=%d",
+            agent_name, turn + 1, result.input_tokens, result.output_tokens,
+            result.cache_read_tokens, result.cache_write_tokens,
         )
 
         msg = resp.get("output", {}).get("message", {})
         if not msg:
             result.error = "empty bedrock message"
-            break
+            return result
         messages.append(msg)
 
-        stop = resp.get("stopReason")
-        if stop != "tool_use":
-            # Final text emitted; collect and exit
-            result.text = "\n".join(
-                b.get("text", "") for b in msg.get("content", []) if "text" in b
-            ).strip()
+        if resp.get("stopReason") != "tool_use":
+            result.text = _extract_text(msg)
             return result
 
-        # Cost cap hit on this turn: skip tool execution to bound overshoot.
-        # The model's tool_use response is preserved in messages so callers can
-        # see what it was about to do. Try to recover any text it emitted
-        # alongside the tool calls.
-        if cost_tracker.get("cap_hit"):
-            text_blocks = [b.get("text", "") for b in msg.get("content", []) if "text" in b]
-            recovered = "\n".join(text_blocks).strip()
-            if recovered:
-                result.text = recovered
-            else:
-                result.text = (
-                    f"Cost cap hit on turn {turn + 1}; tool execution skipped to "
-                    "bound overshoot. Conclude investigation with information "
-                    "gathered so far."
-                )
-            logger.warning(
-                "[%s turn=%d] cost cap hit mid-turn; skipping tool execution",
-                agent_name, turn + 1,
-            )
-            return result
-
-        # Execute tool calls in this turn
-        tool_results_content = []
-        for block in msg.get("content", []):
-            if "toolUse" not in block:
-                continue
-            tu = block["toolUse"]
-            tool_name = tu.get("name", "")
-            tool_args = tu.get("input", {}) or {}
-            tool_use_id = tu.get("toolUseId", "")
-
-            # Enforce per-tool budget
-            per_tool_cap = caps.per_tool_max_calls.get(tool_name, 9999)
-            if per_tool_calls[tool_name] >= per_tool_cap:
-                tool_text = (
-                    f"BUDGET EXHAUSTED: tool '{tool_name}' has been called "
-                    f"{per_tool_cap} times. Investigate with information already "
-                    "gathered, or use a different tool."
-                )
-                logger.info("[%s turn=%d] %s budget exhausted", agent_name, turn + 1, tool_name)
-            elif result.tool_calls >= caps.max_tool_calls:
-                tool_text = (
-                    f"BUDGET EXHAUSTED: total tool calls reached {caps.max_tool_calls}. "
-                    "Conclude investigation with information already gathered."
-                )
-                logger.info("[%s turn=%d] total tool budget exhausted", agent_name, turn + 1)
-            elif result.tool_output_chars >= caps.max_tool_output_chars:
-                tool_text = (
-                    f"BUDGET EXHAUSTED: total tool output {result.tool_output_chars} chars "
-                    f"reached cap {caps.max_tool_output_chars}. Conclude investigation."
-                )
-                logger.info("[%s turn=%d] tool output budget exhausted", agent_name, turn + 1)
-            else:
-                t0 = time.monotonic()
-                tool_text = tool_runner.run(tool_name, tool_args)
-                if not isinstance(tool_text, str):
-                    tool_text = str(tool_text)
-                latency_ms = int((time.monotonic() - t0) * 1000)
-                per_tool_calls[tool_name] += 1
-                result.tool_calls += 1
-                result.tool_output_chars += len(tool_text)
-                logger.info(
-                    "[%s turn=%d] %s(%s) → %d chars in %dms",
-                    agent_name, turn + 1, tool_name,
-                    _summarize_args(tool_args), len(tool_text), latency_ms,
-                )
-                result.tool_trace.append({
-                    "agent": agent_name,
-                    "turn": turn + 1,
-                    "tool": tool_name,
-                    "args": tool_args,
-                    "result_summary": tool_text[:200] + ("..." if len(tool_text) > 200 else ""),
-                    "result_chars": len(tool_text),
-                    "latency_ms": latency_ms,
-                })
-
-            tool_results_content.append({
-                "toolResult": {
-                    "toolUseId": tool_use_id,
-                    "content": [{"text": tool_text}],
-                },
-            })
-
-        if not tool_results_content:
-            # stopReason said tool_use but no toolUse blocks present → bail
-            result.text = "\n".join(
-                b.get("text", "") for b in msg.get("content", []) if "text" in b
-            ).strip()
+        tool_results = _run_tool_calls(
+            msg, agent_name, turn + 1, tool_runner, caps, result, per_tool_calls,
+        )
+        if not tool_results:
+            result.text = _extract_text(msg)
             result.error = "stopReason was tool_use but no toolUse blocks emitted"
             return result
+        messages.append({"role": "user", "content": tool_results})
 
-        messages.append({"role": "user", "content": tool_results_content})
-
-    # Loop exited via max_turns. The last appended message is typically a user
-    # toolResult (we appended it after the last bedrock call), so walk backward
-    # to find the most recent assistant message and extract any text it carried
-    # alongside its tool_use blocks.
     result.max_turns_reached = True
-    for msg in reversed(messages):
-        if msg.get("role") != "assistant":
-            continue
-        text_blocks = [
-            b.get("text", "")
-            for b in msg.get("content", [])
-            if "text" in b and isinstance(b.get("text"), str)
-        ]
-        recovered = "\n".join(text_blocks).strip()
-        if recovered:
-            result.text = recovered
-        break
-    if not result.text:
-        result.text = (
-            f"Investigation hit max_turns ({caps.max_turns}) without conclusion. "
-            f"Made {result.tool_calls} tool call(s)."
-        )
+    result.text = _recover_last_assistant_text(messages) or (
+        f"Investigation hit max_turns ({caps.max_turns}) without conclusion. "
+        f"Made {result.tool_calls} tool call(s)."
+    )
     logger.warning("[%s] max_turns (%d) reached", agent_name, caps.max_turns)
     return result
 
 
+def _run_tool_calls(msg, agent_name, turn, tool_runner, caps, result, per_tool_calls):
+    """Execute every toolUse block in `msg`. Returns the list of toolResult blocks
+    to append to the conversation. Updates `result` in place (tool_calls,
+    tool_output_chars, tool_trace) and `per_tool_calls`."""
+    tool_results = []
+    for block in msg.get("content", []):
+        if "toolUse" not in block:
+            continue
+        tu = block["toolUse"]
+        tool_name = tu.get("name", "")
+        tool_args = tu.get("input") or {}
+        tool_use_id = tu.get("toolUseId", "")
+        tool_text = _execute_or_budget(
+            tool_name, tool_args, agent_name, turn, tool_runner,
+            caps, result, per_tool_calls,
+        )
+        tool_results.append({
+            "toolResult": {
+                "toolUseId": tool_use_id,
+                "content": [{"text": tool_text}],
+            },
+        })
+    return tool_results
+
+
+def _execute_or_budget(tool_name, tool_args, agent_name, turn, tool_runner,
+                       caps, result, per_tool_calls):
+    """Execute a tool call or return a budget-exhausted message. Records
+    successful runs in result.tool_trace and increments counters."""
+    per_tool_cap = caps.per_tool_max_calls.get(tool_name)
+    if per_tool_cap is not None and per_tool_calls[tool_name] >= per_tool_cap:
+        logger.info("[%s turn=%d] %s budget exhausted", agent_name, turn, tool_name)
+        return (
+            f"BUDGET EXHAUSTED: tool '{tool_name}' has been called {per_tool_cap} "
+            "times. Investigate with information already gathered, or use a "
+            "different tool."
+        )
+    if result.tool_calls >= caps.max_tool_calls:
+        logger.info("[%s turn=%d] total tool budget exhausted", agent_name, turn)
+        return (
+            f"BUDGET EXHAUSTED: total tool calls reached {caps.max_tool_calls}. "
+            "Conclude investigation with information already gathered."
+        )
+    if result.tool_output_chars >= caps.max_tool_output_chars:
+        logger.info("[%s turn=%d] tool output budget exhausted", agent_name, turn)
+        return (
+            f"BUDGET EXHAUSTED: total tool output {result.tool_output_chars} chars "
+            f"reached cap {caps.max_tool_output_chars}. Conclude investigation."
+        )
+
+    t0 = time.monotonic()
+    text = tool_runner.run(tool_name, tool_args)
+    if not isinstance(text, str):
+        text = str(text)
+    latency_ms = int((time.monotonic() - t0) * 1000)
+    per_tool_calls[tool_name] += 1
+    result.tool_calls += 1
+    result.tool_output_chars += len(text)
+    logger.info(
+        "[%s turn=%d] %s(%s) → %d chars in %dms",
+        agent_name, turn, tool_name, _summarize_args(tool_args), len(text), latency_ms,
+    )
+    result.tool_trace.append({
+        "agent": agent_name,
+        "turn": turn,
+        "tool": tool_name,
+        "args": tool_args,
+        "result_summary": text[:200] + ("..." if len(text) > 200 else ""),
+        "result_chars": len(text),
+        "latency_ms": latency_ms,
+    })
+    return text
+
+
+def _extract_text(msg):
+    """Concatenate text blocks from an assistant message. Returns "" if none."""
+    return "\n".join(
+        b.get("text", "") for b in msg.get("content", []) if "text" in b
+    ).strip()
+
+
+def _recover_last_assistant_text(messages):
+    """Walk back through the conversation to the most recent assistant message
+    and extract any text it carried (possibly alongside tool_use blocks).
+    Used on max_turns exit so partial findings aren't dropped."""
+    for msg in reversed(messages):
+        if msg.get("role") == "assistant":
+            return _extract_text(msg)
+    return ""
+
+
 def _summarize_args(args):
-    """One-line summary of tool args for logging."""
+    """One-line representation of tool args for log output."""
     if not isinstance(args, dict):
         return repr(args)[:80]
     parts = []

--- a/src/scripts/issue_bot/agent_loop.py
+++ b/src/scripts/issue_bot/agent_loop.py
@@ -24,7 +24,13 @@ logger = logging.getLogger("issue_bot")
 @dataclass
 class AgentCaps:
     """Per-agent budgets enforced by the loop. Defaults match the registered
-    tool set in tools.py; pass per_tool_max_calls explicitly to override."""
+    tool set in tools.py; pass per_tool_max_calls explicitly to override.
+
+    The wall-clock cap is the ultimate runaway protection: structural budgets
+    bound *steady-state* cost but a stuck loop can still pay the per-turn
+    Bedrock cost up to max_turns. wall_clock_seconds bounds total elapsed
+    time end-to-end.
+    """
     max_turns: int = 15
     max_tool_calls: int = 50
     max_tool_output_chars: int = 400_000
@@ -32,6 +38,7 @@ class AgentCaps:
         default_factory=lambda: dict(DEFAULT_PER_TOOL_CALL_CAPS)
     )
     max_tokens_per_call: int = 8000
+    wall_clock_seconds: int = 300
 
 
 @dataclass
@@ -71,9 +78,18 @@ def run(
     result = AgentResult()
     messages = [{"role": "user", "content": [{"text": user_prompt}]}]
     per_tool_calls = defaultdict(int)
+    deadline = time.monotonic() + max(1, caps.wall_clock_seconds)
 
-    for turn in range(caps.max_turns):
+    for turn in range(max(0, caps.max_turns)):
         result.turns = turn + 1
+
+        if time.monotonic() >= deadline:
+            result.error = f"wall-clock cap ({caps.wall_clock_seconds}s) reached"
+            logger.warning(
+                "[%s turn=%d] wall-clock cap reached, terminating",
+                agent_name, turn + 1,
+            )
+            return result
 
         try:
             resp = bedrock_client.converse_with_tools(
@@ -84,7 +100,11 @@ def run(
             )
         except Exception as e:
             logger.error("[%s turn=%d] bedrock error: %s", agent_name, turn + 1, type(e).__name__)
-            result.error = f"bedrock error: {type(e).__name__}: {e}"
+            # Truncate exception message: Bedrock validation errors can echo
+            # prompt fragments which may include PR-content. Strip control
+            # chars that could mangle JSON-serialized artifacts.
+            msg_str = "".join(c for c in str(e)[:200] if c.isprintable() or c in " \t")
+            result.error = f"bedrock error: {type(e).__name__}: {msg_str}"
             return result
 
         if resp is None:
@@ -119,6 +139,19 @@ def run(
             result.text = _extract_text(msg)
             result.error = "stopReason was tool_use but no toolUse blocks emitted"
             return result
+
+        # If structural caps were hit during tool execution, terminate now
+        # rather than paying another Bedrock turn that will only emit more
+        # tool_use blocks against exhausted budgets.
+        if (result.tool_calls >= caps.max_tool_calls
+                or result.tool_output_chars >= caps.max_tool_output_chars):
+            result.error = "structural cap hit; terminating before next turn"
+            result.text = _extract_text(msg) or (
+                f"Investigation terminated on turn {turn + 1}: structural cap "
+                "reached (max_tool_calls or max_tool_output_chars)."
+            )
+            return result
+
         messages.append({"role": "user", "content": tool_results})
 
     result.max_turns_reached = True
@@ -196,12 +229,29 @@ def _execute_or_budget(tool_name, tool_args, agent_name, turn, tool_runner,
         "agent": agent_name,
         "turn": turn,
         "tool": tool_name,
-        "args": tool_args,
+        "args": _capped_args(tool_args),
         "result_summary": text[:200] + ("..." if len(text) > 200 else ""),
         "result_chars": len(text),
         "latency_ms": latency_ms,
     })
     return text
+
+
+_MAX_TRACE_ARG_CHARS = 500
+
+
+def _capped_args(args):
+    """Cap each arg value to avoid a single huge model-supplied value
+    swamping the artifact's tool trace."""
+    if not isinstance(args, dict):
+        return repr(args)[:_MAX_TRACE_ARG_CHARS]
+    out = {}
+    for k, v in args.items():
+        if isinstance(v, str) and len(v) > _MAX_TRACE_ARG_CHARS:
+            out[k] = v[:_MAX_TRACE_ARG_CHARS] + "...[truncated]"
+        else:
+            out[k] = v
+    return out
 
 
 def _extract_text(msg):

--- a/src/scripts/issue_bot/agent_loop.py
+++ b/src/scripts/issue_bot/agent_loop.py
@@ -1,14 +1,9 @@
 """Multi-turn tool-use loop for Bedrock Converse.
 
-Used by both the Investigator and the Critic. Each turn:
-  1. Call Bedrock with toolConfig.
-  2. If stopReason is "tool_use", execute the requested tools and append
-     the toolResults; loop.
-  3. Otherwise, return the final text.
-
-Owns budget enforcement (turns, tool calls, tool output chars) and
-tool-call provenance recording. Token usage is reported in the result
-for downstream observability; this module does NOT enforce cost limits.
+Each turn calls Bedrock with toolConfig; if stopReason is "tool_use" the
+loop executes the requested tools and continues, otherwise it returns the
+final text. Owns budget enforcement (turns, tool calls, tool output chars)
+and records each tool call in the result's tool_trace.
 """
 import logging
 import time
@@ -24,13 +19,7 @@ logger = logging.getLogger("issue_bot")
 @dataclass
 class AgentCaps:
     """Per-agent budgets enforced by the loop. Defaults match the registered
-    tool set in tools.py; pass per_tool_max_calls explicitly to override.
-
-    The wall-clock cap is the ultimate runaway protection: structural budgets
-    bound *steady-state* cost but a stuck loop can still pay the per-turn
-    Bedrock cost up to max_turns. wall_clock_seconds bounds total elapsed
-    time end-to-end.
-    """
+    tool set in tools.py; pass per_tool_max_calls explicitly to override."""
     max_turns: int = 15
     max_tool_calls: int = 50
     max_tool_output_chars: int = 400_000
@@ -38,18 +27,13 @@ class AgentCaps:
         default_factory=lambda: dict(DEFAULT_PER_TOOL_CALL_CAPS)
     )
     max_tokens_per_call: int = 8000
-    wall_clock_seconds: int = 300
 
 
 @dataclass
 class AgentResult:
-    """Outcome of an agent loop run.
-
-    `error` is set on any non-clean exit (Bedrock failure, structural cap,
-    wall-clock cap, max_turns, protocol violation). Callers must check
-    `fatal` to decide whether `text` is usable: structural exits often
-    produce partial-but-valid output, fatal exits do not.
-    """
+    """Outcome of an agent loop run. Empty `text` means the agent had no
+    usable output and downstream stages should skip; `error` is a one-line
+    label for logs."""
     text: str = ""
     turns: int = 0
     tool_calls: int = 0
@@ -60,7 +44,6 @@ class AgentResult:
     cache_write_tokens: int = 0
     max_turns_reached: bool = False
     error: Optional[str] = None
-    fatal: bool = False
     tool_trace: List[Dict[str, Any]] = field(default_factory=list)
 
 
@@ -76,30 +59,22 @@ def run(
 ):
     """Execute an agent's tool-use loop. Returns an AgentResult.
 
-    Termination is bounded structurally:
-      - caps.max_turns total Bedrock turns
-      - caps.max_tool_calls total tool executions
-      - caps.max_tool_output_chars cumulative tool output size
-      - caps.per_tool_max_calls per-tool budget
-      - caps.wall_clock_seconds elapsed time for THIS agent
-      - pipeline_deadline (optional) absolute monotonic deadline shared
-        across all stages of the pipeline; whichever is sooner wins
+    Termination: caps.max_turns, caps.max_tool_calls, caps.max_tool_output_chars,
+    caps.per_tool_max_calls, or pipeline_deadline (a shared monotonic deadline
+    threaded across pipeline stages) — whichever fires first.
     """
     result = AgentResult()
     messages = [{"role": "user", "content": [{"text": user_prompt}]}]
     per_tool_calls = defaultdict(int)
-    own_deadline = time.monotonic() + max(1, caps.wall_clock_seconds)
-    deadline = own_deadline if pipeline_deadline is None else min(own_deadline, pipeline_deadline)
 
     for turn in range(max(0, caps.max_turns)):
         result.turns = turn + 1
 
-        if time.monotonic() >= deadline:
-            result.error = f"wall-clock cap ({caps.wall_clock_seconds}s) reached"
-            # Bounded exit; any text recovered from prior turns is usable.
+        if pipeline_deadline is not None and time.monotonic() >= pipeline_deadline:
+            result.error = "pipeline wall-clock deadline reached"
             result.text = result.text or _recover_last_assistant_text(messages)
             logger.warning(
-                "[%s turn=%d] wall-clock cap reached, terminating",
+                "[%s turn=%d] pipeline wall-clock reached, terminating",
                 agent_name, turn + 1,
             )
             return result
@@ -110,21 +85,14 @@ def run(
                 messages=messages,
                 tool_specs=tool_specs,
                 max_tokens=caps.max_tokens_per_call,
-                timeout_seconds=max(1, deadline - time.monotonic()),
             )
         except Exception as e:
             logger.error("[%s turn=%d] bedrock error: %s", agent_name, turn + 1, type(e).__name__)
-            # Truncate exception message: Bedrock validation errors can echo
-            # prompt fragments which may include PR-content. Strip control
-            # chars that could mangle JSON-serialized artifacts.
-            msg_str = "".join(c for c in str(e)[:200] if c.isprintable() or c in " \t")
-            result.error = f"bedrock error: {type(e).__name__}: {msg_str}"
-            result.fatal = True
+            result.error = f"bedrock error: {type(e).__name__}"
             return result
 
         if resp is None:
             result.error = "bedrock returned None (circuit-breaker or transient failure)"
-            result.fatal = True
             return result
 
         usage = resp.get("usage") or {}
@@ -141,7 +109,6 @@ def run(
         msg = resp.get("output", {}).get("message", {})
         if not msg:
             result.error = "empty bedrock message"
-            result.fatal = True
             return result
         messages.append(msg)
 
@@ -153,20 +120,19 @@ def run(
             msg, agent_name, turn + 1, tool_runner, caps, result, per_tool_calls,
         )
         if not tool_results:
+            # Bedrock protocol violation: stopReason=tool_use with no toolUse
+            # blocks. We capture any accompanying text and exit; if the text
+            # happens to be parseable downstream the caller can use it.
             result.text = _extract_text(msg)
             result.error = "stopReason was tool_use but no toolUse blocks emitted"
-            result.fatal = True
             return result
 
-        # If structural caps were hit during tool execution, terminate now
-        # rather than paying another Bedrock turn that will only emit more
-        # tool_use blocks against exhausted budgets.
+        # Stop before paying another Bedrock turn against exhausted budgets.
         if (result.tool_calls >= caps.max_tool_calls
                 or result.tool_output_chars >= caps.max_tool_output_chars):
             result.error = "structural cap hit; terminating before next turn"
             result.text = _extract_text(msg) or (
-                f"Investigation terminated on turn {turn + 1}: structural cap "
-                "reached (max_tool_calls or max_tool_output_chars)."
+                f"Investigation terminated on turn {turn + 1}: structural cap reached."
             )
             return result
 
@@ -182,9 +148,8 @@ def run(
 
 
 def _run_tool_calls(msg, agent_name, turn, tool_runner, caps, result, per_tool_calls):
-    """Execute every toolUse block in `msg`. Returns the list of toolResult blocks
-    to append to the conversation. Updates `result` in place (tool_calls,
-    tool_output_chars, tool_trace) and `per_tool_calls`."""
+    """Execute every toolUse block in `msg` and return the toolResult blocks
+    to append to the conversation. Mutates `result` and `per_tool_calls`."""
     tool_results = []
     for block in msg.get("content", []):
         if "toolUse" not in block:
@@ -208,8 +173,7 @@ def _run_tool_calls(msg, agent_name, turn, tool_runner, caps, result, per_tool_c
 
 def _execute_or_budget(tool_name, tool_args, agent_name, turn, tool_runner,
                        caps, result, per_tool_calls):
-    """Execute a tool call or return a budget-exhausted message. Records
-    successful runs in result.tool_trace and increments counters."""
+    """Run the tool, or return a budget-exhausted text the model will read."""
     per_tool_cap = caps.per_tool_max_calls.get(tool_name)
     if per_tool_cap is not None and per_tool_calls[tool_name] >= per_tool_cap:
         logger.info("[%s turn=%d] %s budget exhausted", agent_name, turn, tool_name)
@@ -259,8 +223,8 @@ _MAX_TRACE_ARG_CHARS = 500
 
 
 def _capped_args(args):
-    """Cap each arg value to avoid a single huge model-supplied value
-    swamping the artifact's tool trace."""
+    """Cap each arg value so a single huge model-supplied string can't
+    swamp the artifact's tool trace."""
     if not isinstance(args, dict):
         return repr(args)[:_MAX_TRACE_ARG_CHARS]
     out = {}
@@ -273,16 +237,16 @@ def _capped_args(args):
 
 
 def _extract_text(msg):
-    """Concatenate text blocks from an assistant message. Returns "" if none."""
+    """Join text blocks from an assistant message; "" if none."""
     return "\n".join(
         b.get("text", "") for b in msg.get("content", []) if "text" in b
     ).strip()
 
 
 def _recover_last_assistant_text(messages):
-    """Walk back through the conversation to the most recent assistant message
-    and extract any text it carried (possibly alongside tool_use blocks).
-    Used on max_turns exit so partial findings aren't dropped."""
+    """Walk back to the most recent assistant message and extract its text.
+    Used on max_turns / wall-clock exits so partial findings aren't dropped
+    when the trailing message is the user-side toolResult."""
     for msg in reversed(messages):
         if msg.get("role") == "assistant":
             return _extract_text(msg)
@@ -290,7 +254,7 @@ def _recover_last_assistant_text(messages):
 
 
 def _summarize_args(args):
-    """One-line representation of tool args for log output."""
+    """One-line repr of tool args, truncated for log output."""
     if not isinstance(args, dict):
         return repr(args)[:80]
     parts = []

--- a/src/scripts/issue_bot/agent_loop.py
+++ b/src/scripts/issue_bot/agent_loop.py
@@ -1,0 +1,264 @@
+"""
+Multi-turn tool-use loop for Bedrock Converse.
+
+Runs an agent (Investigator or Critic) through repeated rounds of:
+  1. Bedrock Converse call with toolConfig
+  2. If stopReason == "tool_use", execute the requested tools
+  3. Append tool results, continue
+  4. Otherwise, terminate with the final text
+
+Owns budget enforcement (turns, tool calls, tool output chars, cost),
+provenance tracking (tool trace), and graceful termination on caps.
+Both Investigator and Critic use the same loop with different caps and
+prompts.
+"""
+import logging
+import time
+from collections import defaultdict
+from dataclasses import dataclass, field
+from typing import List, Dict, Any, Optional
+
+logger = logging.getLogger("issue_bot")
+
+
+@dataclass
+class AgentCaps:
+    """Per-agent budgets enforced by the loop."""
+    max_turns: int = 15
+    max_tool_calls: int = 50
+    max_tool_output_chars: int = 400_000
+    per_tool_max_calls: Dict[str, int] = field(default_factory=lambda: {
+        "grep_codebase": 50,
+        "read_file": 30,
+        "list_dir": 20,
+        "find_callers": 20,
+        "find_tests_for": 10,
+    })
+    max_tokens_per_call: int = 8000
+
+
+@dataclass
+class AgentResult:
+    """Outcome of an agent loop run."""
+    text: str = ""
+    turns: int = 0
+    tool_calls: int = 0
+    tool_output_chars: int = 0
+    input_tokens: int = 0
+    output_tokens: int = 0
+    cache_read_tokens: int = 0
+    cache_write_tokens: int = 0
+    max_turns_reached: bool = False
+    cost_cap_hit: bool = False
+    error: Optional[str] = None
+    tool_trace: List[Dict[str, Any]] = field(default_factory=list)
+
+
+def _estimate_cost_usd(input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, pricing):
+    """Convert token counts to USD using the provided per-million rates.
+
+    pricing is a dict with keys: input_per_million, output_per_million,
+    cache_read_per_million, cache_write_per_million.
+    """
+    return (
+        (input_tokens / 1_000_000) * pricing["input_per_million"]
+        + (output_tokens / 1_000_000) * pricing["output_per_million"]
+        + (cache_read_tokens / 1_000_000) * pricing["cache_read_per_million"]
+        + (cache_write_tokens / 1_000_000) * pricing["cache_write_per_million"]
+    )
+
+
+def run(
+    bedrock_client,
+    agent_name: str,
+    system_prompt: str,
+    user_prompt: str,
+    tool_specs: List[Dict[str, Any]],
+    tool_runner,
+    caps: AgentCaps,
+    cost_tracker,
+    pricing: Dict[str, float],
+):
+    """Execute an agent's tool-use loop.
+
+    bedrock_client: instance of BedrockClient (must support converse_with_tools).
+    tool_runner: callable (name, args_dict) -> str. Implements actual tool dispatch.
+    cost_tracker: shared mutable dict {"cost_usd": float, "cap_hit": bool}.
+        The loop enforces the cap by reading/writing cost_tracker before each turn.
+    pricing: per-million-token rates for the model in use.
+
+    Returns an AgentResult.
+    """
+    result = AgentResult()
+    messages = [{"role": "user", "content": [{"text": user_prompt}]}]
+    per_tool_calls = defaultdict(int)
+
+    for turn in range(caps.max_turns):
+        result.turns = turn + 1
+
+        # Pre-turn cost cap check
+        if cost_tracker.get("cap_hit"):
+            result.cost_cap_hit = True
+            result.error = "cost cap hit before turn"
+            logger.warning("[%s turn=%d] cost cap hit, terminating", agent_name, turn + 1)
+            break
+
+        try:
+            resp = bedrock_client.converse_with_tools(
+                system_prompt=system_prompt,
+                messages=messages,
+                tool_specs=tool_specs,
+                max_tokens=caps.max_tokens_per_call,
+            )
+        except Exception as e:
+            logger.error("[%s turn=%d] bedrock error: %s", agent_name, turn + 1, type(e).__name__)
+            result.error = f"bedrock error: {type(e).__name__}: {e}"
+            break
+
+        if resp is None:
+            result.error = "bedrock returned None (circuit-breaker or transient failure)"
+            break
+
+        usage = resp.get("usage", {}) or {}
+        in_t = usage.get("inputTokens", 0) or 0
+        out_t = usage.get("outputTokens", 0) or 0
+        cr_t = usage.get("cacheReadInputTokens", 0) or 0
+        cw_t = usage.get("cacheWriteInputTokens", 0) or 0
+        result.input_tokens += in_t
+        result.output_tokens += out_t
+        result.cache_read_tokens += cr_t
+        result.cache_write_tokens += cw_t
+        delta_cost = _estimate_cost_usd(in_t, out_t, cr_t, cw_t, pricing)
+        cost_tracker["cost_usd"] = cost_tracker.get("cost_usd", 0.0) + delta_cost
+        if cost_tracker["cost_usd"] >= cost_tracker.get("cap_usd", float("inf")):
+            cost_tracker["cap_hit"] = True
+            result.cost_cap_hit = True
+        logger.info(
+            "[%s turn=%d] in=%d out=%d cacheR=%d cacheW=%d cost_so_far=$%.4f",
+            agent_name, turn + 1, in_t, out_t, cr_t, cw_t,
+            cost_tracker.get("cost_usd", 0.0),
+        )
+
+        msg = resp.get("output", {}).get("message", {})
+        if not msg:
+            result.error = "empty bedrock message"
+            break
+        messages.append(msg)
+
+        stop = resp.get("stopReason")
+        if stop != "tool_use":
+            # Final text emitted; collect and exit
+            result.text = "\n".join(
+                b.get("text", "") for b in msg.get("content", []) if "text" in b
+            ).strip()
+            return result
+
+        # Execute tool calls in this turn
+        tool_results_content = []
+        for block in msg.get("content", []):
+            if "toolUse" not in block:
+                continue
+            tu = block["toolUse"]
+            tool_name = tu.get("name", "")
+            tool_args = tu.get("input", {}) or {}
+            tool_use_id = tu.get("toolUseId", "")
+
+            # Enforce per-tool budget
+            per_tool_cap = caps.per_tool_max_calls.get(tool_name, 9999)
+            if per_tool_calls[tool_name] >= per_tool_cap:
+                tool_text = (
+                    f"BUDGET EXHAUSTED: tool '{tool_name}' has been called "
+                    f"{per_tool_cap} times. Investigate with information already "
+                    "gathered, or use a different tool."
+                )
+                logger.info("[%s turn=%d] %s budget exhausted", agent_name, turn + 1, tool_name)
+            elif result.tool_calls >= caps.max_tool_calls:
+                tool_text = (
+                    f"BUDGET EXHAUSTED: total tool calls reached {caps.max_tool_calls}. "
+                    "Conclude investigation with information already gathered."
+                )
+                logger.info("[%s turn=%d] total tool budget exhausted", agent_name, turn + 1)
+            elif result.tool_output_chars >= caps.max_tool_output_chars:
+                tool_text = (
+                    f"BUDGET EXHAUSTED: total tool output {result.tool_output_chars} chars "
+                    f"reached cap {caps.max_tool_output_chars}. Conclude investigation."
+                )
+                logger.info("[%s turn=%d] tool output budget exhausted", agent_name, turn + 1)
+            else:
+                t0 = time.monotonic()
+                tool_text = tool_runner.run(tool_name, tool_args)
+                if not isinstance(tool_text, str):
+                    tool_text = str(tool_text)
+                latency_ms = int((time.monotonic() - t0) * 1000)
+                per_tool_calls[tool_name] += 1
+                result.tool_calls += 1
+                result.tool_output_chars += len(tool_text)
+                logger.info(
+                    "[%s turn=%d] %s(%s) → %d chars in %dms",
+                    agent_name, turn + 1, tool_name,
+                    _summarize_args(tool_args), len(tool_text), latency_ms,
+                )
+                result.tool_trace.append({
+                    "agent": agent_name,
+                    "turn": turn + 1,
+                    "tool": tool_name,
+                    "args": tool_args,
+                    "result_summary": tool_text[:200] + ("..." if len(tool_text) > 200 else ""),
+                    "result_chars": len(tool_text),
+                    "latency_ms": latency_ms,
+                })
+
+            tool_results_content.append({
+                "toolResult": {
+                    "toolUseId": tool_use_id,
+                    "content": [{"text": tool_text}],
+                },
+            })
+
+        if not tool_results_content:
+            # stopReason said tool_use but no toolUse blocks present → bail
+            result.text = "\n".join(
+                b.get("text", "") for b in msg.get("content", []) if "text" in b
+            ).strip()
+            result.error = "stopReason was tool_use but no toolUse blocks emitted"
+            return result
+
+        messages.append({"role": "user", "content": tool_results_content})
+
+    # Loop exited via max_turns. The last appended message is typically a user
+    # toolResult (we appended it after the last bedrock call), so walk backward
+    # to find the most recent assistant message and extract any text it carried
+    # alongside its tool_use blocks.
+    result.max_turns_reached = True
+    for msg in reversed(messages):
+        if msg.get("role") != "assistant":
+            continue
+        text_blocks = [
+            b.get("text", "")
+            for b in msg.get("content", [])
+            if "text" in b and isinstance(b.get("text"), str)
+        ]
+        recovered = "\n".join(text_blocks).strip()
+        if recovered:
+            result.text = recovered
+        break
+    if not result.text:
+        result.text = (
+            f"Investigation hit max_turns ({caps.max_turns}) without conclusion. "
+            f"Made {result.tool_calls} tool call(s)."
+        )
+    logger.warning("[%s] max_turns (%d) reached", agent_name, caps.max_turns)
+    return result
+
+
+def _summarize_args(args):
+    """One-line summary of tool args for logging."""
+    if not isinstance(args, dict):
+        return repr(args)[:80]
+    parts = []
+    for k, v in args.items():
+        if isinstance(v, str):
+            parts.append(f"{k}={v[:60]!r}")
+        else:
+            parts.append(f"{k}={v!r}")
+    return ", ".join(parts)

--- a/src/scripts/issue_bot/agent_loop.py
+++ b/src/scripts/issue_bot/agent_loop.py
@@ -56,15 +56,25 @@ def run(
     tool_runner,
     caps: AgentCaps,
     pipeline_deadline: Optional[float] = None,
+    untrusted_user_prompt: Optional[str] = None,
 ):
     """Execute an agent's tool-use loop. Returns an AgentResult.
 
-    Termination: caps.max_turns, caps.max_tool_calls, caps.max_tool_output_chars,
-    caps.per_tool_max_calls, or pipeline_deadline (a shared monotonic deadline
-    threaded across pipeline stages) — whichever fires first.
+    user_prompt is trusted; untrusted_user_prompt (PR/issue user input)
+    goes in a guardContent block when the client has a guardrail so model
+    paraphrases of repo content don't false-trip the scanner.
+
+    Termination: caps.max_turns / max_tool_calls / max_tool_output_chars /
+    per_tool_max_calls, or pipeline_deadline.
     """
     result = AgentResult()
-    messages = [{"role": "user", "content": [{"text": user_prompt}]}]
+    messages = [{
+        "role": "user",
+        "content": _build_user_content(
+            user_prompt, untrusted_user_prompt,
+            has_guardrail=getattr(bedrock_client, "has_guardrail", False),
+        ),
+    }]
     per_tool_calls = defaultdict(int)
 
     for turn in range(max(0, caps.max_turns)):
@@ -145,6 +155,19 @@ def run(
     )
     logger.warning("[%s] max_turns (%d) reached", agent_name, caps.max_turns)
     return result
+
+
+def _build_user_content(trusted, untrusted, *, has_guardrail):
+    """Two-block form only when an untrusted segment AND a guardrail are
+    both present; otherwise concatenate into one text block."""
+    if untrusted and has_guardrail:
+        return [
+            {"text": trusted},
+            {"guardContent": {"text": {"text": untrusted}}},
+        ]
+    if untrusted:
+        return [{"text": f"{trusted}\n{untrusted}"}]
+    return [{"text": trusted}]
 
 
 def _run_tool_calls(msg, agent_name, turn, tool_runner, caps, result, per_tool_calls):

--- a/src/scripts/issue_bot/agent_loop.py
+++ b/src/scripts/issue_bot/agent_loop.py
@@ -54,7 +54,7 @@ class AgentResult:
     tool_trace: List[Dict[str, Any]] = field(default_factory=list)
 
 
-def _estimate_cost_usd(input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, pricing):
+def estimate_cost_usd(input_tokens, output_tokens, cache_read_tokens, cache_write_tokens, pricing):
     """Convert token counts to USD using the provided per-million rates.
 
     pricing is a dict with keys: input_per_million, output_per_million,
@@ -66,6 +66,11 @@ def _estimate_cost_usd(input_tokens, output_tokens, cache_read_tokens, cache_wri
         + (cache_read_tokens / 1_000_000) * pricing["cache_read_per_million"]
         + (cache_write_tokens / 1_000_000) * pricing["cache_write_per_million"]
     )
+
+
+# Backward-compatible alias for internal callers that already use the
+# private name. New code should call estimate_cost_usd().
+_estimate_cost_usd = estimate_cost_usd
 
 
 def run(
@@ -130,10 +135,16 @@ def run(
         result.cache_write_tokens += cw_t
         delta_cost = _estimate_cost_usd(in_t, out_t, cr_t, cw_t, pricing)
         cost_tracker["cost_usd"] = cost_tracker.get("cost_usd", 0.0) + delta_cost
+        # Per-turn overshoot bound: a single turn's tokens are already paid for
+        # by the time we observe the usage field. Worst-case overshoot of the
+        # cap is therefore one turn's cost, bounded by max_tokens_per_call ×
+        # the model's input rate × ~1 (output tokens are dwarfed by typical
+        # input). At default $1.00 cap and 8000 max output, plus typical 50K
+        # input, overshoot is bounded at ~$0.75 (Opus rates).
         if cost_tracker["cost_usd"] >= cost_tracker.get("cap_usd", float("inf")):
             cost_tracker["cap_hit"] = True
             result.cost_cap_hit = True
-        logger.info(
+        logger.debug(
             "[%s turn=%d] in=%d out=%d cacheR=%d cacheW=%d cost_so_far=$%.4f",
             agent_name, turn + 1, in_t, out_t, cr_t, cw_t,
             cost_tracker.get("cost_usd", 0.0),
@@ -151,6 +162,27 @@ def run(
             result.text = "\n".join(
                 b.get("text", "") for b in msg.get("content", []) if "text" in b
             ).strip()
+            return result
+
+        # Cost cap hit on this turn: skip tool execution to bound overshoot.
+        # The model's tool_use response is preserved in messages so callers can
+        # see what it was about to do. Try to recover any text it emitted
+        # alongside the tool calls.
+        if cost_tracker.get("cap_hit"):
+            text_blocks = [b.get("text", "") for b in msg.get("content", []) if "text" in b]
+            recovered = "\n".join(text_blocks).strip()
+            if recovered:
+                result.text = recovered
+            else:
+                result.text = (
+                    f"Cost cap hit on turn {turn + 1}; tool execution skipped to "
+                    "bound overshoot. Conclude investigation with information "
+                    "gathered so far."
+                )
+            logger.warning(
+                "[%s turn=%d] cost cap hit mid-turn; skipping tool execution",
+                agent_name, turn + 1,
+            )
             return result
 
         # Execute tool calls in this turn

--- a/src/scripts/issue_bot/agent_loop.py
+++ b/src/scripts/issue_bot/agent_loop.py
@@ -43,7 +43,13 @@ class AgentCaps:
 
 @dataclass
 class AgentResult:
-    """Outcome of an agent loop run."""
+    """Outcome of an agent loop run.
+
+    `error` is set on any non-clean exit (Bedrock failure, structural cap,
+    wall-clock cap, max_turns, protocol violation). Callers must check
+    `fatal` to decide whether `text` is usable: structural exits often
+    produce partial-but-valid output, fatal exits do not.
+    """
     text: str = ""
     turns: int = 0
     tool_calls: int = 0
@@ -54,6 +60,7 @@ class AgentResult:
     cache_write_tokens: int = 0
     max_turns_reached: bool = False
     error: Optional[str] = None
+    fatal: bool = False
     tool_trace: List[Dict[str, Any]] = field(default_factory=list)
 
 
@@ -65,6 +72,7 @@ def run(
     tool_specs: List[Dict[str, Any]],
     tool_runner,
     caps: AgentCaps,
+    pipeline_deadline: Optional[float] = None,
 ):
     """Execute an agent's tool-use loop. Returns an AgentResult.
 
@@ -73,18 +81,23 @@ def run(
       - caps.max_tool_calls total tool executions
       - caps.max_tool_output_chars cumulative tool output size
       - caps.per_tool_max_calls per-tool budget
-    Wall-clock is bounded by the workflow timeout.
+      - caps.wall_clock_seconds elapsed time for THIS agent
+      - pipeline_deadline (optional) absolute monotonic deadline shared
+        across all stages of the pipeline; whichever is sooner wins
     """
     result = AgentResult()
     messages = [{"role": "user", "content": [{"text": user_prompt}]}]
     per_tool_calls = defaultdict(int)
-    deadline = time.monotonic() + max(1, caps.wall_clock_seconds)
+    own_deadline = time.monotonic() + max(1, caps.wall_clock_seconds)
+    deadline = own_deadline if pipeline_deadline is None else min(own_deadline, pipeline_deadline)
 
     for turn in range(max(0, caps.max_turns)):
         result.turns = turn + 1
 
         if time.monotonic() >= deadline:
             result.error = f"wall-clock cap ({caps.wall_clock_seconds}s) reached"
+            # Bounded exit; any text recovered from prior turns is usable.
+            result.text = result.text or _recover_last_assistant_text(messages)
             logger.warning(
                 "[%s turn=%d] wall-clock cap reached, terminating",
                 agent_name, turn + 1,
@@ -97,6 +110,7 @@ def run(
                 messages=messages,
                 tool_specs=tool_specs,
                 max_tokens=caps.max_tokens_per_call,
+                timeout_seconds=max(1, deadline - time.monotonic()),
             )
         except Exception as e:
             logger.error("[%s turn=%d] bedrock error: %s", agent_name, turn + 1, type(e).__name__)
@@ -105,10 +119,12 @@ def run(
             # chars that could mangle JSON-serialized artifacts.
             msg_str = "".join(c for c in str(e)[:200] if c.isprintable() or c in " \t")
             result.error = f"bedrock error: {type(e).__name__}: {msg_str}"
+            result.fatal = True
             return result
 
         if resp is None:
             result.error = "bedrock returned None (circuit-breaker or transient failure)"
+            result.fatal = True
             return result
 
         usage = resp.get("usage") or {}
@@ -125,6 +141,7 @@ def run(
         msg = resp.get("output", {}).get("message", {})
         if not msg:
             result.error = "empty bedrock message"
+            result.fatal = True
             return result
         messages.append(msg)
 
@@ -138,6 +155,7 @@ def run(
         if not tool_results:
             result.text = _extract_text(msg)
             result.error = "stopReason was tool_use but no toolUse blocks emitted"
+            result.fatal = True
             return result
 
         # If structural caps were hit during tool execution, terminate now

--- a/src/scripts/issue_bot/bedrock_client.py
+++ b/src/scripts/issue_bot/bedrock_client.py
@@ -24,18 +24,32 @@ def _extract_first_text(content_blocks):
 class BedrockClient:
     def __init__(self, cfg):
         self._model_id = cfg.bedrock_model_id
-        self._client = boto3.client(
-            "bedrock-runtime",
-            config=BotoConfig(
-                read_timeout=cfg.bedrock_timeout,
-                connect_timeout=cfg.bedrock_timeout,
-                retries={"max_attempts": 3, "mode": "adaptive"},
-            ),
-        )
+        self._default_timeout = cfg.bedrock_timeout
+        self._client = self._build_client(self._default_timeout)
         self._guardrail_id = cfg.guardrail_id
         self._guardrail_version = cfg.guardrail_version
         self._failures = 0
         self._circuit_open = False  # Resets per-process; GHA runs are ephemeral
+
+    @staticmethod
+    def _build_client(timeout):
+        return boto3.client(
+            "bedrock-runtime",
+            config=BotoConfig(
+                read_timeout=timeout,
+                connect_timeout=timeout,
+                retries={"max_attempts": 3, "mode": "adaptive"},
+            ),
+        )
+
+    def _client_with_timeout(self, timeout_seconds):
+        """Return a Bedrock client whose read_timeout is the smaller of the
+        default and `timeout_seconds`. Avoids reuse of clients with
+        too-permissive timeouts when the caller is racing a deadline."""
+        if timeout_seconds is None or timeout_seconds >= self._default_timeout:
+            return self._client
+        # Floor at 5s so a near-zero remaining deadline still attempts the call.
+        return self._build_client(max(5, int(timeout_seconds)))
 
     @property
     def available(self):
@@ -183,7 +197,8 @@ class BedrockClient:
             return None, {}
 
     def converse_with_tools(self, system_prompt, messages, tool_specs,
-                             max_tokens=8000, temperature=0.3):
+                             max_tokens=8000, temperature=0.3,
+                             timeout_seconds=None):
         """Multi-turn Converse with toolConfig.
 
         Used by the agentic pipeline (Investigator and Critic). Caller owns
@@ -218,7 +233,8 @@ class BedrockClient:
                     "guardrailVersion": self._guardrail_version,
                     "trace": "enabled",
                 }
-            resp = self._client.converse(**kwargs)
+            client = self._client_with_timeout(timeout_seconds)
+            resp = client.converse(**kwargs)
             if resp.get("stopReason") == "guardrail_intervened":
                 logger.warning("Guardrail intervened on tool-use turn: %s", resp.get("trace", ""))
                 return None

--- a/src/scripts/issue_bot/bedrock_client.py
+++ b/src/scripts/issue_bot/bedrock_client.py
@@ -107,7 +107,8 @@ class BedrockClient:
 
     def invoke_with_usage(self, system_prompt, user_prompt, max_tokens=4096,
                            temperature=0.3, json_schema=None):
-        """Like invoke() but also returns token usage so the caller can update a cost tracker.
+        """Like invoke() but also returns the token usage so the caller can
+        report it in artifacts or metrics.
 
         Returns (text, usage_dict) where usage_dict has inputTokens/outputTokens/
         cacheReadInputTokens/cacheWriteInputTokens. On failure, returns (None, {}).

--- a/src/scripts/issue_bot/bedrock_client.py
+++ b/src/scripts/issue_bot/bedrock_client.py
@@ -9,47 +9,21 @@ logger = logging.getLogger("issue_bot")
 _CIRCUIT_BREAKER_THRESHOLD = 3
 
 
-def _extract_first_text(content_blocks):
-    """Return the first text block in a Converse response, stripped.
-
-    Tolerates blocks that don't carry text (e.g., toolUse-only responses)
-    and missing keys; returns "" rather than raising.
-    """
-    for block in content_blocks or []:
-        if isinstance(block, dict) and isinstance(block.get("text"), str):
-            return block["text"].strip()
-    return ""
-
-
 class BedrockClient:
     def __init__(self, cfg):
         self._model_id = cfg.bedrock_model_id
-        self._default_timeout = cfg.bedrock_timeout
-        self._client = self._build_client(self._default_timeout)
+        self._client = boto3.client(
+            "bedrock-runtime",
+            config=BotoConfig(
+                read_timeout=cfg.bedrock_timeout,
+                connect_timeout=cfg.bedrock_timeout,
+                retries={"max_attempts": 3, "mode": "adaptive"},
+            ),
+        )
         self._guardrail_id = cfg.guardrail_id
         self._guardrail_version = cfg.guardrail_version
         self._failures = 0
         self._circuit_open = False  # Resets per-process; GHA runs are ephemeral
-
-    @staticmethod
-    def _build_client(timeout):
-        return boto3.client(
-            "bedrock-runtime",
-            config=BotoConfig(
-                read_timeout=timeout,
-                connect_timeout=timeout,
-                retries={"max_attempts": 3, "mode": "adaptive"},
-            ),
-        )
-
-    def _client_with_timeout(self, timeout_seconds):
-        """Return a Bedrock client whose read_timeout is the smaller of the
-        default and `timeout_seconds`. Avoids reuse of clients with
-        too-permissive timeouts when the caller is racing a deadline."""
-        if timeout_seconds is None or timeout_seconds >= self._default_timeout:
-            return self._client
-        # Floor at 5s so a near-zero remaining deadline still attempts the call.
-        return self._build_client(max(5, int(timeout_seconds)))
 
     @property
     def available(self):
@@ -122,7 +96,7 @@ class BedrockClient:
             logger.info("Bedrock: input=%s, output=%s, cacheRead=%s, cacheWrite=%s",
                         usage.get("inputTokens"), usage.get("outputTokens"),
                         usage.get("cacheReadInputTokens"), usage.get("cacheWriteInputTokens"))
-            return _extract_first_text(output)
+            return (output[0].get("text") or "").strip()
         except (ClientError, BotoCoreError, ValueError, KeyError, ConnectionError) as e:
             self._failures += 1
             logger.error(f"Bedrock failed ({self._failures}/{_CIRCUIT_BREAKER_THRESHOLD}): {e}")
@@ -133,12 +107,8 @@ class BedrockClient:
 
     def invoke_with_usage(self, system_prompt, user_prompt, max_tokens=4096,
                            temperature=0.3, json_schema=None):
-        """Like invoke() but also returns the token usage so the caller can
-        report it in artifacts or metrics.
-
-        Returns (text, usage_dict) where usage_dict has inputTokens/outputTokens/
-        cacheReadInputTokens/cacheWriteInputTokens. On failure, returns (None, {}).
-        """
+        """Like invoke() but also returns the response's token usage dict so
+        the caller can record it. Returns (None, {}) on failure."""
         if self._circuit_open:
             logger.warning("Circuit breaker open, skipping Bedrock call")
             return None, {}
@@ -187,7 +157,7 @@ class BedrockClient:
                 usage.get("inputTokens"), usage.get("outputTokens"),
                 usage.get("cacheReadInputTokens"), usage.get("cacheWriteInputTokens"),
             )
-            return _extract_first_text(output), usage
+            return (output[0].get("text") or "").strip(), usage
         except (ClientError, BotoCoreError, ValueError, KeyError, ConnectionError) as e:
             self._failures += 1
             logger.error(f"Bedrock failed ({self._failures}/{_CIRCUIT_BREAKER_THRESHOLD}): {e}")
@@ -197,19 +167,13 @@ class BedrockClient:
             return None, {}
 
     def converse_with_tools(self, system_prompt, messages, tool_specs,
-                             max_tokens=8000, temperature=0.3,
-                             timeout_seconds=None):
-        """Multi-turn Converse with toolConfig.
+                             max_tokens=8000, temperature=0.3):
+        """One turn of Converse with toolConfig. The caller owns the messages
+        list and appends tool results between turns. Returns the raw response
+        dict (or None on failure / guardrail intervention / circuit open).
 
-        Used by the agentic pipeline (Investigator and Critic). Caller owns
-        the messages list and appends tool results between turns. Returns the
-        raw response dict so the caller can inspect stopReason, content blocks,
-        and usage.
-
-        The first user message in `messages` is wrapped in guardContent when a
-        guardrail is configured. Subsequent messages (toolResult content from
-        the loop) are NOT wrapped — they originate from the bot's own
-        filesystem reads, not user input.
+        Only the first user message is wrapped in guardContent — subsequent
+        toolResult messages come from our own filesystem and aren't user input.
         """
         if self._circuit_open:
             logger.warning("Circuit breaker open, skipping Bedrock tool-use call")
@@ -233,8 +197,7 @@ class BedrockClient:
                     "guardrailVersion": self._guardrail_version,
                     "trace": "enabled",
                 }
-            client = self._client_with_timeout(timeout_seconds)
-            resp = client.converse(**kwargs)
+            resp = self._client.converse(**kwargs)
             if resp.get("stopReason") == "guardrail_intervened":
                 logger.warning("Guardrail intervened on tool-use turn: %s", resp.get("trace", ""))
                 return None
@@ -249,10 +212,8 @@ class BedrockClient:
             return None
 
     def _wrap_first_user_for_guardrail(self, messages):
-        """Wrap the FIRST user message's text content in guardContent for prompt-injection scanning.
-
-        Subsequent user messages (toolResult blocks) are passthrough.
-        """
+        """Wrap the first user message's text in guardContent so the
+        guardrail scans it; pass subsequent user messages through unchanged."""
         if not self._guardrail_id or not messages:
             return messages
         out = []

--- a/src/scripts/issue_bot/bedrock_client.py
+++ b/src/scripts/issue_bot/bedrock_client.py
@@ -9,6 +9,18 @@ logger = logging.getLogger("issue_bot")
 _CIRCUIT_BREAKER_THRESHOLD = 3
 
 
+def _extract_first_text(content_blocks):
+    """Return the first text block in a Converse response, stripped.
+
+    Tolerates blocks that don't carry text (e.g., toolUse-only responses)
+    and missing keys; returns "" rather than raising.
+    """
+    for block in content_blocks or []:
+        if isinstance(block, dict) and isinstance(block.get("text"), str):
+            return block["text"].strip()
+    return ""
+
+
 class BedrockClient:
     def __init__(self, cfg):
         self._model_id = cfg.bedrock_model_id
@@ -96,8 +108,8 @@ class BedrockClient:
             logger.info("Bedrock: input=%s, output=%s, cacheRead=%s, cacheWrite=%s",
                         usage.get("inputTokens"), usage.get("outputTokens"),
                         usage.get("cacheReadInputTokens"), usage.get("cacheWriteInputTokens"))
-            return output[0]["text"].strip()
-        except (ClientError, BotoCoreError, ValueError, ConnectionError) as e:
+            return _extract_first_text(output)
+        except (ClientError, BotoCoreError, ValueError, KeyError, ConnectionError) as e:
             self._failures += 1
             logger.error(f"Bedrock failed ({self._failures}/{_CIRCUIT_BREAKER_THRESHOLD}): {e}")
             if self._failures >= _CIRCUIT_BREAKER_THRESHOLD:
@@ -161,8 +173,8 @@ class BedrockClient:
                 usage.get("inputTokens"), usage.get("outputTokens"),
                 usage.get("cacheReadInputTokens"), usage.get("cacheWriteInputTokens"),
             )
-            return output[0]["text"].strip(), usage
-        except (ClientError, BotoCoreError, ValueError, ConnectionError) as e:
+            return _extract_first_text(output), usage
+        except (ClientError, BotoCoreError, ValueError, KeyError, ConnectionError) as e:
             self._failures += 1
             logger.error(f"Bedrock failed ({self._failures}/{_CIRCUIT_BREAKER_THRESHOLD}): {e}")
             if self._failures >= _CIRCUIT_BREAKER_THRESHOLD:

--- a/src/scripts/issue_bot/bedrock_client.py
+++ b/src/scripts/issue_bot/bedrock_client.py
@@ -12,11 +12,12 @@ _CIRCUIT_BREAKER_THRESHOLD = 3
 class BedrockClient:
     def __init__(self, cfg):
         self._model_id = cfg.bedrock_model_id
+        self._default_timeout = cfg.bedrock_timeout
         self._client = boto3.client(
             "bedrock-runtime",
             config=BotoConfig(
-                read_timeout=cfg.bedrock_timeout,
-                connect_timeout=cfg.bedrock_timeout,
+                read_timeout=self._default_timeout,
+                connect_timeout=self._default_timeout,
                 retries={"max_attempts": 3, "mode": "adaptive"},
             ),
         )
@@ -25,9 +26,32 @@ class BedrockClient:
         self._failures = 0
         self._circuit_open = False  # Resets per-process; GHA runs are ephemeral
 
+    def _client_for_timeout(self, timeout_seconds):
+        """Return a client whose read_timeout is at most timeout_seconds.
+        Single-attempt retry policy: retry storms aren't useful when the
+        caller is already on a tight wall-clock budget."""
+        if timeout_seconds is None or timeout_seconds >= self._default_timeout:
+            return self._client
+        if timeout_seconds <= 0:
+            timeout_seconds = 1  # botocore rejects 0/negative
+        return boto3.client(
+            "bedrock-runtime",
+            config=BotoConfig(
+                read_timeout=timeout_seconds,
+                connect_timeout=min(timeout_seconds, self._default_timeout),
+                retries={"max_attempts": 1, "mode": "standard"},
+            ),
+        )
+
     @property
     def available(self):
         return not self._circuit_open
+
+    @property
+    def has_guardrail(self):
+        """Whether a guardrail is configured on this client. Read by
+        agent_loop to decide whether to compose guardContent blocks."""
+        return bool(self._guardrail_id)
 
     def invoke(self, system_prompt, user_prompt, max_tokens=4096,
                temperature=0.3, json_schema=None):
@@ -106,9 +130,17 @@ class BedrockClient:
             return None
 
     def invoke_with_usage(self, system_prompt, user_prompt, max_tokens=4096,
-                           temperature=0.3, json_schema=None):
-        """Like invoke() but also returns the response's token usage dict so
-        the caller can record it. Returns (None, {}) on failure."""
+                           temperature=0.3, json_schema=None,
+                           timeout_seconds=None):
+        """Like invoke() but also returns the response's token usage dict.
+        Returns (None, {}) on failure.
+
+        timeout_seconds (optional): per-call read/connect timeout, used by
+        the Reporter to bound the call at the remaining wall-clock budget.
+
+        No cachePoint: the Reporter (sole caller) embeds the per-PR diff
+        in its system prompt, so the cache prefix never repeats.
+        """
         if self._circuit_open:
             logger.warning("Circuit breaker open, skipping Bedrock call")
             return None, {}
@@ -123,10 +155,7 @@ class BedrockClient:
                 "inferenceConfig": {"maxTokens": max_tokens, "temperature": temperature},
             }
             if system_prompt:
-                kwargs["system"] = [
-                    {"text": system_prompt},
-                    {"cachePoint": {"type": "default"}},
-                ]
+                kwargs["system"] = [{"text": system_prompt}]
             if json_schema:
                 kwargs["outputConfig"] = {
                     "textFormat": {
@@ -143,7 +172,8 @@ class BedrockClient:
                     "guardrailVersion": self._guardrail_version,
                     "trace": "enabled",
                 }
-            resp = self._client.converse(**kwargs)
+            client = self._client_for_timeout(timeout_seconds)
+            resp = client.converse(**kwargs)
             if resp.get("stopReason") == "guardrail_intervened":
                 logger.warning("Guardrail intervened: %s", resp.get("trace", ""))
                 return None, resp.get("usage", {}) or {}
@@ -168,12 +198,14 @@ class BedrockClient:
 
     def converse_with_tools(self, system_prompt, messages, tool_specs,
                              max_tokens=8000, temperature=0.3):
-        """One turn of Converse with toolConfig. The caller owns the messages
-        list and appends tool results between turns. Returns the raw response
+        """One turn of Converse with toolConfig. Returns the raw response
         dict (or None on failure / guardrail intervention / circuit open).
 
-        Only the first user message is wrapped in guardContent — subsequent
-        toolResult messages come from our own filesystem and aren't user input.
+        cachePoint is set here (unlike invoke()/invoke_with_usage) because
+        Investigator and Critic share the static prefix from
+        _build_static_context — the Investigator's first turn warms a cache
+        the Critic's first turn can read. Validate via cacheReadInputTokens
+        on the Critic stage in the artifact metrics.
         """
         if self._circuit_open:
             logger.warning("Circuit breaker open, skipping Bedrock tool-use call")
@@ -212,16 +244,31 @@ class BedrockClient:
             return None
 
     def _wrap_first_user_for_guardrail(self, messages):
-        """Wrap the first user message's text in guardContent so the
-        guardrail scans it; pass subsequent user messages through unchanged."""
+        """Wrap the first user message's text in guardContent for guardrail
+        scanning. Skipped when the caller has already set a guardContent
+        block (signals an explicit trust boundary, don't re-wrap adjacent
+        trusted text).
+
+        Assumes callers using the [trusted, guardContent(untrusted)]
+        composition pattern from agent_loop._build_user_content. Reusing
+        this helper with arbitrary content layouts (e.g., multiple
+        text blocks alongside a guardContent block) requires re-thinking
+        the wrap rule — a text block in any position alongside a
+        guardContent block currently passes through unwrapped.
+        """
         if not self._guardrail_id or not messages:
             return messages
         out = []
         guarded = False
         for msg in messages:
             if not guarded and msg.get("role") == "user":
+                content = msg.get("content", [])
+                if any("guardContent" in block for block in content):
+                    out.append(msg)
+                    guarded = True
+                    continue
                 new_content = []
-                for block in msg.get("content", []):
+                for block in content:
                     if "text" in block:
                         new_content.append({"guardContent": {"text": {"text": block["text"]}}})
                     else:

--- a/src/scripts/issue_bot/bedrock_client.py
+++ b/src/scripts/issue_bot/bedrock_client.py
@@ -104,3 +104,140 @@ class BedrockClient:
                 self._circuit_open = True
                 logger.error("Circuit breaker OPEN")
             return None
+
+    def invoke_with_usage(self, system_prompt, user_prompt, max_tokens=4096,
+                           temperature=0.3, json_schema=None):
+        """Like invoke() but also returns token usage so the caller can update a cost tracker.
+
+        Returns (text, usage_dict) where usage_dict has inputTokens/outputTokens/
+        cacheReadInputTokens/cacheWriteInputTokens. On failure, returns (None, {}).
+        """
+        if self._circuit_open:
+            logger.warning("Circuit breaker open, skipping Bedrock call")
+            return None, {}
+        try:
+            if self._guardrail_id:
+                user_content = [{"guardContent": {"text": {"text": user_prompt}}}]
+            else:
+                user_content = [{"text": user_prompt}]
+            kwargs = {
+                "modelId": self._model_id,
+                "messages": [{"role": "user", "content": user_content}],
+                "inferenceConfig": {"maxTokens": max_tokens, "temperature": temperature},
+            }
+            if system_prompt:
+                kwargs["system"] = [
+                    {"text": system_prompt},
+                    {"cachePoint": {"type": "default"}},
+                ]
+            if json_schema:
+                kwargs["outputConfig"] = {
+                    "textFormat": {
+                        "type": "json_schema",
+                        "structure": {"jsonSchema": {
+                            "schema": json_schema,
+                            "name": "bot_response",
+                        }},
+                    }
+                }
+            if self._guardrail_id:
+                kwargs["guardrailConfig"] = {
+                    "guardrailIdentifier": self._guardrail_id,
+                    "guardrailVersion": self._guardrail_version,
+                    "trace": "enabled",
+                }
+            resp = self._client.converse(**kwargs)
+            if resp.get("stopReason") == "guardrail_intervened":
+                logger.warning("Guardrail intervened: %s", resp.get("trace", ""))
+                return None, resp.get("usage", {}) or {}
+            output = resp.get("output", {}).get("message", {}).get("content", [])
+            if not output:
+                raise ValueError("Empty Bedrock response")
+            self._failures = 0
+            usage = resp.get("usage", {}) or {}
+            logger.info(
+                "Bedrock: input=%s, output=%s, cacheRead=%s, cacheWrite=%s",
+                usage.get("inputTokens"), usage.get("outputTokens"),
+                usage.get("cacheReadInputTokens"), usage.get("cacheWriteInputTokens"),
+            )
+            return output[0]["text"].strip(), usage
+        except (ClientError, BotoCoreError, ValueError, ConnectionError) as e:
+            self._failures += 1
+            logger.error(f"Bedrock failed ({self._failures}/{_CIRCUIT_BREAKER_THRESHOLD}): {e}")
+            if self._failures >= _CIRCUIT_BREAKER_THRESHOLD:
+                self._circuit_open = True
+                logger.error("Circuit breaker OPEN")
+            return None, {}
+
+    def converse_with_tools(self, system_prompt, messages, tool_specs,
+                             max_tokens=8000, temperature=0.3):
+        """Multi-turn Converse with toolConfig.
+
+        Used by the agentic pipeline (Investigator and Critic). Caller owns
+        the messages list and appends tool results between turns. Returns the
+        raw response dict so the caller can inspect stopReason, content blocks,
+        and usage.
+
+        The first user message in `messages` is wrapped in guardContent when a
+        guardrail is configured. Subsequent messages (toolResult content from
+        the loop) are NOT wrapped — they originate from the bot's own
+        filesystem reads, not user input.
+        """
+        if self._circuit_open:
+            logger.warning("Circuit breaker open, skipping Bedrock tool-use call")
+            return None
+        try:
+            wrapped_messages = self._wrap_first_user_for_guardrail(messages)
+            kwargs = {
+                "modelId": self._model_id,
+                "messages": wrapped_messages,
+                "inferenceConfig": {"maxTokens": max_tokens, "temperature": temperature},
+                "toolConfig": {"tools": tool_specs},
+            }
+            if system_prompt:
+                kwargs["system"] = [
+                    {"text": system_prompt},
+                    {"cachePoint": {"type": "default"}},
+                ]
+            if self._guardrail_id:
+                kwargs["guardrailConfig"] = {
+                    "guardrailIdentifier": self._guardrail_id,
+                    "guardrailVersion": self._guardrail_version,
+                    "trace": "enabled",
+                }
+            resp = self._client.converse(**kwargs)
+            if resp.get("stopReason") == "guardrail_intervened":
+                logger.warning("Guardrail intervened on tool-use turn: %s", resp.get("trace", ""))
+                return None
+            self._failures = 0
+            return resp
+        except (ClientError, BotoCoreError, ValueError, ConnectionError) as e:
+            self._failures += 1
+            logger.error(f"Bedrock tool-use call failed ({self._failures}/{_CIRCUIT_BREAKER_THRESHOLD}): {e}")
+            if self._failures >= _CIRCUIT_BREAKER_THRESHOLD:
+                self._circuit_open = True
+                logger.error("Circuit breaker OPEN")
+            return None
+
+    def _wrap_first_user_for_guardrail(self, messages):
+        """Wrap the FIRST user message's text content in guardContent for prompt-injection scanning.
+
+        Subsequent user messages (toolResult blocks) are passthrough.
+        """
+        if not self._guardrail_id or not messages:
+            return messages
+        out = []
+        guarded = False
+        for msg in messages:
+            if not guarded and msg.get("role") == "user":
+                new_content = []
+                for block in msg.get("content", []):
+                    if "text" in block:
+                        new_content.append({"guardContent": {"text": {"text": block["text"]}}})
+                    else:
+                        new_content.append(block)
+                out.append({**msg, "content": new_content})
+                guarded = True
+            else:
+                out.append(msg)
+        return out

--- a/src/scripts/issue_bot/config.py
+++ b/src/scripts/issue_bot/config.py
@@ -52,29 +52,23 @@ class Config:
         # the legacy two-phase flow active. Conservative: default off.
         self.agent_pipeline = os.getenv("BOT_AGENT_PIPELINE", "").strip().lower() in ("1", "true", "yes", "on")
 
-        # Structural caps for runaway protection. Token usage is reported in
-        # artifacts but is not used to enforce a budget — operators monitor
-        # cost via the artifact metrics, not via this code.
-        self.investigator_max_turns = _int_env("BOT_INVESTIGATOR_MAX_TURNS", 15, minimum=1)
-        self.investigator_max_tool_calls = _int_env("BOT_INVESTIGATOR_MAX_TOOL_CALLS", 50, minimum=1)
+        # Structural caps for runaway protection.
+        self.investigator_max_turns = _int_env("BOT_INVESTIGATOR_MAX_TURNS", 15)
+        self.investigator_max_tool_calls = _int_env("BOT_INVESTIGATOR_MAX_TOOL_CALLS", 50)
         self.investigator_max_tool_output_chars = _int_env(
-            "BOT_INVESTIGATOR_MAX_TOOL_OUTPUT", 400_000, minimum=1024,
-        )
-        self.investigator_wall_clock_seconds = _int_env(
-            "BOT_INVESTIGATOR_WALL_CLOCK_S", 300, minimum=10,
+            "BOT_INVESTIGATOR_MAX_TOOL_OUTPUT", 400_000,
         )
 
-        self.critic_max_turns = _int_env("BOT_CRITIC_MAX_TURNS", 10, minimum=1)
-        self.critic_max_tool_calls = _int_env("BOT_CRITIC_MAX_TOOL_CALLS", 30, minimum=1)
+        self.critic_max_turns = _int_env("BOT_CRITIC_MAX_TURNS", 10)
+        self.critic_max_tool_calls = _int_env("BOT_CRITIC_MAX_TOOL_CALLS", 30)
         self.critic_max_tool_output_chars = _int_env(
-            "BOT_CRITIC_MAX_TOOL_OUTPUT", 200_000, minimum=1024,
+            "BOT_CRITIC_MAX_TOOL_OUTPUT", 200_000,
         )
-        self.critic_max_diff_chars = _int_env("BOT_CRITIC_MAX_DIFF_CHARS", 200_000, minimum=1024)
-        self.critic_wall_clock_seconds = _int_env("BOT_CRITIC_WALL_CLOCK_S", 240, minimum=10)
+        self.critic_max_diff_chars = _int_env("BOT_CRITIC_MAX_DIFF_CHARS", 200_000)
         # Pipeline-wide wall-clock cap shared across Investigator + Critic.
         # The workflow itself is bounded at 10 minutes; this leaves room for
         # the Reporter call and artifact upload.
-        self.pipeline_wall_clock_seconds = _int_env("BOT_PIPELINE_WALL_CLOCK_S", 480, minimum=30)
+        self.pipeline_wall_clock_seconds = _int_env("BOT_PIPELINE_WALL_CLOCK_S", 480)
 
 
 def _require(name):
@@ -85,30 +79,13 @@ def _require(name):
     return val
 
 
-def _int_env(name, default, minimum=None):
+def _int_env(name, default):
     """Parse an integer env var, falling back to `default` on garbage input.
-
-    Logs a warning rather than crashing when the value is non-numeric so a
-    typo in workflow vars (e.g., "15m") doesn't kill analyze() before any
-    artifact can be written. `minimum` clamps absurdly low values to a safe
-    floor.
+    A typo in workflow vars (e.g., "15m") shouldn't kill analyze() before
+    any artifact can be written.
     """
-    raw = os.getenv(name)
-    if raw is None or raw.strip() == "":
-        value = default
-    else:
-        try:
-            value = int(raw.strip())
-        except (TypeError, ValueError):
-            logger.warning(
-                "Env var %s=%r is not an integer; using default %d",
-                name, raw, default,
-            )
-            value = default
-    if minimum is not None and value < minimum:
-        logger.warning(
-            "Env var %s=%d below minimum %d; clamping to minimum",
-            name, value, minimum,
-        )
-        value = minimum
-    return value
+    try:
+        return int(os.getenv(name) or default)
+    except (TypeError, ValueError):
+        logger.warning("Env var %s is not an integer; using default %d", name, default)
+        return default

--- a/src/scripts/issue_bot/config.py
+++ b/src/scripts/issue_bot/config.py
@@ -55,14 +55,22 @@ class Config:
         # Structural caps for runaway protection. Token usage is reported in
         # artifacts but is not used to enforce a budget — operators monitor
         # cost via the artifact metrics, not via this code.
-        self.investigator_max_turns = int(os.getenv("BOT_INVESTIGATOR_MAX_TURNS", "15"))
-        self.investigator_max_tool_calls = int(os.getenv("BOT_INVESTIGATOR_MAX_TOOL_CALLS", "50"))
-        self.investigator_max_tool_output_chars = int(os.getenv("BOT_INVESTIGATOR_MAX_TOOL_OUTPUT", "400000"))
+        self.investigator_max_turns = _int_env("BOT_INVESTIGATOR_MAX_TURNS", 15, minimum=1)
+        self.investigator_max_tool_calls = _int_env("BOT_INVESTIGATOR_MAX_TOOL_CALLS", 50, minimum=1)
+        self.investigator_max_tool_output_chars = _int_env(
+            "BOT_INVESTIGATOR_MAX_TOOL_OUTPUT", 400_000, minimum=1024,
+        )
+        self.investigator_wall_clock_seconds = _int_env(
+            "BOT_INVESTIGATOR_WALL_CLOCK_S", 300, minimum=10,
+        )
 
-        self.critic_max_turns = int(os.getenv("BOT_CRITIC_MAX_TURNS", "10"))
-        self.critic_max_tool_calls = int(os.getenv("BOT_CRITIC_MAX_TOOL_CALLS", "30"))
-        self.critic_max_tool_output_chars = int(os.getenv("BOT_CRITIC_MAX_TOOL_OUTPUT", "200000"))
-        self.critic_max_diff_chars = int(os.getenv("BOT_CRITIC_MAX_DIFF_CHARS", "200000"))
+        self.critic_max_turns = _int_env("BOT_CRITIC_MAX_TURNS", 10, minimum=1)
+        self.critic_max_tool_calls = _int_env("BOT_CRITIC_MAX_TOOL_CALLS", 30, minimum=1)
+        self.critic_max_tool_output_chars = _int_env(
+            "BOT_CRITIC_MAX_TOOL_OUTPUT", 200_000, minimum=1024,
+        )
+        self.critic_max_diff_chars = _int_env("BOT_CRITIC_MAX_DIFF_CHARS", 200_000, minimum=1024)
+        self.critic_wall_clock_seconds = _int_env("BOT_CRITIC_WALL_CLOCK_S", 240, minimum=10)
 
 
 def _require(name):
@@ -71,3 +79,32 @@ def _require(name):
         logger.error(f"Missing required env var: {name}")
         sys.exit(1)
     return val
+
+
+def _int_env(name, default, minimum=None):
+    """Parse an integer env var, falling back to `default` on garbage input.
+
+    Logs a warning rather than crashing when the value is non-numeric so a
+    typo in workflow vars (e.g., "15m") doesn't kill analyze() before any
+    artifact can be written. `minimum` clamps absurdly low values to a safe
+    floor.
+    """
+    raw = os.getenv(name)
+    if raw is None or raw.strip() == "":
+        value = default
+    else:
+        try:
+            value = int(raw.strip())
+        except (TypeError, ValueError):
+            logger.warning(
+                "Env var %s=%r is not an integer; using default %d",
+                name, raw, default,
+            )
+            value = default
+    if minimum is not None and value < minimum:
+        logger.warning(
+            "Env var %s=%d below minimum %d; clamping to minimum",
+            name, value, minimum,
+        )
+        value = minimum
+    return value

--- a/src/scripts/issue_bot/config.py
+++ b/src/scripts/issue_bot/config.py
@@ -64,11 +64,20 @@ class Config:
         self.critic_max_tool_output_chars = _int_env(
             "BOT_CRITIC_MAX_TOOL_OUTPUT", 200_000,
         )
-        self.critic_max_diff_chars = _int_env("BOT_CRITIC_MAX_DIFF_CHARS", 200_000)
-        # Pipeline-wide wall-clock cap shared across Investigator + Critic.
-        # The workflow itself is bounded at 10 minutes; this leaves room for
-        # the Reporter call and artifact upload.
+        # Cap on diff bytes in either agent's user prompt. Non-positive
+        # would silently drop the diff entirely → fail safe to default.
+        agent_max_diff = _int_env("BOT_AGENT_MAX_DIFF_CHARS", 200_000)
+        if agent_max_diff <= 0:
+            logger.warning(
+                "BOT_AGENT_MAX_DIFF_CHARS=%d is non-positive; using default 200_000",
+                agent_max_diff,
+            )
+            agent_max_diff = 200_000
+        self.agent_max_diff_chars = agent_max_diff
         self.pipeline_wall_clock_seconds = _int_env("BOT_PIPELINE_WALL_CLOCK_S", 480)
+        # Reporter latency on slow Bedrock days runs 20-45s; below this
+        # margin a Reporter started in budget could finish out of budget.
+        self.reporter_min_remaining_seconds = _int_env("BOT_REPORTER_MIN_REMAINING_S", 60)
 
 
 def _require(name):

--- a/src/scripts/issue_bot/config.py
+++ b/src/scripts/issue_bot/config.py
@@ -71,6 +71,10 @@ class Config:
         )
         self.critic_max_diff_chars = _int_env("BOT_CRITIC_MAX_DIFF_CHARS", 200_000, minimum=1024)
         self.critic_wall_clock_seconds = _int_env("BOT_CRITIC_WALL_CLOCK_S", 240, minimum=10)
+        # Pipeline-wide wall-clock cap shared across Investigator + Critic.
+        # The workflow itself is bounded at 10 minutes; this leaves room for
+        # the Reporter call and artifact upload.
+        self.pipeline_wall_clock_seconds = _int_env("BOT_PIPELINE_WALL_CLOCK_S", 480, minimum=30)
 
 
 def _require(name):

--- a/src/scripts/issue_bot/config.py
+++ b/src/scripts/issue_bot/config.py
@@ -46,6 +46,33 @@ class Config:
             "help-wanted", "dqdl", "analyzer", "spark-compatibility",
         }
 
+        # Agentic pipeline (Investigator/Critic/Reporter). Enabled only when
+        # BOT_AGENT_PIPELINE is set to one of: 1, true, yes, on (case-insensitive,
+        # whitespace-stripped). Any other value (including no/off/empty) keeps
+        # the legacy two-phase flow active. Conservative: default off.
+        self.agent_pipeline = os.getenv("BOT_AGENT_PIPELINE", "").strip().lower() in ("1", "true", "yes", "on")
+        self.agent_max_review_cost_usd = float(os.getenv("BOT_AGENT_COST_CAP_USD", "1.00"))
+
+        # Investigator caps (adapted to PR size at runtime; these are upper bounds).
+        self.investigator_max_turns = int(os.getenv("BOT_INVESTIGATOR_MAX_TURNS", "15"))
+        self.investigator_max_tool_calls = int(os.getenv("BOT_INVESTIGATOR_MAX_TOOL_CALLS", "50"))
+        self.investigator_max_tool_output_chars = int(os.getenv("BOT_INVESTIGATOR_MAX_TOOL_OUTPUT", "400000"))
+
+        # Critic caps (smaller — verification is narrower than discovery).
+        self.critic_max_turns = int(os.getenv("BOT_CRITIC_MAX_TURNS", "10"))
+        self.critic_max_tool_calls = int(os.getenv("BOT_CRITIC_MAX_TOOL_CALLS", "30"))
+        self.critic_max_tool_output_chars = int(os.getenv("BOT_CRITIC_MAX_TOOL_OUTPUT", "200000"))
+        self.critic_top_n_findings = int(os.getenv("BOT_CRITIC_TOP_N", "10"))
+
+        # Bedrock pricing (per million tokens) for cost estimation. Update when prices change.
+        # Defaults are for Claude Opus 4.6 on Bedrock as of plan-write date.
+        self.bedrock_pricing = {
+            "input_per_million": float(os.getenv("BEDROCK_INPUT_PER_MILLION", "15.00")),
+            "output_per_million": float(os.getenv("BEDROCK_OUTPUT_PER_MILLION", "75.00")),
+            "cache_read_per_million": float(os.getenv("BEDROCK_CACHE_READ_PER_MILLION", "1.50")),
+            "cache_write_per_million": float(os.getenv("BEDROCK_CACHE_WRITE_PER_MILLION", "18.75")),
+        }
+
 
 def _require(name):
     val = os.getenv(name)

--- a/src/scripts/issue_bot/config.py
+++ b/src/scripts/issue_bot/config.py
@@ -51,27 +51,18 @@ class Config:
         # whitespace-stripped). Any other value (including no/off/empty) keeps
         # the legacy two-phase flow active. Conservative: default off.
         self.agent_pipeline = os.getenv("BOT_AGENT_PIPELINE", "").strip().lower() in ("1", "true", "yes", "on")
-        self.agent_max_review_cost_usd = float(os.getenv("BOT_AGENT_COST_CAP_USD", "1.00"))
 
-        # Investigator caps (adapted to PR size at runtime; these are upper bounds).
+        # Structural caps for runaway protection. Token usage is reported in
+        # artifacts but is not used to enforce a budget — operators monitor
+        # cost via the artifact metrics, not via this code.
         self.investigator_max_turns = int(os.getenv("BOT_INVESTIGATOR_MAX_TURNS", "15"))
         self.investigator_max_tool_calls = int(os.getenv("BOT_INVESTIGATOR_MAX_TOOL_CALLS", "50"))
         self.investigator_max_tool_output_chars = int(os.getenv("BOT_INVESTIGATOR_MAX_TOOL_OUTPUT", "400000"))
 
-        # Critic caps (smaller — verification is narrower than discovery).
         self.critic_max_turns = int(os.getenv("BOT_CRITIC_MAX_TURNS", "10"))
         self.critic_max_tool_calls = int(os.getenv("BOT_CRITIC_MAX_TOOL_CALLS", "30"))
         self.critic_max_tool_output_chars = int(os.getenv("BOT_CRITIC_MAX_TOOL_OUTPUT", "200000"))
-        self.critic_top_n_findings = int(os.getenv("BOT_CRITIC_TOP_N", "10"))
-
-        # Bedrock pricing (per million tokens) for cost estimation. Update when prices change.
-        # Defaults are for Claude Opus 4.6 on Bedrock as of plan-write date.
-        self.bedrock_pricing = {
-            "input_per_million": float(os.getenv("BEDROCK_INPUT_PER_MILLION", "15.00")),
-            "output_per_million": float(os.getenv("BEDROCK_OUTPUT_PER_MILLION", "75.00")),
-            "cache_read_per_million": float(os.getenv("BEDROCK_CACHE_READ_PER_MILLION", "1.50")),
-            "cache_write_per_million": float(os.getenv("BEDROCK_CACHE_WRITE_PER_MILLION", "18.75")),
-        }
+        self.critic_max_diff_chars = int(os.getenv("BOT_CRITIC_MAX_DIFF_CHARS", "200000"))
 
 
 def _require(name):

--- a/src/scripts/issue_bot/github_client.py
+++ b/src/scripts/issue_bot/github_client.py
@@ -18,6 +18,11 @@ class GitHubClient:
             "Accept": "application/vnd.github.v3+json",
         }
 
+    @property
+    def repo_root(self):
+        """Absolute path to the checked-out repo (GITHUB_WORKSPACE in CI)."""
+        return self._repo_root
+
     def get_issue(self, number):
         return self._get(f"/repos/{self._repo}/issues/{number}")
 

--- a/src/scripts/issue_bot/main.py
+++ b/src/scripts/issue_bot/main.py
@@ -820,6 +820,11 @@ def _run_agent_pipeline(*, cfg, gh, bedrock, number, title, body, html_url, item
     if not reporter_tmpl:
         missing.append("reporter")
     if missing:
+        logger.error(
+            "Pipeline enabled but required prompt(s) missing: %s. Failing closed "
+            "(escalating). Set the corresponding SM_* env var or PR_*_PROMPT.",
+            ", ".join(missing),
+        )
         _write_artifact({
             "action": "ESCALATE", "labels": [], "response": "",
             "reason": f"prompt_load_failed: {','.join(missing)}",
@@ -897,7 +902,7 @@ def _run_agent_pipeline(*, cfg, gh, bedrock, number, title, body, html_url, item
         f"<pr>\nTitle: {title}\nBody: {body}\n</pr>"
     )
 
-    tool_runner = ToolRunner(cfg, gh._repo_root)
+    tool_runner = ToolRunner(cfg, gh.repo_root)
     cost_tracker = {
         "cost_usd": 0.0,
         "cap_usd": cfg.agent_max_review_cost_usd,
@@ -1046,12 +1051,7 @@ def _invoke_reporter_tracked(bedrock, system, user_msg, cost_tracker, pricing):
     out_t = (usage.get("outputTokens") or 0) if usage else 0
     cr_t = (usage.get("cacheReadInputTokens") or 0) if usage else 0
     cw_t = (usage.get("cacheWriteInputTokens") or 0) if usage else 0
-    delta = (
-        (in_t / 1_000_000) * pricing["input_per_million"]
-        + (out_t / 1_000_000) * pricing["output_per_million"]
-        + (cr_t / 1_000_000) * pricing["cache_read_per_million"]
-        + (cw_t / 1_000_000) * pricing["cache_write_per_million"]
-    )
+    delta = agent_loop.estimate_cost_usd(in_t, out_t, cr_t, cw_t, pricing)
     cost_tracker["cost_usd"] = cost_tracker.get("cost_usd", 0.0) + delta
     if cost_tracker["cost_usd"] >= cost_tracker.get("cap_usd", float("inf")):
         cost_tracker["cap_hit"] = True
@@ -1178,7 +1178,13 @@ def _write_artifact_pipeline(*, cfg, action, reason, title, html_url, number,
 
 
 def _truncate_trace(trace, max_chars=100_000):
-    """Cap trace size in the artifact to avoid huge JSON blobs."""
+    """Cap trace size in the artifact to avoid huge JSON blobs.
+
+    On truncation, appends a sentinel entry recording how many entries were
+    dropped. The arithmetic `len(trace) - len(out)` is computed BEFORE
+    `out.append(marker)` (Python evaluates the dict literal first), so it
+    correctly reports entries-not-kept (excluding the sentinel itself).
+    """
     if not trace:
         return []
     serialized = json.dumps(trace)

--- a/src/scripts/issue_bot/main.py
+++ b/src/scripts/issue_bot/main.py
@@ -30,6 +30,17 @@ logger = logging.getLogger("issue_bot")
 ARTIFACT_PATH = os.getenv("ARTIFACT_PATH", "/tmp/bot_result.json")
 _MAX_BOT_REPLIES = 2
 
+# Events surfaced by _run_critic_and_reporter. Critic-stage events tag
+# metrics["critic"]; escalate events drive pipeline-level ESCALATE.
+_CRITIC_STAGE_EVENTS = frozenset({"no_confirmed_findings", "critic_failed"})
+_ESCALATE_EVENTS = frozenset({
+    "critic_failed",
+    "reporter_deadline_exceeded",
+    "reporter_failed",
+    "unknown_pipeline_event",
+})
+_KNOWN_PIPELINE_EVENTS = _CRITIC_STAGE_EVENTS | _ESCALATE_EVENTS
+
 
 def _render(template_str, **kwargs):
     """Render a prompt template safely using unique tokens per invocation.
@@ -858,16 +869,18 @@ def _run_agent_pipeline(*, cfg, gh, bedrock, number, title, body, html_url, item
         + f"\n<diff>\n{diff}\n</diff>\n"
         + f"<existing_feedback>\n{existing_feedback}\n</existing_feedback>\n"
     )
-    investigator_user = (
-        f"<diff>\n{diff}\n</diff>\n<pr>\nTitle: {title}\nBody: {body}\n</pr>"
-    )
+    investigator_diff = _truncate_diff_for_user_prompt(diff, cfg.agent_max_diff_chars)
+    investigator_trusted = f"<diff>\n{investigator_diff}\n</diff>"
+    investigator_untrusted = _format_pr_input(title, body)
 
     tool_runner = ToolRunner(cfg, gh.repo_root)
     pipeline_deadline = time.monotonic() + cfg.pipeline_wall_clock_seconds
 
     inv_result = agent_loop.run(
         bedrock_client=bedrock, agent_name="investigator",
-        system_prompt=investigator_system, user_prompt=investigator_user,
+        system_prompt=investigator_system,
+        user_prompt=investigator_trusted,
+        untrusted_user_prompt=investigator_untrusted,
         tool_specs=TOOL_SPECS, tool_runner=tool_runner,
         caps=investigator_caps,
         pipeline_deadline=pipeline_deadline,
@@ -889,7 +902,7 @@ def _run_agent_pipeline(*, cfg, gh, bedrock, number, title, body, html_url, item
         )
         return
 
-    crit_result, critic_skip_reason, rep_inline_comments, reporter_metrics = (
+    crit_result, pipeline_event, rep_inline_comments, reporter_metrics = (
         _run_critic_and_reporter(
             cfg=cfg, bedrock=bedrock, tool_runner=tool_runner,
             critic_system=critic_system, critic_caps=critic_caps,
@@ -901,15 +914,20 @@ def _run_agent_pipeline(*, cfg, gh, bedrock, number, title, body, html_url, item
     )
     if crit_result is not None:
         metrics["critic"] = _agent_metrics(crit_result)
-    if critic_skip_reason:
-        metrics["critic"]["skip_reason"] = critic_skip_reason
+    # Unknown event = bug in a future change. Escalate with a distinct
+    # reason rather than silently posting a clean review.
+    if pipeline_event is not None and pipeline_event not in _KNOWN_PIPELINE_EVENTS:
+        logger.error("Unknown pipeline_event %r; treating as escalate", pipeline_event)
+        pipeline_event = "unknown_pipeline_event"
+    if pipeline_event in _CRITIC_STAGE_EVENTS:
+        metrics["critic"]["skip_reason"] = pipeline_event
     metrics["reporter"] = reporter_metrics
 
-    # Critic produced no usable text → escalate, do not post a clean review.
-    # Carry the investigator's narrative for triage.
-    if critic_skip_reason == "critic_failed":
+    # Escalate paths preserve the investigator narrative — posting "no issues"
+    # while confirmed findings exist would silently drop them.
+    if pipeline_event in _ESCALATE_EVENTS:
         _write_artifact_pipeline(
-            **artifact_kwargs, action="ESCALATE", reason="critic_failed",
+            **artifact_kwargs, action="ESCALATE", reason=pipeline_event,
             inline_comments=[], response="",
             metrics=_finalize_metrics(metrics, inv_result, crit_result),
             tool_trace=(inv_result.tool_trace + (crit_result.tool_trace if crit_result else [])),
@@ -1027,12 +1045,11 @@ def _run_critic_and_reporter(*, cfg, bedrock, tool_runner, critic_system, critic
                               pipeline_deadline=None):
     """Run the Critic (if any CONFIRMED concerns) and then the Reporter.
 
-    Returns (crit_result_or_None, critic_skip_reason_or_None, inline_comments,
-    reporter_metrics). When the Critic is skipped, crit_result is None,
-    critic_skip_reason explains why, and the Reporter is skipped too.
-
-    pipeline_deadline (optional) is a shared monotonic time budget across
-    all pipeline stages, threaded into the Critic loop.
+    Returns (crit_result_or_None, pipeline_event_or_None, inline_comments,
+    reporter_metrics). pipeline_event values: None (happy path),
+    "no_confirmed_findings" (fast path), "critic_failed",
+    "reporter_deadline_exceeded", "reporter_failed". Caller escalates on
+    any non-happy-path event so confirmed findings aren't silently dropped.
     """
     skipped_metrics = _empty_stage_metrics()
 
@@ -1042,15 +1059,19 @@ def _run_critic_and_reporter(*, cfg, bedrock, tool_runner, critic_system, critic
     # Neutralize close-tags so a model that emits "</investigator_notes>" or
     # "</critic_verdicts>" in its body can't escape the wrapping tag.
     safe_notes = investigator_text.replace("</investigator_notes>", "</investigator_notes_>")
-    critic_diff = _truncate_for_critic(diff, cfg.critic_max_diff_chars)
-    critic_user = (
+    critic_diff = _truncate_diff_for_user_prompt(diff, cfg.agent_max_diff_chars)
+    # Investigator notes are model-origin (trusted); only PR title/body
+    # is user-input and needs guardrail scanning.
+    critic_trusted = (
         f"<investigator_notes>\n{safe_notes}\n</investigator_notes>\n"
-        f"<diff>\n{critic_diff}\n</diff>\n"
-        f"<pr>\nTitle: {title}\nBody: {body}\n</pr>"
+        f"<diff>\n{critic_diff}\n</diff>"
     )
+    critic_untrusted = _format_pr_input(title, body)
     crit_result = agent_loop.run(
         bedrock_client=bedrock, agent_name="critic",
-        system_prompt=critic_system, user_prompt=critic_user,
+        system_prompt=critic_system,
+        user_prompt=critic_trusted,
+        untrusted_user_prompt=critic_untrusted,
         tool_specs=TOOL_SPECS, tool_runner=tool_runner,
         caps=critic_caps,
         pipeline_deadline=pipeline_deadline,
@@ -1066,8 +1087,21 @@ def _run_critic_and_reporter(*, cfg, bedrock, tool_runner, critic_system, critic
         f"<critic_verdicts>\n{safe_verdicts}\n</critic_verdicts>\n\n"
         f"<pr>\nTitle: {title}\nBody: {body}\n</pr>"
     )
+
+    # Bound Reporter on wall-clock: pre-empt if too little budget left,
+    # otherwise cap the per-call timeout at the remaining budget.
+    reporter_timeout = None
+    if pipeline_deadline is not None:
+        remaining = pipeline_deadline - time.monotonic()
+        if remaining < cfg.reporter_min_remaining_seconds:
+            deadline_metrics = _empty_stage_metrics()
+            deadline_metrics["skip_reason"] = "reporter_deadline_exceeded"
+            return crit_result, "reporter_deadline_exceeded", [], deadline_metrics
+        reporter_timeout = max(1, int(remaining))
+
     raw, usage = bedrock.invoke_with_usage(
         reporter_system, reporter_user, max_tokens=8000, json_schema=PR_REVIEW_SCHEMA,
+        timeout_seconds=reporter_timeout,
     )
     reporter_metrics = _empty_stage_metrics()
     reporter_metrics.update({
@@ -1078,24 +1112,32 @@ def _run_critic_and_reporter(*, cfg, bedrock, tool_runner, critic_system, critic
         "cache_read_tokens": (usage.get("cacheReadInputTokens") if usage else 0) or 0,
         "cache_write_tokens": (usage.get("cacheWriteInputTokens") if usage else 0) or 0,
     })
+    # Reporter failure with confirmed findings → escalate, not an empty
+    # post that would drop them.
     if raw is None:
-        return crit_result, None, [], reporter_metrics
+        return crit_result, "reporter_failed", [], reporter_metrics
     inline_comments, parse_ok = _parse_reporter_output(raw)
     if not parse_ok:
         reporter_metrics["parse_failed"] = True
         reporter_metrics["skip_reason"] = "reporter_output_malformed"
+        return crit_result, "reporter_failed", [], reporter_metrics
     return crit_result, None, inline_comments, reporter_metrics
 
 
-def _truncate_for_critic(diff, max_chars):
-    """Cap diff size for the Critic's first turn. Critic uses read_file to
-    fetch full files when needed, so the diff is just a pointer."""
+def _format_pr_input(title, body):
+    """User-supplied portion of an agent's first-turn message. Same shape
+    on Investigator and Critic so the guardrail wraps consistently."""
+    return f"<pr>\nTitle: {title}\nBody: {body}\n</pr>"
+
+
+def _truncate_diff_for_user_prompt(diff, max_chars):
+    """Cap diff size; agents fall back to read_file for full context."""
     if len(diff) <= max_chars:
         return diff
     return (
         diff[:max_chars]
         + f"\n... [diff truncated at {max_chars} chars; "
-        "use read_file to fetch specific files referenced in investigator notes]"
+        "use read_file to fetch specific files referenced in this diff]"
     )
 
 

--- a/src/scripts/issue_bot/main.py
+++ b/src/scripts/issue_bot/main.py
@@ -937,7 +937,7 @@ def _load_pipeline_prompts(cfg, title, html_url, number):
     ESCALATE artifact if any are missing (fail closed)."""
     investigator = prompts.get_pr_investigator_prompt()
     critic = prompts.get_pr_critic_prompt()
-    reporter = prompts.get_pr_file_review_report_prompt()
+    reporter = prompts.get_pr_reporter_prompt()
     missing = [name for name, val in (
         ("investigator", investigator),
         ("critic", critic),

--- a/src/scripts/issue_bot/main.py
+++ b/src/scripts/issue_bot/main.py
@@ -283,33 +283,11 @@ def analyze():
                          type(e).__name__, (raw or "")[:500])
             inline_comments = []
 
-        # Hard filter: drop comments without a usable file path or positive line number
-        inline_comments = [
-            c for c in inline_comments
-            if c.get("file") and isinstance(c.get("line"), int) and c["line"] > 0
-        ]
-
-        # Hard filter: on incremental review, drop comments on files not in the incremental diff
-        if incremental_files and inline_comments:
-            inline_comments = [
-                c for c in inline_comments
-                if c.get("file", "") in incremental_files
-            ]
-
-        # Hard filter: drop NITs on re-reviews (code-enforced, not prompt-dependent)
-        if is_pr_update and inline_comments:
-            inline_comments = [
-                c for c in inline_comments
-                if c.get("severity", "").upper() != "NIT"
-            ]
-
-        # Format comments: prepend severity, append evidence as context
-        for c in inline_comments:
-            severity = c.get("severity", "")
-            evidence = c.get("evidence", "")
-            prefix = f"**{severity}**: " if severity else ""
-            suffix = "\n\n> " + evidence.replace("\n", "\n> ") if evidence else ""
-            c["comment"] = prefix + c.get("comment", "") + suffix
+        inline_comments = _filter_and_format_inline_comments(
+            inline_comments,
+            incremental_files=incremental_files,
+            is_pr_update=is_pr_update,
+        )
 
         # Check CI status to give accurate signal to human reviewers
         ci_passed, ci_summary = gh.get_ci_status(head_sha) if head_sha else (None, "")
@@ -804,68 +782,183 @@ def _has_confirmed_findings(notes):
     return _STATUS_CONFIRMED_RE.search(notes) is not None
 
 
+def _filter_and_format_inline_comments(comments, *, incremental_files, is_pr_update):
+    """Apply the standard post-Reporter hardening to inline comments:
+      - drop entries without a usable file path or positive line number
+      - on incremental re-review, restrict to files in the incremental diff
+      - on re-review, drop NIT severity (the author already saw them once)
+      - prepend severity bold, append evidence as a blockquote
+
+    Mutates and returns the kept list.
+    """
+    kept = [
+        c for c in comments
+        if c.get("file") and isinstance(c.get("line"), int) and c["line"] > 0
+    ]
+    if incremental_files and kept:
+        kept = [c for c in kept if c.get("file", "") in incremental_files]
+    if is_pr_update and kept:
+        kept = [c for c in kept if c.get("severity", "").upper() != "NIT"]
+    for c in kept:
+        severity = c.get("severity", "")
+        evidence = c.get("evidence", "")
+        prefix = f"**{severity}**: " if severity else ""
+        suffix = "\n\n> " + evidence.replace("\n", "\n> ") if evidence else ""
+        c["comment"] = prefix + c.get("comment", "") + suffix
+    return kept
+
+
 def _run_agent_pipeline(*, cfg, gh, bedrock, number, title, body, html_url, item,
                         context, codebase_map, comments_data, is_pr_update):
     """Investigator + Critic + Reporter pipeline. Replaces the legacy two-phase
     flow when cfg.agent_pipeline is True. Writes the analyze artifact and returns.
     """
-    investigator_tmpl = prompts.get_pr_investigator_prompt()
-    critic_tmpl = prompts.get_pr_critic_prompt()
-    reporter_tmpl = prompts.get_pr_file_review_report_prompt()
-    missing = []
-    if not investigator_tmpl:
-        missing.append("investigator")
-    if not critic_tmpl:
-        missing.append("critic")
-    if not reporter_tmpl:
-        missing.append("reporter")
-    if missing:
-        logger.error(
-            "Pipeline enabled but required prompt(s) missing: %s. Failing closed "
-            "(escalating). Set the corresponding SM_* env var or PR_*_PROMPT.",
-            ", ".join(missing),
-        )
-        _write_artifact({
-            "action": "ESCALATE", "labels": [], "response": "",
-            "reason": f"prompt_load_failed: {','.join(missing)}",
-            "title": title, "html_url": html_url, "number": number, "is_pr": True,
-            "prompt_id": "n/a", "model_id": cfg.bedrock_model_id,
-        })
+    prompts_or_none = _load_pipeline_prompts(cfg, title, html_url, number)
+    if prompts_or_none is None:
         return
+    investigator_tmpl, critic_tmpl, reporter_tmpl = prompts_or_none
 
     diff = gh.get_pr_diff(number)
     review_comments = gh.get_pr_review_comments(number)
     existing_feedback = _format_pr_feedback(comments_data, review_comments)
-
-    incremental_diff = ""
-    incremental_files = set()
-    if is_pr_update and cfg.event_before and cfg.event_after:
-        incremental_diff = gh.get_compare_diff(cfg.event_before, cfg.event_after)
-        if incremental_diff:
-            incremental_files = _extract_diff_files(incremental_diff)
-
     head_sha = cfg.event_after or item.get("head", {}).get("sha", "")
     pr_files = gh.get_pr_files(number)
-    diff_lines = sum(int(pf.get("changes", 0) or 0) for pf in pr_files)
+    incremental_diff, incremental_files = _maybe_compute_incremental(
+        gh, cfg, is_pr_update,
+    )
 
-    # Adaptive caps (PR-size proportional within configured upper bounds).
-    # Floor is min(5, ceiling) so users can throttle below the default floor by
-    # setting BOT_INVESTIGATOR_MAX_TURNS=3 etc.
+    investigator_caps, critic_caps = _build_caps(cfg, pr_files)
+    today = datetime.date.today().isoformat()
+    static_context = _build_static_context(
+        context, codebase_map, existing_feedback, incremental_diff,
+    )
+    investigator_system = _render(investigator_tmpl, current_date=today) + static_context
+    critic_system = _render(critic_tmpl, current_date=today) + static_context
+    reporter_system = (
+        _render(reporter_tmpl, current_date=today)
+        + f"\n<diff>\n{diff}\n</diff>\n"
+        + f"<existing_feedback>\n{existing_feedback}\n</existing_feedback>\n"
+    )
+    investigator_user = (
+        f"<diff>\n{diff}\n</diff>\n<pr>\nTitle: {title}\nBody: {body}\n</pr>"
+    )
+
+    tool_runner = ToolRunner(cfg, gh.repo_root)
+
+    inv_result = agent_loop.run(
+        bedrock_client=bedrock, agent_name="investigator",
+        system_prompt=investigator_system, user_prompt=investigator_user,
+        tool_specs=TOOL_SPECS, tool_runner=tool_runner,
+        caps=investigator_caps,
+    )
+
+    metrics = _initial_metrics(inv_result)
+    artifact_kwargs = dict(
+        cfg=cfg, title=title, html_url=html_url, number=number,
+        inv_tmpl=investigator_tmpl, critic_tmpl=critic_tmpl, reporter_tmpl=reporter_tmpl,
+        is_incremental=bool(incremental_diff),
+    )
+
+    if not inv_result.text:
+        _write_artifact_pipeline(
+            **artifact_kwargs, action="ESCALATE", reason="investigator_empty",
+            inline_comments=[], response="",
+            metrics=_finalize_metrics(metrics, inv_result, None),
+            tool_trace=inv_result.tool_trace,
+        )
+        return
+
+    crit_result, critic_skip_reason, rep_inline_comments, reporter_metrics = (
+        _run_critic_and_reporter(
+            cfg=cfg, bedrock=bedrock, tool_runner=tool_runner,
+            critic_system=critic_system, critic_caps=critic_caps,
+            reporter_system=reporter_system,
+            diff=diff, title=title, body=body,
+            investigator_text=inv_result.text,
+        )
+    )
+    if crit_result is not None:
+        metrics["critic"] = _agent_metrics(crit_result)
+    else:
+        metrics["critic"]["skip_reason"] = critic_skip_reason
+    metrics["reporter"] = reporter_metrics
+
+    rep_inline_comments = _filter_and_format_inline_comments(
+        rep_inline_comments,
+        incremental_files=incremental_files,
+        is_pr_update=is_pr_update,
+    )
+    response = _build_clean_response(gh, head_sha, rep_inline_comments)
+
+    _write_artifact_pipeline(
+        **artifact_kwargs, action="RESPOND", reason=None,
+        inline_comments=rep_inline_comments, response=response,
+        metrics=_finalize_metrics(metrics, inv_result, crit_result),
+        tool_trace=(inv_result.tool_trace + (crit_result.tool_trace if crit_result else [])),
+    )
+
+
+def _load_pipeline_prompts(cfg, title, html_url, number):
+    """Load the three prompts. Returns the tuple, or None after writing an
+    ESCALATE artifact if any are missing (fail closed)."""
+    investigator = prompts.get_pr_investigator_prompt()
+    critic = prompts.get_pr_critic_prompt()
+    reporter = prompts.get_pr_file_review_report_prompt()
+    missing = [name for name, val in (
+        ("investigator", investigator),
+        ("critic", critic),
+        ("reporter", reporter),
+    ) if not val]
+    if not missing:
+        return investigator, critic, reporter
+    logger.error(
+        "Pipeline enabled but required prompt(s) missing: %s. Failing closed.",
+        ", ".join(missing),
+    )
+    _write_artifact({
+        "action": "ESCALATE", "labels": [], "response": "",
+        "reason": f"prompt_load_failed: {','.join(missing)}",
+        "title": title, "html_url": html_url, "number": number, "is_pr": True,
+        "prompt_id": "n/a", "model_id": cfg.bedrock_model_id,
+    })
+    return None
+
+
+def _maybe_compute_incremental(gh, cfg, is_pr_update):
+    """Return (incremental_diff, incremental_files) or ("", set()) when N/A."""
+    if not (is_pr_update and cfg.event_before and cfg.event_after):
+        return "", set()
+    diff = gh.get_compare_diff(cfg.event_before, cfg.event_after)
+    files = _extract_diff_files(diff) if diff else set()
+    return diff, files
+
+
+def _build_caps(cfg, pr_files):
+    """Return (investigator_caps, critic_caps), sized to PR length within
+    user-configured ceilings. The Investigator floor is min(5, ceiling) and the
+    Critic floor is min(3, ceiling) so a user lowering the ceiling below the
+    default floor is still respected."""
+    diff_lines = sum(int(pf.get("changes", 0) or 0) for pf in pr_files)
     inv_ceiling = max(1, cfg.investigator_max_turns)
     inv_floor = min(5, inv_ceiling)
-    investigator_caps = agent_loop.AgentCaps(
+    investigator = agent_loop.AgentCaps(
         max_turns=_clamp(diff_lines // 30, inv_floor, inv_ceiling),
         max_tool_calls=cfg.investigator_max_tool_calls,
         max_tool_output_chars=cfg.investigator_max_tool_output_chars,
     )
     crit_ceiling = max(1, cfg.critic_max_turns)
     crit_floor = min(3, crit_ceiling)
-    critic_caps = agent_loop.AgentCaps(
-        max_turns=_clamp(investigator_caps.max_turns // 2, crit_floor, crit_ceiling),
+    critic = agent_loop.AgentCaps(
+        max_turns=_clamp(investigator.max_turns // 2, crit_floor, crit_ceiling),
         max_tool_calls=cfg.critic_max_tool_calls,
         max_tool_output_chars=cfg.critic_max_tool_output_chars,
     )
+    return investigator, critic
 
+
+def _build_static_context(kb_context, codebase_map, existing_feedback, incremental_diff):
+    """Assemble the system-prompt suffix shared between Investigator and Critic.
+    Same prefix → cache hit on Critic's first turn."""
     incremental_section = ""
     if incremental_diff:
         incremental_section = (
@@ -876,186 +969,93 @@ def _run_agent_pipeline(*, cfg, gh, bedrock, number, title, body, html_url, item
             "</incremental_review_instructions>\n"
             f"<incremental_diff>\n{incremental_diff}\n</incremental_diff>\n"
         )
-
-    # Static priming context (reused across Investigator and Critic for cache hit).
-    static_context = (
-        f"\n<knowledge_base>\n{context}\n</knowledge_base>\n"
+    return (
+        f"\n<knowledge_base>\n{kb_context}\n</knowledge_base>\n"
         f"<codebase_map>\n{codebase_map}\n</codebase_map>\n"
         f"<existing_feedback>\n{existing_feedback}\n</existing_feedback>\n"
         f"{incremental_section}"
     )
 
-    investigator_system = _render(
-        investigator_tmpl, current_date=datetime.date.today().isoformat()
-    ) + static_context
-    critic_system = _render(
-        critic_tmpl, current_date=datetime.date.today().isoformat()
-    ) + static_context
-    reporter_system = (
-        _render(reporter_tmpl, current_date=datetime.date.today().isoformat())
-        + f"\n<diff>\n{diff}\n</diff>\n"
-        + f"<existing_feedback>\n{existing_feedback}\n</existing_feedback>\n"
-    )
 
-    investigator_user = (
-        f"<diff>\n{diff}\n</diff>\n"
-        f"<pr>\nTitle: {title}\nBody: {body}\n</pr>"
-    )
-
-    tool_runner = ToolRunner(cfg, gh.repo_root)
-    cost_tracker = {
-        "cost_usd": 0.0,
-        "cap_usd": cfg.agent_max_review_cost_usd,
-        "cap_hit": False,
-    }
-    pricing = cfg.bedrock_pricing
-
-    inv_result = agent_loop.run(
-        bedrock_client=bedrock, agent_name="investigator",
-        system_prompt=investigator_system, user_prompt=investigator_user,
-        tool_specs=TOOL_SPECS, tool_runner=tool_runner,
-        caps=investigator_caps, cost_tracker=cost_tracker, pricing=pricing,
-    )
-
-    metrics = {
+def _initial_metrics(inv_result):
+    return {
         "investigator": _agent_metrics(inv_result),
         "critic": {"skipped": True, "skip_reason": None},
         "reporter": {"input_tokens": 0, "output_tokens": 0, "skipped": True},
         "totals": {},
-        "cost_cap_hit": cost_tracker["cap_hit"],
         "max_turns_reached": inv_result.max_turns_reached,
         "critic_overturn_rate": None,
     }
 
-    if not inv_result.text:
-        _write_artifact_pipeline(
-            cfg=cfg, action="ESCALATE", reason="investigator_empty",
-            title=title, html_url=html_url, number=number,
-            inv_tmpl=investigator_tmpl, critic_tmpl=critic_tmpl, reporter_tmpl=reporter_tmpl,
-            inline_comments=[], response="", is_incremental=bool(incremental_diff),
-            metrics=_finalize_metrics(metrics, inv_result, None, None, cost_tracker),
-            tool_trace=inv_result.tool_trace,
-        )
-        return
 
-    confirmed_present = _has_confirmed_findings(inv_result.text)
+def _run_critic_and_reporter(*, cfg, bedrock, tool_runner, critic_system, critic_caps,
+                              reporter_system, diff, title, body, investigator_text):
+    """Run the Critic (if any CONFIRMED concerns) and then the Reporter.
 
-    crit_result = None
-    rep_inline_comments = []
-    rep_input_tokens = 0
-    rep_output_tokens = 0
+    Returns (crit_result_or_None, critic_skip_reason_or_None, inline_comments,
+    reporter_metrics). When the Critic is skipped, crit_result is None,
+    critic_skip_reason explains why, and the Reporter is skipped too.
+    """
+    skipped_metrics = {"input_tokens": 0, "output_tokens": 0, "skipped": True, "skip_reason": None}
 
-    if not confirmed_present:
-        # FAST PATH: no confirmed findings → skip Critic and Reporter
-        metrics["critic"]["skip_reason"] = "no_confirmed_findings"
-        metrics["reporter"]["skipped"] = True
-    elif cost_tracker["cap_hit"]:
-        metrics["critic"]["skip_reason"] = "cost_cap_hit_after_investigator"
-        metrics["reporter"]["skipped"] = True
-    else:
-        # Cap Critic's first-turn input. Investigator notes are bounded by
-        # max_tokens_per_call; the diff is unbounded and dominates large PRs.
-        # Truncate the diff so combined input stays well under Bedrock's 200K
-        # token window. Critic can fetch full files via read_file as needed.
-        max_critic_diff_chars = 200_000
-        critic_diff = diff
-        if len(critic_diff) > max_critic_diff_chars:
-            critic_diff = (
-                critic_diff[:max_critic_diff_chars]
-                + f"\n... [diff truncated at {max_critic_diff_chars} chars; "
-                "use read_file to fetch specific files referenced in investigator notes]"
-            )
-        critic_user = (
-            f"<investigator_notes>\n{inv_result.text}\n</investigator_notes>\n"
-            f"<diff>\n{critic_diff}\n</diff>\n"
-            f"<pr>\nTitle: {title}\nBody: {body}\n</pr>"
-        )
-        crit_result = agent_loop.run(
-            bedrock_client=bedrock, agent_name="critic",
-            system_prompt=critic_system, user_prompt=critic_user,
-            tool_specs=TOOL_SPECS, tool_runner=tool_runner,
-            caps=critic_caps, cost_tracker=cost_tracker, pricing=pricing,
-        )
-        metrics["critic"] = _agent_metrics(crit_result)
+    if not _has_confirmed_findings(investigator_text):
+        return None, "no_confirmed_findings", [], skipped_metrics
 
-        if cost_tracker["cap_hit"]:
-            metrics["reporter"]["skipped"] = True
-            metrics["reporter"]["skip_reason"] = "cost_cap_hit_after_critic"
-        else:
-            reporter_user = (
-                f"<investigator_notes>\n{inv_result.text}\n</investigator_notes>\n\n"
-                f"<critic_verdicts>\n{crit_result.text or 'ALL_DISPROVED: critic produced no verdicts'}\n</critic_verdicts>\n\n"
-                f"<pr>\nTitle: {title}\nBody: {body}\n</pr>"
-            )
-            raw, rep_input_tokens, rep_output_tokens = _invoke_reporter_tracked(
-                bedrock, reporter_system, reporter_user, cost_tracker, pricing,
-            )
-            metrics["reporter"]["skipped"] = False
-            metrics["reporter"]["input_tokens"] = rep_input_tokens
-            metrics["reporter"]["output_tokens"] = rep_output_tokens
-            if raw is None:
-                metrics["reporter"]["skip_reason"] = "bedrock_unavailable"
-            else:
-                rep_inline_comments = _parse_reporter_output(raw)
-
-    # Apply post-processing filters (same as legacy path)
-    rep_inline_comments = [
-        c for c in rep_inline_comments
-        if c.get("file") and isinstance(c.get("line"), int) and c["line"] > 0
-    ]
-    if incremental_files and rep_inline_comments:
-        rep_inline_comments = [
-            c for c in rep_inline_comments if c.get("file", "") in incremental_files
-        ]
-    if is_pr_update and rep_inline_comments:
-        rep_inline_comments = [
-            c for c in rep_inline_comments
-            if c.get("severity", "").upper() != "NIT"
-        ]
-    for c in rep_inline_comments:
-        severity = c.get("severity", "")
-        evidence = c.get("evidence", "")
-        prefix = f"**{severity}**: " if severity else ""
-        suffix = "\n\n> " + evidence.replace("\n", "\n> ") if evidence else ""
-        c["comment"] = prefix + c.get("comment", "") + suffix
-
-    ci_passed, ci_summary = gh.get_ci_status(head_sha) if head_sha else (None, "")
-    if not rep_inline_comments:
-        if ci_passed is True:
-            response = "No issues found. CI is passing.\n<!-- deequ-bot:clean -->"
-        elif ci_passed is False:
-            response = f"No code issues found, but {ci_summary}."
-        else:
-            response = "No issues found.\n<!-- deequ-bot:clean -->"
-    else:
-        response = ""
-
-    _write_artifact_pipeline(
-        cfg=cfg, action="RESPOND", reason=None,
-        title=title, html_url=html_url, number=number,
-        inv_tmpl=investigator_tmpl, critic_tmpl=critic_tmpl, reporter_tmpl=reporter_tmpl,
-        inline_comments=rep_inline_comments, response=response,
-        is_incremental=bool(incremental_diff),
-        metrics=_finalize_metrics(metrics, inv_result, crit_result, None, cost_tracker),
-        tool_trace=(inv_result.tool_trace + (crit_result.tool_trace if crit_result else [])),
+    critic_diff = _truncate_for_critic(diff, cfg.critic_max_diff_chars)
+    critic_user = (
+        f"<investigator_notes>\n{investigator_text}\n</investigator_notes>\n"
+        f"<diff>\n{critic_diff}\n</diff>\n"
+        f"<pr>\nTitle: {title}\nBody: {body}\n</pr>"
+    )
+    crit_result = agent_loop.run(
+        bedrock_client=bedrock, agent_name="critic",
+        system_prompt=critic_system, user_prompt=critic_user,
+        tool_specs=TOOL_SPECS, tool_runner=tool_runner,
+        caps=critic_caps,
     )
 
-
-def _invoke_reporter_tracked(bedrock, system, user_msg, cost_tracker, pricing):
-    """Invoke Reporter (single-shot, schema-enforced) while updating cost_tracker.
-    Returns (raw_text, input_tokens, output_tokens). On failure: (None, 0, 0)."""
+    reporter_user = (
+        f"<investigator_notes>\n{investigator_text}\n</investigator_notes>\n\n"
+        f"<critic_verdicts>\n"
+        f"{crit_result.text or 'ALL_DISPROVED: critic produced no verdicts'}"
+        f"\n</critic_verdicts>\n\n"
+        f"<pr>\nTitle: {title}\nBody: {body}\n</pr>"
+    )
     raw, usage = bedrock.invoke_with_usage(
-        system, user_msg, max_tokens=8000, json_schema=PR_REVIEW_SCHEMA,
+        reporter_system, reporter_user, max_tokens=8000, json_schema=PR_REVIEW_SCHEMA,
     )
-    in_t = (usage.get("inputTokens") or 0) if usage else 0
-    out_t = (usage.get("outputTokens") or 0) if usage else 0
-    cr_t = (usage.get("cacheReadInputTokens") or 0) if usage else 0
-    cw_t = (usage.get("cacheWriteInputTokens") or 0) if usage else 0
-    delta = agent_loop.estimate_cost_usd(in_t, out_t, cr_t, cw_t, pricing)
-    cost_tracker["cost_usd"] = cost_tracker.get("cost_usd", 0.0) + delta
-    if cost_tracker["cost_usd"] >= cost_tracker.get("cap_usd", float("inf")):
-        cost_tracker["cap_hit"] = True
-    return raw, in_t, out_t
+    reporter_metrics = {
+        "skipped": False,
+        "skip_reason": None if raw is not None else "bedrock_unavailable",
+        "input_tokens": (usage.get("inputTokens") if usage else 0) or 0,
+        "output_tokens": (usage.get("outputTokens") if usage else 0) or 0,
+    }
+    inline_comments = _parse_reporter_output(raw) if raw is not None else []
+    return crit_result, None, inline_comments, reporter_metrics
+
+
+def _truncate_for_critic(diff, max_chars):
+    """Cap diff size for the Critic's first turn. Critic uses read_file to
+    fetch full files when needed, so the diff is just a pointer."""
+    if len(diff) <= max_chars:
+        return diff
+    return (
+        diff[:max_chars]
+        + f"\n... [diff truncated at {max_chars} chars; "
+        "use read_file to fetch specific files referenced in investigator notes]"
+    )
+
+
+def _build_clean_response(gh, head_sha, inline_comments):
+    """Compose the top-level review body when no inline comments were emitted."""
+    if inline_comments:
+        return ""
+    ci_passed, ci_summary = gh.get_ci_status(head_sha) if head_sha else (None, "")
+    if ci_passed is True:
+        return "No issues found. CI is passing.\n<!-- deequ-bot:clean -->"
+    if ci_passed is False:
+        return f"No code issues found, but {ci_summary}."
+    return "No issues found.\n<!-- deequ-bot:clean -->"
 
 
 def _agent_metrics(r):
@@ -1074,17 +1074,16 @@ def _agent_metrics(r):
     }
 
 
-def _finalize_metrics(metrics, inv, crit, _rep, cost_tracker):
-    overturn = _critic_overturn_rate(crit.text if (crit and crit.text) else "")
-    metrics["critic_overturn_rate"] = overturn
+def _finalize_metrics(metrics, inv, crit):
+    metrics["critic_overturn_rate"] = _critic_overturn_rate(
+        crit.text if (crit and crit.text) else ""
+    )
     rep_in = metrics.get("reporter", {}).get("input_tokens", 0) or 0
     rep_out = metrics.get("reporter", {}).get("output_tokens", 0) or 0
     metrics["totals"] = {
         "input_tokens": (inv.input_tokens if inv else 0) + (crit.input_tokens if crit else 0) + rep_in,
         "output_tokens": (inv.output_tokens if inv else 0) + (crit.output_tokens if crit else 0) + rep_out,
-        "cost_usd": round(cost_tracker.get("cost_usd", 0.0), 4),
     }
-    metrics["cost_cap_hit"] = cost_tracker.get("cap_hit", False)
     return metrics
 
 

--- a/src/scripts/issue_bot/main.py
+++ b/src/scripts/issue_bot/main.py
@@ -9,6 +9,7 @@ import datetime
 import json
 import logging
 import os
+import posixpath
 import re
 import sys
 import time
@@ -736,13 +737,12 @@ def _extract_diff_files(diff_text):
 
 
 def _canonicalize_path(path):
-    """Normalize a repo-relative path: strip leading './', collapse '//',
-    fold redundant '.' segments. Always uses POSIX separators."""
+    """Normalize a repo-relative path so the diff-extracted set and the
+    Reporter's emitted path compare equal. Returns "" for falsy input."""
     if not isinstance(path, str) or not path:
         return ""
-    path = path.replace("\\", "/")
-    parts = [p for p in path.split("/") if p not in ("", ".")]
-    return "/".join(parts)
+    p = posixpath.normpath(path.replace("\\", "/"))
+    return "" if p == "." else p
 
 
 def _read_requested_files(gh, file_paths, cfg):
@@ -796,19 +796,12 @@ def _has_confirmed_findings(notes):
 
 
 def _filter_and_format_inline_comments(comments, *, incremental_files, is_pr_update):
-    """Apply the standard post-Reporter hardening to inline comments:
-      - drop entries without a usable file path or positive line number
-      - on incremental re-review, restrict to files in the incremental diff
-        (paths canonicalized on both sides for reliable comparison)
-      - on re-review, drop NIT severity (the author already saw them once)
-      - prepend severity bold, append evidence as a blockquote
+    """Filter and decorate inline comments before they reach GitHub.
 
-    Mutates and returns the kept list.
-    """
-    # Canonicalize file paths once up front so the incremental-files filter
-    # and the eventual GitHub POST agree on the spelling. Without this, a
-    # model emitting "./src/foo.py" would pass the filter (we canonicalize
-    # there) but reach post_pr_review with the raw path and 422.
+    Drops entries without a positive line number; restricts to files in the
+    incremental diff on re-review; drops NIT severity on re-review (the
+    author saw them on the first pass); prepends severity, appends evidence
+    as a blockquote. Returns the kept list (does not mutate the input)."""
     kept = []
     for c in comments:
         if not (c.get("file") and isinstance(c.get("line"), int) and c["line"] > 0):
@@ -912,9 +905,8 @@ def _run_agent_pipeline(*, cfg, gh, bedrock, number, title, body, html_url, item
         metrics["critic"]["skip_reason"] = critic_skip_reason
     metrics["reporter"] = reporter_metrics
 
-    # If the Critic crashed mid-run, do not post anything as clean — escalate.
-    # Preserve the Investigator's narrative so an operator triaging the
-    # escalation can see what was suspected.
+    # Critic produced no usable text → escalate, do not post a clean review.
+    # Carry the investigator's narrative for triage.
     if critic_skip_reason == "critic_failed":
         _write_artifact_pipeline(
             **artifact_kwargs, action="ESCALATE", reason="critic_failed",
@@ -987,7 +979,6 @@ def _build_caps(cfg, pr_files):
         max_turns=_clamp(diff_lines // 30, inv_floor, inv_ceiling),
         max_tool_calls=cfg.investigator_max_tool_calls,
         max_tool_output_chars=cfg.investigator_max_tool_output_chars,
-        wall_clock_seconds=cfg.investigator_wall_clock_seconds,
     )
     crit_ceiling = max(1, cfg.critic_max_turns)
     crit_floor = min(3, crit_ceiling)
@@ -995,7 +986,6 @@ def _build_caps(cfg, pr_files):
         max_turns=_clamp(investigator.max_turns // 2, crit_floor, crit_ceiling),
         max_tool_calls=cfg.critic_max_tool_calls,
         max_tool_output_chars=cfg.critic_max_tool_output_chars,
-        wall_clock_seconds=cfg.critic_wall_clock_seconds,
     )
     return investigator, critic
 
@@ -1049,11 +1039,10 @@ def _run_critic_and_reporter(*, cfg, bedrock, tool_runner, critic_system, critic
     if not _has_confirmed_findings(investigator_text):
         return None, "no_confirmed_findings", [], skipped_metrics
 
-    critic_diff = _truncate_for_critic(diff, cfg.critic_max_diff_chars)
-    # Guard against an Investigator that emits literal </investigator_notes>:
-    # neutralize close-tag occurrences in the body so the Critic can't be
-    # tricked into reading a follow-on injection as a top-level instruction.
+    # Neutralize close-tags so a model that emits "</investigator_notes>" or
+    # "</critic_verdicts>" in its body can't escape the wrapping tag.
     safe_notes = investigator_text.replace("</investigator_notes>", "</investigator_notes_>")
+    critic_diff = _truncate_for_critic(diff, cfg.critic_max_diff_chars)
     critic_user = (
         f"<investigator_notes>\n{safe_notes}\n</investigator_notes>\n"
         f"<diff>\n{critic_diff}\n</diff>\n"
@@ -1067,17 +1056,10 @@ def _run_critic_and_reporter(*, cfg, bedrock, tool_runner, critic_system, critic
         pipeline_deadline=pipeline_deadline,
     )
 
-    # Distinguish fatal Critic failures (no usable output: Bedrock error,
-    # empty response, protocol violation) from bounded-completion exits
-    # (max_turns, structural cap, wall-clock) which may have produced valid
-    # partial verdicts. Only fatal failures escalate; bounded exits flow
-    # through to the Reporter, which applies its own UPHELD filter.
-    if crit_result.fatal or not crit_result.text:
-        skipped_metrics = _empty_stage_metrics()
+    if not crit_result.text:
         skipped_metrics["skip_reason"] = "critic_failed"
         return crit_result, "critic_failed", [], skipped_metrics
 
-    safe_notes = investigator_text.replace("</investigator_notes>", "</investigator_notes_>")
     safe_verdicts = crit_result.text.replace("</critic_verdicts>", "</critic_verdicts_>")
     reporter_user = (
         f"<investigator_notes>\n{safe_notes}\n</investigator_notes>\n\n"
@@ -1185,11 +1167,9 @@ _VERDICT_RE = re.compile(
 
 
 def _critic_overturn_rate(critic_text):
-    """Compute overturn rate by parsing VERDICT lines anchored at line start.
-
-    Avoids substring false-positives where 'UPHELD' or 'OVERTURNED' appears
-    in rationale text. Returns None if no verdicts parsed.
-    """
+    """Fraction of OVERTURNED verdicts among VERDICT lines, or None if there
+    are no parseable verdicts. Anchored regex prevents substring matches in
+    rationale text from skewing the count."""
     if not critic_text:
         return None
     upheld = 0
@@ -1246,12 +1226,8 @@ def _write_artifact_pipeline(*, cfg, action, reason, title, html_url, number,
                               inv_tmpl, critic_tmpl, reporter_tmpl,
                               inline_comments, response, is_incremental,
                               metrics, tool_trace, investigator_summary=None):
-    """Artifact writer for pipeline runs. Includes metrics and trace.
-
-    investigator_summary (optional) preserves the Investigator's narrative on
-    ESCALATE artifacts so an operator can see what was suspected when the
-    Critic or Reporter failed and the findings never reached the PR.
-    """
+    """Write the analyze artifact for a pipeline run, including per-stage
+    metrics, tool trace, and (on escalate) the investigator's narrative."""
     artifact = {
         "action": action,
         "labels": [],
@@ -1278,13 +1254,8 @@ def _write_artifact_pipeline(*, cfg, action, reason, title, html_url, number,
 
 
 def _truncate_trace(trace, max_chars=100_000):
-    """Cap trace size in the artifact to avoid huge JSON blobs.
-
-    On truncation, appends a sentinel entry recording how many entries were
-    dropped. The arithmetic `len(trace) - len(out)` is computed BEFORE
-    `out.append(marker)` (Python evaluates the dict literal first), so it
-    correctly reports entries-not-kept (excluding the sentinel itself).
-    """
+    """Cap trace size in the artifact and append a sentinel describing how
+    many entries were dropped."""
     if not trace:
         return []
     serialized = json.dumps(trace)

--- a/src/scripts/issue_bot/main.py
+++ b/src/scripts/issue_bot/main.py
@@ -723,13 +723,25 @@ def _format_pr_feedback(issue_comments, review_comments):
 
 
 def _extract_diff_files(diff_text):
-    """Extract the set of file paths touched in a unified diff."""
+    """Extract the set of file paths touched in a unified diff. Paths are
+    normalized via posixpath.normpath so they compare equal to Reporter
+    output (which the model derives from the same diff text)."""
     files = set()
     for line in diff_text.split("\n"):
         m = re.match(r'^diff --git a/.+ b/(.+)$', line)
         if m:
-            files.add(m.group(1))
+            files.add(_canonicalize_path(m.group(1)))
     return files
+
+
+def _canonicalize_path(path):
+    """Normalize a repo-relative path: strip leading './', collapse '//',
+    fold redundant '.' segments. Always uses POSIX separators."""
+    if not isinstance(path, str) or not path:
+        return ""
+    path = path.replace("\\", "/")
+    parts = [p for p in path.split("/") if p not in ("", ".")]
+    return "/".join(parts)
 
 
 def _read_requested_files(gh, file_paths, cfg):
@@ -786,25 +798,28 @@ def _filter_and_format_inline_comments(comments, *, incremental_files, is_pr_upd
     """Apply the standard post-Reporter hardening to inline comments:
       - drop entries without a usable file path or positive line number
       - on incremental re-review, restrict to files in the incremental diff
+        (paths canonicalized on both sides for reliable comparison)
       - on re-review, drop NIT severity (the author already saw them once)
       - prepend severity bold, append evidence as a blockquote
 
     Mutates and returns the kept list.
     """
     kept = [
-        c for c in comments
+        dict(c) for c in comments
         if c.get("file") and isinstance(c.get("line"), int) and c["line"] > 0
     ]
     if incremental_files and kept:
-        kept = [c for c in kept if c.get("file", "") in incremental_files]
+        kept = [c for c in kept if _canonicalize_path(c.get("file", "")) in incremental_files]
     if is_pr_update and kept:
         kept = [c for c in kept if c.get("severity", "").upper() != "NIT"]
     for c in kept:
         severity = c.get("severity", "")
         evidence = c.get("evidence", "")
+        raw_comment = c.get("comment", "")
+        c["comment_raw"] = raw_comment
         prefix = f"**{severity}**: " if severity else ""
         suffix = "\n\n> " + evidence.replace("\n", "\n> ") if evidence else ""
-        c["comment"] = prefix + c.get("comment", "") + suffix
+        c["comment"] = prefix + raw_comment + suffix
     return kept
 
 
@@ -879,9 +894,19 @@ def _run_agent_pipeline(*, cfg, gh, bedrock, number, title, body, html_url, item
     )
     if crit_result is not None:
         metrics["critic"] = _agent_metrics(crit_result)
-    else:
+    if critic_skip_reason:
         metrics["critic"]["skip_reason"] = critic_skip_reason
     metrics["reporter"] = reporter_metrics
+
+    # If the Critic crashed mid-run, do not post anything as clean — escalate.
+    if critic_skip_reason == "critic_failed":
+        _write_artifact_pipeline(
+            **artifact_kwargs, action="ESCALATE", reason="critic_failed",
+            inline_comments=[], response="",
+            metrics=_finalize_metrics(metrics, inv_result, crit_result),
+            tool_trace=(inv_result.tool_trace + (crit_result.tool_trace if crit_result else [])),
+        )
+        return
 
     rep_inline_comments = _filter_and_format_inline_comments(
         rep_inline_comments,
@@ -945,6 +970,7 @@ def _build_caps(cfg, pr_files):
         max_turns=_clamp(diff_lines // 30, inv_floor, inv_ceiling),
         max_tool_calls=cfg.investigator_max_tool_calls,
         max_tool_output_chars=cfg.investigator_max_tool_output_chars,
+        wall_clock_seconds=cfg.investigator_wall_clock_seconds,
     )
     crit_ceiling = max(1, cfg.critic_max_turns)
     crit_floor = min(3, crit_ceiling)
@@ -952,6 +978,7 @@ def _build_caps(cfg, pr_files):
         max_turns=_clamp(investigator.max_turns // 2, crit_floor, crit_ceiling),
         max_tool_calls=cfg.critic_max_tool_calls,
         max_tool_output_chars=cfg.critic_max_tool_output_chars,
+        wall_clock_seconds=cfg.critic_wall_clock_seconds,
     )
     return investigator, critic
 
@@ -980,8 +1007,8 @@ def _build_static_context(kb_context, codebase_map, existing_feedback, increment
 def _initial_metrics(inv_result):
     return {
         "investigator": _agent_metrics(inv_result),
-        "critic": {"skipped": True, "skip_reason": None},
-        "reporter": {"input_tokens": 0, "output_tokens": 0, "skipped": True},
+        "critic": _empty_stage_metrics(),
+        "reporter": _empty_stage_metrics(),
         "totals": {},
         "max_turns_reached": inv_result.max_turns_reached,
         "critic_overturn_rate": None,
@@ -996,14 +1023,18 @@ def _run_critic_and_reporter(*, cfg, bedrock, tool_runner, critic_system, critic
     reporter_metrics). When the Critic is skipped, crit_result is None,
     critic_skip_reason explains why, and the Reporter is skipped too.
     """
-    skipped_metrics = {"input_tokens": 0, "output_tokens": 0, "skipped": True, "skip_reason": None}
+    skipped_metrics = _empty_stage_metrics()
 
     if not _has_confirmed_findings(investigator_text):
         return None, "no_confirmed_findings", [], skipped_metrics
 
     critic_diff = _truncate_for_critic(diff, cfg.critic_max_diff_chars)
+    # Guard against an Investigator that emits literal </investigator_notes>:
+    # neutralize close-tag occurrences in the body so the Critic can't be
+    # tricked into reading a follow-on injection as a top-level instruction.
+    safe_notes = investigator_text.replace("</investigator_notes>", "</investigator_notes_>")
     critic_user = (
-        f"<investigator_notes>\n{investigator_text}\n</investigator_notes>\n"
+        f"<investigator_notes>\n{safe_notes}\n</investigator_notes>\n"
         f"<diff>\n{critic_diff}\n</diff>\n"
         f"<pr>\nTitle: {title}\nBody: {body}\n</pr>"
     )
@@ -1014,23 +1045,39 @@ def _run_critic_and_reporter(*, cfg, bedrock, tool_runner, critic_system, critic
         caps=critic_caps,
     )
 
+    # If the Critic failed to run (Bedrock error, circuit breaker, empty
+    # response), DO NOT synthesize a "ALL_DISPROVED" verdict — that would
+    # silently drop real findings. Skip the Reporter and ESCALATE upstream.
+    if crit_result.error or not crit_result.text:
+        skipped_metrics = _empty_stage_metrics()
+        skipped_metrics["skip_reason"] = "critic_failed"
+        return crit_result, "critic_failed", [], skipped_metrics
+
+    safe_notes = investigator_text.replace("</investigator_notes>", "</investigator_notes_>")
+    safe_verdicts = crit_result.text.replace("</critic_verdicts>", "</critic_verdicts_>")
     reporter_user = (
-        f"<investigator_notes>\n{investigator_text}\n</investigator_notes>\n\n"
-        f"<critic_verdicts>\n"
-        f"{crit_result.text or 'ALL_DISPROVED: critic produced no verdicts'}"
-        f"\n</critic_verdicts>\n\n"
+        f"<investigator_notes>\n{safe_notes}\n</investigator_notes>\n\n"
+        f"<critic_verdicts>\n{safe_verdicts}\n</critic_verdicts>\n\n"
         f"<pr>\nTitle: {title}\nBody: {body}\n</pr>"
     )
     raw, usage = bedrock.invoke_with_usage(
         reporter_system, reporter_user, max_tokens=8000, json_schema=PR_REVIEW_SCHEMA,
     )
-    reporter_metrics = {
+    reporter_metrics = _empty_stage_metrics()
+    reporter_metrics.update({
         "skipped": False,
         "skip_reason": None if raw is not None else "bedrock_unavailable",
         "input_tokens": (usage.get("inputTokens") if usage else 0) or 0,
         "output_tokens": (usage.get("outputTokens") if usage else 0) or 0,
-    }
-    inline_comments = _parse_reporter_output(raw) if raw is not None else []
+        "cache_read_tokens": (usage.get("cacheReadInputTokens") if usage else 0) or 0,
+        "cache_write_tokens": (usage.get("cacheWriteInputTokens") if usage else 0) or 0,
+    })
+    if raw is None:
+        return crit_result, None, [], reporter_metrics
+    inline_comments, parse_ok = _parse_reporter_output(raw)
+    if not parse_ok:
+        reporter_metrics["parse_failed"] = True
+        reporter_metrics["skip_reason"] = "reporter_output_malformed"
     return crit_result, None, inline_comments, reporter_metrics
 
 
@@ -1058,10 +1105,29 @@ def _build_clean_response(gh, head_sha, inline_comments):
     return "No issues found.\n<!-- deequ-bot:clean -->"
 
 
-def _agent_metrics(r):
+def _empty_stage_metrics():
+    """Canonical shape for a per-stage metrics block. Every stage emits the
+    same keys so dashboards can iterate uniformly."""
     return {
-        "skipped": False,
+        "skipped": True,
         "skip_reason": None,
+        "turns": 0,
+        "tool_calls": 0,
+        "tool_output_chars": 0,
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_read_tokens": 0,
+        "cache_write_tokens": 0,
+        "max_turns_reached": False,
+        "error": None,
+        "parse_failed": False,
+    }
+
+
+def _agent_metrics(r):
+    metrics = _empty_stage_metrics()
+    metrics.update({
+        "skipped": False,
         "turns": r.turns,
         "tool_calls": r.tool_calls,
         "tool_output_chars": r.tool_output_chars,
@@ -1071,7 +1137,8 @@ def _agent_metrics(r):
         "cache_write_tokens": r.cache_write_tokens,
         "max_turns_reached": r.max_turns_reached,
         "error": r.error,
-    }
+    })
+    return metrics
 
 
 def _finalize_metrics(metrics, inv, crit):
@@ -1116,8 +1183,11 @@ def _critic_overturn_rate(critic_text):
 
 
 def _parse_reporter_output(raw):
-    """Parse the Reporter's JSON output and return inline_comments list.
-    Same defensive parsing as the legacy path; never raises."""
+    """Parse the Reporter's JSON output. Returns (inline_comments, parse_ok).
+
+    Defensive — never raises. parse_ok=False signals malformed output so the
+    caller can flag it in metrics rather than treating empty == clean.
+    """
     try:
         result = json.loads(raw)
         if not isinstance(result, dict):
@@ -1141,11 +1211,11 @@ def _parse_reporter_output(raw):
                 "comment": finding.get("comment") or "",
                 "evidence": finding.get("evidence") or "",
             })
-        return out
+        return out, True
     except (json.JSONDecodeError, KeyError, TypeError, AttributeError) as e:
         logger.error("Reporter output parse failed (%s): %s",
                      type(e).__name__, (raw or "")[:500])
-        return []
+        return [], False
 
 
 def _write_artifact_pipeline(*, cfg, action, reason, title, html_url, number,

--- a/src/scripts/issue_bot/main.py
+++ b/src/scripts/issue_bot/main.py
@@ -20,6 +20,8 @@ from .knowledge_base import KnowledgeBase
 from .slack_client import SlackClient
 from .sanitizer import sanitize
 from . import prompts
+from . import agent_loop
+from .tools import TOOL_SPECS, ToolRunner
 
 logger = logging.getLogger("issue_bot")
 
@@ -139,6 +141,15 @@ def analyze():
     issue_text = f"{title} {body}"
     context = kb.build_context(issue_text)
     codebase_map = gh.get_codebase_map() if not is_followup else ""
+
+    if is_pr and cfg.agent_pipeline:
+        _run_agent_pipeline(
+            cfg=cfg, gh=gh, bedrock=bedrock,
+            number=number, title=title, body=body, html_url=html_url, item=item,
+            context=context, codebase_map=codebase_map,
+            comments_data=comments_data, is_pr_update=is_pr_update,
+        )
+        return
 
     if is_pr:
         tmpl = prompts.get_pr_file_review_prompt()
@@ -770,6 +781,419 @@ def _read_artifact():
     except Exception as e:
         logger.error(f"Artifact read failed: {e}")
         return None
+
+
+def _clamp(value, lo, hi):
+    return max(lo, min(hi, value))
+
+
+_STATUS_CONFIRMED_RE = re.compile(
+    r"^\s*STATUS\s*:\s*CONFIRMED\s*$",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _has_confirmed_findings(notes):
+    """Check for any line matching exactly 'STATUS: CONFIRMED' in investigator notes.
+
+    Anchored at line start/end with optional surrounding whitespace. Avoids
+    false positives where 'CONFIRMED' appears in a COMMENT or rationale.
+    """
+    if not notes:
+        return False
+    return _STATUS_CONFIRMED_RE.search(notes) is not None
+
+
+def _run_agent_pipeline(*, cfg, gh, bedrock, number, title, body, html_url, item,
+                        context, codebase_map, comments_data, is_pr_update):
+    """Investigator + Critic + Reporter pipeline. Replaces the legacy two-phase
+    flow when cfg.agent_pipeline is True. Writes the analyze artifact and returns.
+    """
+    investigator_tmpl = prompts.get_pr_investigator_prompt()
+    critic_tmpl = prompts.get_pr_critic_prompt()
+    reporter_tmpl = prompts.get_pr_file_review_report_prompt()
+    missing = []
+    if not investigator_tmpl:
+        missing.append("investigator")
+    if not critic_tmpl:
+        missing.append("critic")
+    if not reporter_tmpl:
+        missing.append("reporter")
+    if missing:
+        _write_artifact({
+            "action": "ESCALATE", "labels": [], "response": "",
+            "reason": f"prompt_load_failed: {','.join(missing)}",
+            "title": title, "html_url": html_url, "number": number, "is_pr": True,
+            "prompt_id": "n/a", "model_id": cfg.bedrock_model_id,
+        })
+        return
+
+    diff = gh.get_pr_diff(number)
+    review_comments = gh.get_pr_review_comments(number)
+    existing_feedback = _format_pr_feedback(comments_data, review_comments)
+
+    incremental_diff = ""
+    incremental_files = set()
+    if is_pr_update and cfg.event_before and cfg.event_after:
+        incremental_diff = gh.get_compare_diff(cfg.event_before, cfg.event_after)
+        if incremental_diff:
+            incremental_files = _extract_diff_files(incremental_diff)
+
+    head_sha = cfg.event_after or item.get("head", {}).get("sha", "")
+    pr_files = gh.get_pr_files(number)
+    diff_lines = sum(int(pf.get("changes", 0) or 0) for pf in pr_files)
+
+    # Adaptive caps (PR-size proportional within configured upper bounds).
+    # Floor is min(5, ceiling) so users can throttle below the default floor by
+    # setting BOT_INVESTIGATOR_MAX_TURNS=3 etc.
+    inv_ceiling = max(1, cfg.investigator_max_turns)
+    inv_floor = min(5, inv_ceiling)
+    investigator_caps = agent_loop.AgentCaps(
+        max_turns=_clamp(diff_lines // 30, inv_floor, inv_ceiling),
+        max_tool_calls=cfg.investigator_max_tool_calls,
+        max_tool_output_chars=cfg.investigator_max_tool_output_chars,
+    )
+    crit_ceiling = max(1, cfg.critic_max_turns)
+    crit_floor = min(3, crit_ceiling)
+    critic_caps = agent_loop.AgentCaps(
+        max_turns=_clamp(investigator_caps.max_turns // 2, crit_floor, crit_ceiling),
+        max_tool_calls=cfg.critic_max_tool_calls,
+        max_tool_output_chars=cfg.critic_max_tool_output_chars,
+    )
+
+    incremental_section = ""
+    if incremental_diff:
+        incremental_section = (
+            "\n<incremental_review_instructions>\n"
+            "This is a RE-REVIEW after the author pushed new commits. "
+            "Limit findings to lines/files in the incremental diff below. "
+            "Do not re-raise issues on unchanged code.\n"
+            "</incremental_review_instructions>\n"
+            f"<incremental_diff>\n{incremental_diff}\n</incremental_diff>\n"
+        )
+
+    # Static priming context (reused across Investigator and Critic for cache hit).
+    static_context = (
+        f"\n<knowledge_base>\n{context}\n</knowledge_base>\n"
+        f"<codebase_map>\n{codebase_map}\n</codebase_map>\n"
+        f"<existing_feedback>\n{existing_feedback}\n</existing_feedback>\n"
+        f"{incremental_section}"
+    )
+
+    investigator_system = _render(
+        investigator_tmpl, current_date=datetime.date.today().isoformat()
+    ) + static_context
+    critic_system = _render(
+        critic_tmpl, current_date=datetime.date.today().isoformat()
+    ) + static_context
+    reporter_system = (
+        _render(reporter_tmpl, current_date=datetime.date.today().isoformat())
+        + f"\n<diff>\n{diff}\n</diff>\n"
+        + f"<existing_feedback>\n{existing_feedback}\n</existing_feedback>\n"
+    )
+
+    investigator_user = (
+        f"<diff>\n{diff}\n</diff>\n"
+        f"<pr>\nTitle: {title}\nBody: {body}\n</pr>"
+    )
+
+    tool_runner = ToolRunner(cfg, gh._repo_root)
+    cost_tracker = {
+        "cost_usd": 0.0,
+        "cap_usd": cfg.agent_max_review_cost_usd,
+        "cap_hit": False,
+    }
+    pricing = cfg.bedrock_pricing
+
+    inv_result = agent_loop.run(
+        bedrock_client=bedrock, agent_name="investigator",
+        system_prompt=investigator_system, user_prompt=investigator_user,
+        tool_specs=TOOL_SPECS, tool_runner=tool_runner,
+        caps=investigator_caps, cost_tracker=cost_tracker, pricing=pricing,
+    )
+
+    metrics = {
+        "investigator": _agent_metrics(inv_result),
+        "critic": {"skipped": True, "skip_reason": None},
+        "reporter": {"input_tokens": 0, "output_tokens": 0, "skipped": True},
+        "totals": {},
+        "cost_cap_hit": cost_tracker["cap_hit"],
+        "max_turns_reached": inv_result.max_turns_reached,
+        "critic_overturn_rate": None,
+    }
+
+    if not inv_result.text:
+        _write_artifact_pipeline(
+            cfg=cfg, action="ESCALATE", reason="investigator_empty",
+            title=title, html_url=html_url, number=number,
+            inv_tmpl=investigator_tmpl, critic_tmpl=critic_tmpl, reporter_tmpl=reporter_tmpl,
+            inline_comments=[], response="", is_incremental=bool(incremental_diff),
+            metrics=_finalize_metrics(metrics, inv_result, None, None, cost_tracker),
+            tool_trace=inv_result.tool_trace,
+        )
+        return
+
+    confirmed_present = _has_confirmed_findings(inv_result.text)
+
+    crit_result = None
+    rep_inline_comments = []
+    rep_input_tokens = 0
+    rep_output_tokens = 0
+
+    if not confirmed_present:
+        # FAST PATH: no confirmed findings → skip Critic and Reporter
+        metrics["critic"]["skip_reason"] = "no_confirmed_findings"
+        metrics["reporter"]["skipped"] = True
+    elif cost_tracker["cap_hit"]:
+        metrics["critic"]["skip_reason"] = "cost_cap_hit_after_investigator"
+        metrics["reporter"]["skipped"] = True
+    else:
+        # Cap Critic's first-turn input. Investigator notes are bounded by
+        # max_tokens_per_call; the diff is unbounded and dominates large PRs.
+        # Truncate the diff so combined input stays well under Bedrock's 200K
+        # token window. Critic can fetch full files via read_file as needed.
+        max_critic_diff_chars = 200_000
+        critic_diff = diff
+        if len(critic_diff) > max_critic_diff_chars:
+            critic_diff = (
+                critic_diff[:max_critic_diff_chars]
+                + f"\n... [diff truncated at {max_critic_diff_chars} chars; "
+                "use read_file to fetch specific files referenced in investigator notes]"
+            )
+        critic_user = (
+            f"<investigator_notes>\n{inv_result.text}\n</investigator_notes>\n"
+            f"<diff>\n{critic_diff}\n</diff>\n"
+            f"<pr>\nTitle: {title}\nBody: {body}\n</pr>"
+        )
+        crit_result = agent_loop.run(
+            bedrock_client=bedrock, agent_name="critic",
+            system_prompt=critic_system, user_prompt=critic_user,
+            tool_specs=TOOL_SPECS, tool_runner=tool_runner,
+            caps=critic_caps, cost_tracker=cost_tracker, pricing=pricing,
+        )
+        metrics["critic"] = _agent_metrics(crit_result)
+
+        if cost_tracker["cap_hit"]:
+            metrics["reporter"]["skipped"] = True
+            metrics["reporter"]["skip_reason"] = "cost_cap_hit_after_critic"
+        else:
+            reporter_user = (
+                f"<investigator_notes>\n{inv_result.text}\n</investigator_notes>\n\n"
+                f"<critic_verdicts>\n{crit_result.text or 'ALL_DISPROVED: critic produced no verdicts'}\n</critic_verdicts>\n\n"
+                f"<pr>\nTitle: {title}\nBody: {body}\n</pr>"
+            )
+            raw, rep_input_tokens, rep_output_tokens = _invoke_reporter_tracked(
+                bedrock, reporter_system, reporter_user, cost_tracker, pricing,
+            )
+            metrics["reporter"]["skipped"] = False
+            metrics["reporter"]["input_tokens"] = rep_input_tokens
+            metrics["reporter"]["output_tokens"] = rep_output_tokens
+            if raw is None:
+                metrics["reporter"]["skip_reason"] = "bedrock_unavailable"
+            else:
+                rep_inline_comments = _parse_reporter_output(raw)
+
+    # Apply post-processing filters (same as legacy path)
+    rep_inline_comments = [
+        c for c in rep_inline_comments
+        if c.get("file") and isinstance(c.get("line"), int) and c["line"] > 0
+    ]
+    if incremental_files and rep_inline_comments:
+        rep_inline_comments = [
+            c for c in rep_inline_comments if c.get("file", "") in incremental_files
+        ]
+    if is_pr_update and rep_inline_comments:
+        rep_inline_comments = [
+            c for c in rep_inline_comments
+            if c.get("severity", "").upper() != "NIT"
+        ]
+    for c in rep_inline_comments:
+        severity = c.get("severity", "")
+        evidence = c.get("evidence", "")
+        prefix = f"**{severity}**: " if severity else ""
+        suffix = "\n\n> " + evidence.replace("\n", "\n> ") if evidence else ""
+        c["comment"] = prefix + c.get("comment", "") + suffix
+
+    ci_passed, ci_summary = gh.get_ci_status(head_sha) if head_sha else (None, "")
+    if not rep_inline_comments:
+        if ci_passed is True:
+            response = "No issues found. CI is passing.\n<!-- deequ-bot:clean -->"
+        elif ci_passed is False:
+            response = f"No code issues found, but {ci_summary}."
+        else:
+            response = "No issues found.\n<!-- deequ-bot:clean -->"
+    else:
+        response = ""
+
+    _write_artifact_pipeline(
+        cfg=cfg, action="RESPOND", reason=None,
+        title=title, html_url=html_url, number=number,
+        inv_tmpl=investigator_tmpl, critic_tmpl=critic_tmpl, reporter_tmpl=reporter_tmpl,
+        inline_comments=rep_inline_comments, response=response,
+        is_incremental=bool(incremental_diff),
+        metrics=_finalize_metrics(metrics, inv_result, crit_result, None, cost_tracker),
+        tool_trace=(inv_result.tool_trace + (crit_result.tool_trace if crit_result else [])),
+    )
+
+
+def _invoke_reporter_tracked(bedrock, system, user_msg, cost_tracker, pricing):
+    """Invoke Reporter (single-shot, schema-enforced) while updating cost_tracker.
+    Returns (raw_text, input_tokens, output_tokens). On failure: (None, 0, 0)."""
+    raw, usage = bedrock.invoke_with_usage(
+        system, user_msg, max_tokens=8000, json_schema=PR_REVIEW_SCHEMA,
+    )
+    in_t = (usage.get("inputTokens") or 0) if usage else 0
+    out_t = (usage.get("outputTokens") or 0) if usage else 0
+    cr_t = (usage.get("cacheReadInputTokens") or 0) if usage else 0
+    cw_t = (usage.get("cacheWriteInputTokens") or 0) if usage else 0
+    delta = (
+        (in_t / 1_000_000) * pricing["input_per_million"]
+        + (out_t / 1_000_000) * pricing["output_per_million"]
+        + (cr_t / 1_000_000) * pricing["cache_read_per_million"]
+        + (cw_t / 1_000_000) * pricing["cache_write_per_million"]
+    )
+    cost_tracker["cost_usd"] = cost_tracker.get("cost_usd", 0.0) + delta
+    if cost_tracker["cost_usd"] >= cost_tracker.get("cap_usd", float("inf")):
+        cost_tracker["cap_hit"] = True
+    return raw, in_t, out_t
+
+
+def _agent_metrics(r):
+    return {
+        "skipped": False,
+        "skip_reason": None,
+        "turns": r.turns,
+        "tool_calls": r.tool_calls,
+        "tool_output_chars": r.tool_output_chars,
+        "input_tokens": r.input_tokens,
+        "output_tokens": r.output_tokens,
+        "cache_read_tokens": r.cache_read_tokens,
+        "cache_write_tokens": r.cache_write_tokens,
+        "max_turns_reached": r.max_turns_reached,
+        "error": r.error,
+    }
+
+
+def _finalize_metrics(metrics, inv, crit, _rep, cost_tracker):
+    overturn = _critic_overturn_rate(crit.text if (crit and crit.text) else "")
+    metrics["critic_overturn_rate"] = overturn
+    rep_in = metrics.get("reporter", {}).get("input_tokens", 0) or 0
+    rep_out = metrics.get("reporter", {}).get("output_tokens", 0) or 0
+    metrics["totals"] = {
+        "input_tokens": (inv.input_tokens if inv else 0) + (crit.input_tokens if crit else 0) + rep_in,
+        "output_tokens": (inv.output_tokens if inv else 0) + (crit.output_tokens if crit else 0) + rep_out,
+        "cost_usd": round(cost_tracker.get("cost_usd", 0.0), 4),
+    }
+    metrics["cost_cap_hit"] = cost_tracker.get("cap_hit", False)
+    return metrics
+
+
+_VERDICT_RE = re.compile(
+    r"^\s*VERDICT\s*:\s*\S+\s*\|\s*(UPHELD|OVERTURNED)\b",
+    re.IGNORECASE | re.MULTILINE,
+)
+
+
+def _critic_overturn_rate(critic_text):
+    """Compute overturn rate by parsing VERDICT lines anchored at line start.
+
+    Avoids substring false-positives where 'UPHELD' or 'OVERTURNED' appears
+    in rationale text. Returns None if no verdicts parsed.
+    """
+    if not critic_text:
+        return None
+    upheld = 0
+    overturned = 0
+    for m in _VERDICT_RE.finditer(critic_text):
+        verdict = m.group(1).upper()
+        if verdict == "UPHELD":
+            upheld += 1
+        elif verdict == "OVERTURNED":
+            overturned += 1
+    total = upheld + overturned
+    if total == 0:
+        return None
+    return round(overturned / total, 3)
+
+
+def _parse_reporter_output(raw):
+    """Parse the Reporter's JSON output and return inline_comments list.
+    Same defensive parsing as the legacy path; never raises."""
+    try:
+        result = json.loads(raw)
+        if not isinstance(result, dict):
+            raise TypeError("reporter root is not an object")
+        analysis = result.get("analysis", [])
+        if not isinstance(analysis, list):
+            raise TypeError("reporter analysis is not a list")
+        out = []
+        for a in analysis:
+            if not isinstance(a, dict):
+                continue
+            if a.get("disproved") is True:
+                continue
+            finding = a.get("finding")
+            if not isinstance(finding, dict):
+                continue
+            out.append({
+                "file": a.get("file") or "",
+                "line": a.get("line") or 0,
+                "severity": finding.get("severity") or "",
+                "comment": finding.get("comment") or "",
+                "evidence": finding.get("evidence") or "",
+            })
+        return out
+    except (json.JSONDecodeError, KeyError, TypeError, AttributeError) as e:
+        logger.error("Reporter output parse failed (%s): %s",
+                     type(e).__name__, (raw or "")[:500])
+        return []
+
+
+def _write_artifact_pipeline(*, cfg, action, reason, title, html_url, number,
+                              inv_tmpl, critic_tmpl, reporter_tmpl,
+                              inline_comments, response, is_incremental,
+                              metrics, tool_trace):
+    """Artifact writer for pipeline runs. Includes metrics and trace."""
+    artifact = {
+        "action": action,
+        "labels": [],
+        "response": response,
+        "inline_comments": inline_comments,
+        "title": title, "html_url": html_url, "number": number,
+        "is_pr": True, "is_incremental": is_incremental,
+        "prompt_id": prompts.prompt_version(inv_tmpl) if inv_tmpl else "n/a",
+        "prompt_ids": {
+            "investigator": prompts.prompt_version(inv_tmpl) if inv_tmpl else "n/a",
+            "critic": prompts.prompt_version(critic_tmpl) if critic_tmpl else "n/a",
+            "reporter": prompts.prompt_version(reporter_tmpl) if reporter_tmpl else "n/a",
+        },
+        "model_id": cfg.bedrock_model_id,
+        "metrics": metrics,
+        "tool_trace": _truncate_trace(tool_trace),
+        "pipeline": "agentic",
+    }
+    if reason:
+        artifact["reason"] = reason
+    _write_artifact(artifact)
+
+
+def _truncate_trace(trace, max_chars=100_000):
+    """Cap trace size in the artifact to avoid huge JSON blobs."""
+    if not trace:
+        return []
+    serialized = json.dumps(trace)
+    if len(serialized) <= max_chars:
+        return trace
+    out = []
+    running = 2  # for the brackets
+    for entry in trace:
+        s = json.dumps(entry)
+        if running + len(s) + 2 > max_chars:
+            out.append({"truncated": True, "remaining_entries": len(trace) - len(out)})
+            break
+        out.append(entry)
+        running += len(s) + 1
+    return out
 
 
 def main():

--- a/src/scripts/issue_bot/main.py
+++ b/src/scripts/issue_bot/main.py
@@ -5,12 +5,13 @@ Deequ Bot — two-phase orchestration.
   act:     write-only phase, reads artifact and posts to GitHub/Slack
 """
 
+import datetime
 import json
+import logging
+import os
 import re
 import sys
-import os
-import datetime
-import logging
+import time
 import uuid
 
 from .config import Config
@@ -804,12 +805,22 @@ def _filter_and_format_inline_comments(comments, *, incremental_files, is_pr_upd
 
     Mutates and returns the kept list.
     """
-    kept = [
-        dict(c) for c in comments
-        if c.get("file") and isinstance(c.get("line"), int) and c["line"] > 0
-    ]
+    # Canonicalize file paths once up front so the incremental-files filter
+    # and the eventual GitHub POST agree on the spelling. Without this, a
+    # model emitting "./src/foo.py" would pass the filter (we canonicalize
+    # there) but reach post_pr_review with the raw path and 422.
+    kept = []
+    for c in comments:
+        if not (c.get("file") and isinstance(c.get("line"), int) and c["line"] > 0):
+            continue
+        canon = _canonicalize_path(c["file"])
+        if not canon:
+            continue
+        new_c = dict(c)
+        new_c["file"] = canon
+        kept.append(new_c)
     if incremental_files and kept:
-        kept = [c for c in kept if _canonicalize_path(c.get("file", "")) in incremental_files]
+        kept = [c for c in kept if c["file"] in incremental_files]
     if is_pr_update and kept:
         kept = [c for c in kept if c.get("severity", "").upper() != "NIT"]
     for c in kept:
@@ -859,12 +870,14 @@ def _run_agent_pipeline(*, cfg, gh, bedrock, number, title, body, html_url, item
     )
 
     tool_runner = ToolRunner(cfg, gh.repo_root)
+    pipeline_deadline = time.monotonic() + cfg.pipeline_wall_clock_seconds
 
     inv_result = agent_loop.run(
         bedrock_client=bedrock, agent_name="investigator",
         system_prompt=investigator_system, user_prompt=investigator_user,
         tool_specs=TOOL_SPECS, tool_runner=tool_runner,
         caps=investigator_caps,
+        pipeline_deadline=pipeline_deadline,
     )
 
     metrics = _initial_metrics(inv_result)
@@ -890,6 +903,7 @@ def _run_agent_pipeline(*, cfg, gh, bedrock, number, title, body, html_url, item
             reporter_system=reporter_system,
             diff=diff, title=title, body=body,
             investigator_text=inv_result.text,
+            pipeline_deadline=pipeline_deadline,
         )
     )
     if crit_result is not None:
@@ -899,12 +913,15 @@ def _run_agent_pipeline(*, cfg, gh, bedrock, number, title, body, html_url, item
     metrics["reporter"] = reporter_metrics
 
     # If the Critic crashed mid-run, do not post anything as clean — escalate.
+    # Preserve the Investigator's narrative so an operator triaging the
+    # escalation can see what was suspected.
     if critic_skip_reason == "critic_failed":
         _write_artifact_pipeline(
             **artifact_kwargs, action="ESCALATE", reason="critic_failed",
             inline_comments=[], response="",
             metrics=_finalize_metrics(metrics, inv_result, crit_result),
             tool_trace=(inv_result.tool_trace + (crit_result.tool_trace if crit_result else [])),
+            investigator_summary=inv_result.text,
         )
         return
 
@@ -1016,12 +1033,16 @@ def _initial_metrics(inv_result):
 
 
 def _run_critic_and_reporter(*, cfg, bedrock, tool_runner, critic_system, critic_caps,
-                              reporter_system, diff, title, body, investigator_text):
+                              reporter_system, diff, title, body, investigator_text,
+                              pipeline_deadline=None):
     """Run the Critic (if any CONFIRMED concerns) and then the Reporter.
 
     Returns (crit_result_or_None, critic_skip_reason_or_None, inline_comments,
     reporter_metrics). When the Critic is skipped, crit_result is None,
     critic_skip_reason explains why, and the Reporter is skipped too.
+
+    pipeline_deadline (optional) is a shared monotonic time budget across
+    all pipeline stages, threaded into the Critic loop.
     """
     skipped_metrics = _empty_stage_metrics()
 
@@ -1043,12 +1064,15 @@ def _run_critic_and_reporter(*, cfg, bedrock, tool_runner, critic_system, critic
         system_prompt=critic_system, user_prompt=critic_user,
         tool_specs=TOOL_SPECS, tool_runner=tool_runner,
         caps=critic_caps,
+        pipeline_deadline=pipeline_deadline,
     )
 
-    # If the Critic failed to run (Bedrock error, circuit breaker, empty
-    # response), DO NOT synthesize a "ALL_DISPROVED" verdict — that would
-    # silently drop real findings. Skip the Reporter and ESCALATE upstream.
-    if crit_result.error or not crit_result.text:
+    # Distinguish fatal Critic failures (no usable output: Bedrock error,
+    # empty response, protocol violation) from bounded-completion exits
+    # (max_turns, structural cap, wall-clock) which may have produced valid
+    # partial verdicts. Only fatal failures escalate; bounded exits flow
+    # through to the Reporter, which applies its own UPHELD filter.
+    if crit_result.fatal or not crit_result.text:
         skipped_metrics = _empty_stage_metrics()
         skipped_metrics["skip_reason"] = "critic_failed"
         return crit_result, "critic_failed", [], skipped_metrics
@@ -1221,8 +1245,13 @@ def _parse_reporter_output(raw):
 def _write_artifact_pipeline(*, cfg, action, reason, title, html_url, number,
                               inv_tmpl, critic_tmpl, reporter_tmpl,
                               inline_comments, response, is_incremental,
-                              metrics, tool_trace):
-    """Artifact writer for pipeline runs. Includes metrics and trace."""
+                              metrics, tool_trace, investigator_summary=None):
+    """Artifact writer for pipeline runs. Includes metrics and trace.
+
+    investigator_summary (optional) preserves the Investigator's narrative on
+    ESCALATE artifacts so an operator can see what was suspected when the
+    Critic or Reporter failed and the findings never reached the PR.
+    """
     artifact = {
         "action": action,
         "labels": [],
@@ -1243,6 +1272,8 @@ def _write_artifact_pipeline(*, cfg, action, reason, title, html_url, number,
     }
     if reason:
         artifact["reason"] = reason
+    if investigator_summary:
+        artifact["investigator_summary"] = investigator_summary[:5000]
     _write_artifact(artifact)
 
 

--- a/src/scripts/issue_bot/prompts.py
+++ b/src/scripts/issue_bot/prompts.py
@@ -54,5 +54,18 @@ def get_pr_file_review_report_prompt():
     return _get_prompt("PR_FILE_REVIEW_REPORT_PROMPT", "SM_PR_FILE_REVIEW_REPORT_PROMPT")
 
 
+def get_pr_critic_prompt():
+    return _get_prompt("PR_CRITIC_PROMPT", "SM_PR_CRITIC_PROMPT")
+
+
+def get_pr_investigator_prompt():
+    """Investigator prompt for the agentic pipeline. Falls back to the
+    existing PR file review prompt if the investigator-specific one is unset."""
+    val = _get_prompt("PR_INVESTIGATOR_PROMPT", "SM_PR_INVESTIGATOR_PROMPT")
+    if val:
+        return val
+    return get_pr_file_review_prompt()
+
+
 def prompt_version(template):
     return hashlib.sha256(template.encode()).hexdigest()[:8]

--- a/src/scripts/issue_bot/prompts.py
+++ b/src/scripts/issue_bot/prompts.py
@@ -59,12 +59,14 @@ def get_pr_critic_prompt():
 
 
 def get_pr_investigator_prompt():
-    """Investigator prompt for the agentic pipeline. Falls back to the
-    existing PR file review prompt if the investigator-specific one is unset."""
-    val = _get_prompt("PR_INVESTIGATOR_PROMPT", "SM_PR_INVESTIGATOR_PROMPT")
-    if val:
-        return val
-    return get_pr_file_review_prompt()
+    """Investigator prompt for the agentic pipeline.
+
+    Returns empty string if neither the env override nor the SM secret is set.
+    Callers MUST fail closed: the legacy PR file review prompt does not produce
+    the HYPOTHESIS / STATUS:CONFIRMED markers the pipeline relies on. A silent
+    fallback would mask a misconfiguration as a clean-PR result.
+    """
+    return _get_prompt("PR_INVESTIGATOR_PROMPT", "SM_PR_INVESTIGATOR_PROMPT")
 
 
 def prompt_version(template):

--- a/src/scripts/issue_bot/prompts.py
+++ b/src/scripts/issue_bot/prompts.py
@@ -58,6 +58,13 @@ def get_pr_critic_prompt():
     return _get_prompt("PR_CRITIC_PROMPT", "SM_PR_CRITIC_PROMPT")
 
 
+def get_pr_reporter_prompt():
+    """Reporter prompt for the agentic pipeline. Distinct from
+    `get_pr_file_review_report_prompt` (the legacy two-phase reporter) so
+    the legacy flow can keep its own prompt format unchanged."""
+    return _get_prompt("PR_REPORTER_PROMPT", "SM_PR_REPORTER_PROMPT")
+
+
 def get_pr_investigator_prompt():
     """Investigator prompt for the agentic pipeline.
 

--- a/src/scripts/issue_bot/tools.py
+++ b/src/scripts/issue_bot/tools.py
@@ -173,6 +173,8 @@ def _safe_repo_path(repo_root, rel_path):
     """
     if not rel_path or not isinstance(rel_path, str):
         return None, "ERROR: path must be a non-empty string"
+    if "\x00" in rel_path:
+        return None, "ERROR: path contains NUL byte"
     if rel_path.startswith("/") or ".." in rel_path.split("/"):
         return None, f"ERROR: path '{rel_path}' must be repo-relative without '..' segments"
     real_root = os.path.realpath(repo_root)

--- a/src/scripts/issue_bot/tools.py
+++ b/src/scripts/issue_bot/tools.py
@@ -14,9 +14,22 @@ import re
 
 logger = logging.getLogger("issue_bot")
 
+# Per-tool output caps. These bound a single tool call's response size; the
+# loop separately bounds total tool output across the agent run.
 _MAX_RESULT_CHARS = 50_000
 _MAX_FILE_LINES_PER_CALL = 200
 _MAX_GREP_RESULTS = 50
+
+# Default per-tool call budgets, co-located with TOOL_SPECS so a tool rename
+# requires updating both in one place. Tools omitted from this dict have no
+# per-tool cap and are bounded only by AgentCaps.max_tool_calls.
+DEFAULT_PER_TOOL_CALL_CAPS = {
+    "grep_codebase": 50,
+    "read_file": 30,
+    "list_dir": 20,
+    "find_callers": 20,
+    "find_tests_for": 10,
+}
 
 # JSON Schema definitions for Bedrock toolConfig. These describe each tool
 # in the format Bedrock Converse expects.
@@ -170,7 +183,12 @@ def _safe_repo_path(repo_root, rel_path):
 
 
 def grep_codebase(pattern, path_glob, repo_root, src_dir, default_ext):
-    """Search for a regex across the codebase. Returns 'path:line:text' lines."""
+    """Search for a regex across the codebase. Returns 'path:line:text' lines.
+
+    The pattern is model-supplied; pathological patterns can ReDoS-pin a
+    worker. Acceptable today (we own the model and the diffs it sees);
+    revisit when this runs in less-trusted contexts.
+    """
     if not pattern or not isinstance(pattern, str):
         return "ERROR: pattern must be a non-empty string"
     try:
@@ -178,12 +196,20 @@ def grep_codebase(pattern, path_glob, repo_root, src_dir, default_ext):
     except re.error as e:
         return f"ERROR: invalid regex: {e}"
     ext = path_glob if (path_glob and path_glob.startswith(".")) else default_ext
-    if not ext:
-        ext = default_ext
     search_root = os.path.join(repo_root, src_dir)
     if not os.path.isdir(search_root):
         return f"ERROR: search root '{src_dir}' does not exist in repo"
-    matches = []
+
+    matches = list(_iter_matches(regex, search_root, repo_root, ext, _MAX_GREP_RESULTS))
+    if not matches:
+        return f"No matches for pattern '{pattern}' in {src_dir}/**/*{ext}"
+    header = f"Found {len(matches)} match(es) (capped at {_MAX_GREP_RESULTS}):\n"
+    return _truncate(header + "\n".join(matches))
+
+
+def _iter_matches(regex, search_root, repo_root, ext, limit):
+    """Yield up to `limit` regex matches as 'path:line:text' strings."""
+    count = 0
     for dirpath, _, files in os.walk(search_root):
         for fn in files:
             if not fn.endswith(ext):
@@ -191,22 +217,15 @@ def grep_codebase(pattern, path_glob, repo_root, src_dir, default_ext):
             full = os.path.join(dirpath, fn)
             try:
                 with open(full, encoding="utf-8", errors="ignore") as f:
+                    rel = os.path.relpath(full, repo_root)
                     for lineno, line in enumerate(f, 1):
                         if regex.search(line):
-                            rel = os.path.relpath(full, repo_root)
-                            matches.append(f"{rel}:{lineno}:{line.rstrip()}")
-                            if len(matches) >= _MAX_GREP_RESULTS:
-                                break
+                            yield f"{rel}:{lineno}:{line.rstrip()}"
+                            count += 1
+                            if count >= limit:
+                                return
             except OSError:
                 continue
-            if len(matches) >= _MAX_GREP_RESULTS:
-                break
-        if len(matches) >= _MAX_GREP_RESULTS:
-            break
-    if not matches:
-        return f"No matches for pattern '{pattern}' in {src_dir}/**/*{ext}"
-    header = f"Found {len(matches)} match(es) (capped at {_MAX_GREP_RESULTS}):\n"
-    return _truncate(header + "\n".join(matches))
 
 
 def read_file(path, start_line, end_line, repo_root):
@@ -229,13 +248,13 @@ def read_file(path, start_line, end_line, repo_root):
     except OSError as e:
         return f"ERROR: cannot read '{path}': {e}"
     total = len(lines)
-    start = max(1, start_line if isinstance(start_line, int) and start_line >= 1 else 1)
+    start = start_line if isinstance(start_line, int) and start_line >= 1 else 1
     if isinstance(end_line, int) and end_line == -1:
         end = total
-    elif end_line is None or not isinstance(end_line, int) or end_line < 0:
-        end = min(start + _MAX_FILE_LINES_PER_CALL - 1, total)
-    else:
+    elif isinstance(end_line, int) and end_line >= 1:
         end = min(end_line, total)
+    else:
+        end = min(start + _MAX_FILE_LINES_PER_CALL - 1, total)
     if start > total:
         return f"ERROR: start_line {start} exceeds file length {total}"
     if end - start + 1 > _MAX_FILE_LINES_PER_CALL:
@@ -308,55 +327,59 @@ def find_callers(symbol, repo_root, src_dir, default_ext):
 
 
 def find_tests_for(target, repo_root, src_dir, default_ext):
-    """Find test files for a source file or symbol."""
+    """Find test files for a source file or symbol.
+
+    First looks for naming-convention matches (X.scala → XTest.scala /
+    XSpec.scala) under the test directory mirroring src_dir, then grep-matches
+    the symbol name in remaining test files. Returns up to 20 candidates.
+    """
     if not target or not isinstance(target, str):
         return "ERROR: target must be a non-empty string"
     test_root = os.path.join(repo_root, src_dir.replace("src/main", "src/test", 1))
     if not os.path.isdir(test_root):
-        # Fall back to the conventional test directory under repo_root
         test_root = os.path.join(repo_root, "src", "test")
         if not os.path.isdir(test_root):
-            return f"ERROR: no test directory found at src/test"
-    candidates = []
-    if "/" in target and target.endswith(default_ext):
-        # Target is a source path. Map to conventional test path: X.scala → XTest.scala / XSpec.scala
-        base = os.path.basename(target)
-        stem = base[:-len(default_ext)]
-        for suffix in ("Test", "Spec", ""):
-            for dirpath, _, files in os.walk(test_root):
-                for fn in files:
-                    if fn == f"{stem}{suffix}{default_ext}":
-                        rel = os.path.relpath(os.path.join(dirpath, fn), repo_root)
-                        if rel not in candidates:
-                            candidates.append(rel)
-    # Also grep for the target name in test files (covers symbol case and additional matches)
+            return "ERROR: no test directory found at src/test"
+
     name = os.path.basename(target)
     if name.endswith(default_ext):
         name = name[:-len(default_ext)]
-    if re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", name):
-        pattern = re.compile(rf"\b{re.escape(name)}\b")
-        for dirpath, _, files in os.walk(test_root):
-            for fn in files:
-                if not fn.endswith(default_ext):
-                    continue
-                full = os.path.join(dirpath, fn)
+    if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", name):
+        return f"ERROR: target '{target}' did not yield a valid identifier"
+
+    convention_names = {f"{name}{suffix}{default_ext}" for suffix in ("Test", "Spec")}
+    grep_pattern = re.compile(rf"\b{re.escape(name)}\b")
+    candidates = []
+    seen = set()
+    limit = 20
+
+    for dirpath, _, files in os.walk(test_root):
+        for fn in files:
+            if not fn.endswith(default_ext):
+                continue
+            full = os.path.join(dirpath, fn)
+            rel = os.path.relpath(full, repo_root)
+            if rel in seen:
+                continue
+            if fn in convention_names:
+                candidates.append(rel)
+                seen.add(rel)
+            else:
                 try:
                     with open(full, encoding="utf-8", errors="ignore") as f:
-                        if pattern.search(f.read()):
-                            rel = os.path.relpath(full, repo_root)
-                            if rel not in candidates:
-                                candidates.append(rel)
+                        if grep_pattern.search(f.read()):
+                            candidates.append(rel)
+                            seen.add(rel)
                 except OSError:
                     continue
-                if len(candidates) >= 20:
-                    break
-            if len(candidates) >= 20:
+            if len(candidates) >= limit:
                 break
+        if len(candidates) >= limit:
+            break
+
     if not candidates:
         return f"No tests found for '{target}' under {os.path.relpath(test_root, repo_root)}"
-    out = [f"Tests for '{target}':"]
-    for rel in candidates[:20]:
-        out.append(f"  {rel}")
+    out = [f"Tests for '{target}':"] + [f"  {rel}" for rel in candidates]
     return _truncate("\n".join(out))
 
 

--- a/src/scripts/issue_bot/tools.py
+++ b/src/scripts/issue_bot/tools.py
@@ -210,7 +210,14 @@ def grep_codebase(pattern, path_glob, repo_root, src_dir, default_ext):
 
 
 def read_file(path, start_line, end_line, repo_root):
-    """Read a file slice from the repo with line numbers."""
+    """Read a file slice from the repo with line numbers.
+
+    end_line semantics:
+      None or omitted: read up to start_line + MAX_FILE_LINES_PER_CALL - 1
+      -1: read to end of file (still capped at MAX_FILE_LINES_PER_CALL)
+      any other negative or non-int: same as None (use default range)
+      positive int: read up to that line (capped at total)
+    """
     abs_path, err = _safe_repo_path(repo_root, path)
     if err:
         return err
@@ -223,13 +230,9 @@ def read_file(path, start_line, end_line, repo_root):
         return f"ERROR: cannot read '{path}': {e}"
     total = len(lines)
     start = max(1, start_line if isinstance(start_line, int) and start_line >= 1 else 1)
-    # Three end_line modes:
-    #   -1: read to end of file (capped at MAX_FILE_LINES_PER_CALL below)
-    #   any other negative or non-int: use default of start + 199
-    #   positive: read up to that line (capped at total)
     if isinstance(end_line, int) and end_line == -1:
         end = total
-    elif not isinstance(end_line, int) or end_line < 0:
+    elif end_line is None or not isinstance(end_line, int) or end_line < 0:
         end = min(start + _MAX_FILE_LINES_PER_CALL - 1, total)
     else:
         end = min(end_line, total)
@@ -381,7 +384,7 @@ class ToolRunner:
                 return read_file(
                     path=args.get("path", ""),
                     start_line=args.get("start_line", 1),
-                    end_line=args.get("end_line", -2),
+                    end_line=args.get("end_line", None),
                     repo_root=self._repo_root,
                 )
             if name == "list_dir":

--- a/src/scripts/issue_bot/tools.py
+++ b/src/scripts/issue_bot/tools.py
@@ -1,0 +1,409 @@
+"""
+Tools for the agentic PR review pipeline.
+
+Each tool is a pure function that takes structured args and returns a string
+the model reads as text. Tools never raise — they return error messages as
+text so the model can self-correct and continue investigating.
+
+Path safety: every tool that accepts a path normalizes via realpath and
+rejects anything outside the repo root.
+"""
+import logging
+import os
+import re
+
+logger = logging.getLogger("issue_bot")
+
+_MAX_RESULT_CHARS = 50_000
+_MAX_FILE_LINES_PER_CALL = 200
+_MAX_GREP_RESULTS = 50
+
+# JSON Schema definitions for Bedrock toolConfig. These describe each tool
+# in the format Bedrock Converse expects.
+TOOL_SPECS = [
+    {
+        "toolSpec": {
+            "name": "grep_codebase",
+            "description": (
+                "Search for a regex pattern across the codebase. Returns matching "
+                "lines as 'path:line:text'. Use to find references to a symbol, "
+                "method, type parameter, or any specific identifier across files."
+            ),
+            "inputSchema": {
+                "json": {
+                    "type": "object",
+                    "properties": {
+                        "pattern": {
+                            "type": "string",
+                            "description": "Regex pattern to search for. Use \\b for word boundaries on identifiers.",
+                        },
+                        "path_glob": {
+                            "type": "string",
+                            "description": "File extension filter (e.g., '.scala', '.py'). Defaults to the codebase's primary extension.",
+                        },
+                    },
+                    "required": ["pattern"],
+                },
+            },
+        },
+    },
+    {
+        "toolSpec": {
+            "name": "read_file",
+            "description": (
+                "Read a file (or a slice of it) from the repository at the PR head "
+                "SHA. Returns content with line numbers prefixed. Max 200 lines per "
+                "call — request a specific range for large files."
+            ),
+            "inputSchema": {
+                "json": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Repo-relative path to the file (e.g., 'src/main/scala/com/amazon/deequ/X.scala').",
+                        },
+                        "start_line": {
+                            "type": "integer",
+                            "description": "First line to read (1-indexed). Defaults to 1.",
+                        },
+                        "end_line": {
+                            "type": "integer",
+                            "description": "Last line to read (inclusive). Use -1 for end of file. Defaults to start_line + 199.",
+                        },
+                    },
+                    "required": ["path"],
+                },
+            },
+        },
+    },
+    {
+        "toolSpec": {
+            "name": "list_dir",
+            "description": (
+                "List files and subdirectories in a directory. Use to discover "
+                "what files exist before reading."
+            ),
+            "inputSchema": {
+                "json": {
+                    "type": "object",
+                    "properties": {
+                        "path": {
+                            "type": "string",
+                            "description": "Repo-relative path to a directory.",
+                        },
+                    },
+                    "required": ["path"],
+                },
+            },
+        },
+    },
+    {
+        "toolSpec": {
+            "name": "find_callers",
+            "description": (
+                "Find files that reference a class, trait, object, or method "
+                "name. Returns a list of files ranked by reference count. Use "
+                "when changing a type signature to discover impacted callers."
+            ),
+            "inputSchema": {
+                "json": {
+                    "type": "object",
+                    "properties": {
+                        "symbol": {
+                            "type": "string",
+                            "description": "Symbol name (case-sensitive, no namespace prefix).",
+                        },
+                    },
+                    "required": ["symbol"],
+                },
+            },
+        },
+    },
+    {
+        "toolSpec": {
+            "name": "find_tests_for",
+            "description": (
+                "Find test files that exercise a given source file or symbol. "
+                "Returns paths to test files in src/test/."
+            ),
+            "inputSchema": {
+                "json": {
+                    "type": "object",
+                    "properties": {
+                        "target": {
+                            "type": "string",
+                            "description": "Either a source path (e.g., 'src/main/scala/com/X.scala') or a symbol name.",
+                        },
+                    },
+                    "required": ["target"],
+                },
+            },
+        },
+    },
+]
+
+
+def _truncate(text):
+    if len(text) <= _MAX_RESULT_CHARS:
+        return text
+    return text[:_MAX_RESULT_CHARS] + (
+        f"\n... [truncated at {_MAX_RESULT_CHARS} chars; "
+        "ask for specific path or line range to see more]"
+    )
+
+
+def _safe_repo_path(repo_root, rel_path):
+    """Resolve rel_path against repo_root and reject paths outside.
+
+    Returns (absolute_path, error_message). On error, absolute_path is None.
+    """
+    if not rel_path or not isinstance(rel_path, str):
+        return None, "ERROR: path must be a non-empty string"
+    if rel_path.startswith("/") or ".." in rel_path.split("/"):
+        return None, f"ERROR: path '{rel_path}' must be repo-relative without '..' segments"
+    real_root = os.path.realpath(repo_root)
+    candidate = os.path.realpath(os.path.join(real_root, rel_path))
+    if not (candidate == real_root or candidate.startswith(real_root + os.sep)):
+        return None, f"ERROR: path '{rel_path}' resolves outside repo root"
+    return candidate, ""
+
+
+def grep_codebase(pattern, path_glob, repo_root, src_dir, default_ext):
+    """Search for a regex across the codebase. Returns 'path:line:text' lines."""
+    if not pattern or not isinstance(pattern, str):
+        return "ERROR: pattern must be a non-empty string"
+    try:
+        regex = re.compile(pattern)
+    except re.error as e:
+        return f"ERROR: invalid regex: {e}"
+    ext = path_glob if (path_glob and path_glob.startswith(".")) else default_ext
+    if not ext:
+        ext = default_ext
+    search_root = os.path.join(repo_root, src_dir)
+    if not os.path.isdir(search_root):
+        return f"ERROR: search root '{src_dir}' does not exist in repo"
+    matches = []
+    for dirpath, _, files in os.walk(search_root):
+        for fn in files:
+            if not fn.endswith(ext):
+                continue
+            full = os.path.join(dirpath, fn)
+            try:
+                with open(full, encoding="utf-8", errors="ignore") as f:
+                    for lineno, line in enumerate(f, 1):
+                        if regex.search(line):
+                            rel = os.path.relpath(full, repo_root)
+                            matches.append(f"{rel}:{lineno}:{line.rstrip()}")
+                            if len(matches) >= _MAX_GREP_RESULTS:
+                                break
+            except OSError:
+                continue
+            if len(matches) >= _MAX_GREP_RESULTS:
+                break
+        if len(matches) >= _MAX_GREP_RESULTS:
+            break
+    if not matches:
+        return f"No matches for pattern '{pattern}' in {src_dir}/**/*{ext}"
+    header = f"Found {len(matches)} match(es) (capped at {_MAX_GREP_RESULTS}):\n"
+    return _truncate(header + "\n".join(matches))
+
+
+def read_file(path, start_line, end_line, repo_root):
+    """Read a file slice from the repo with line numbers."""
+    abs_path, err = _safe_repo_path(repo_root, path)
+    if err:
+        return err
+    if not os.path.isfile(abs_path):
+        return f"ERROR: file '{path}' not found"
+    try:
+        with open(abs_path, encoding="utf-8", errors="ignore") as f:
+            lines = f.readlines()
+    except OSError as e:
+        return f"ERROR: cannot read '{path}': {e}"
+    total = len(lines)
+    start = max(1, start_line if isinstance(start_line, int) and start_line >= 1 else 1)
+    # Three end_line modes:
+    #   -1: read to end of file (capped at MAX_FILE_LINES_PER_CALL below)
+    #   any other negative or non-int: use default of start + 199
+    #   positive: read up to that line (capped at total)
+    if isinstance(end_line, int) and end_line == -1:
+        end = total
+    elif not isinstance(end_line, int) or end_line < 0:
+        end = min(start + _MAX_FILE_LINES_PER_CALL - 1, total)
+    else:
+        end = min(end_line, total)
+    if start > total:
+        return f"ERROR: start_line {start} exceeds file length {total}"
+    if end - start + 1 > _MAX_FILE_LINES_PER_CALL:
+        end = start + _MAX_FILE_LINES_PER_CALL - 1
+    out = []
+    width = len(str(end))
+    for i in range(start - 1, end):
+        out.append(f"{str(i + 1).rjust(width)}│ {lines[i].rstrip()}")
+    header = f"`{path}` lines {start}-{end} of {total}:\n"
+    if end < total:
+        out.append(f"... [{total - end} more lines below; request a higher range to see them]")
+    return _truncate(header + "\n".join(out))
+
+
+def list_dir(path, repo_root):
+    """List directory contents."""
+    abs_path, err = _safe_repo_path(repo_root, path)
+    if err:
+        return err
+    if not os.path.isdir(abs_path):
+        return f"ERROR: '{path}' is not a directory"
+    try:
+        entries = sorted(os.listdir(abs_path))
+    except OSError as e:
+        return f"ERROR: cannot list '{path}': {e}"
+    rows = []
+    for name in entries:
+        full = os.path.join(abs_path, name)
+        if os.path.isdir(full):
+            rows.append(f"  {name}/")
+        else:
+            rows.append(f"  {name}")
+    if not rows:
+        return f"`{path}` is empty"
+    return _truncate(f"`{path}`:\n" + "\n".join(rows))
+
+
+def find_callers(symbol, repo_root, src_dir, default_ext):
+    """Find files that reference a symbol, ranked by count."""
+    if not symbol or not isinstance(symbol, str):
+        return "ERROR: symbol must be a non-empty string"
+    if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", symbol):
+        return f"ERROR: symbol '{symbol}' is not a valid identifier"
+    pattern = re.compile(rf"\b{re.escape(symbol)}\b")
+    search_root = os.path.join(repo_root, src_dir)
+    if not os.path.isdir(search_root):
+        return f"ERROR: search root '{src_dir}' does not exist in repo"
+    counts = {}
+    for dirpath, _, files in os.walk(search_root):
+        for fn in files:
+            if not fn.endswith(default_ext):
+                continue
+            full = os.path.join(dirpath, fn)
+            try:
+                with open(full, encoding="utf-8", errors="ignore") as f:
+                    text = f.read()
+            except OSError:
+                continue
+            n = len(pattern.findall(text))
+            if n > 0:
+                rel = os.path.relpath(full, repo_root)
+                counts[rel] = n
+    if not counts:
+        return f"No files reference '{symbol}' in {src_dir}"
+    ranked = sorted(counts.items(), key=lambda kv: -kv[1])
+    out = [f"Files referencing '{symbol}' (top {min(20, len(ranked))} by count):"]
+    for rel, n in ranked[:20]:
+        out.append(f"  {rel} ({n} reference{'s' if n != 1 else ''})")
+    return _truncate("\n".join(out))
+
+
+def find_tests_for(target, repo_root, src_dir, default_ext):
+    """Find test files for a source file or symbol."""
+    if not target or not isinstance(target, str):
+        return "ERROR: target must be a non-empty string"
+    test_root = os.path.join(repo_root, src_dir.replace("src/main", "src/test", 1))
+    if not os.path.isdir(test_root):
+        # Fall back to the conventional test directory under repo_root
+        test_root = os.path.join(repo_root, "src", "test")
+        if not os.path.isdir(test_root):
+            return f"ERROR: no test directory found at src/test"
+    candidates = []
+    if "/" in target and target.endswith(default_ext):
+        # Target is a source path. Map to conventional test path: X.scala → XTest.scala / XSpec.scala
+        base = os.path.basename(target)
+        stem = base[:-len(default_ext)]
+        for suffix in ("Test", "Spec", ""):
+            for dirpath, _, files in os.walk(test_root):
+                for fn in files:
+                    if fn == f"{stem}{suffix}{default_ext}":
+                        rel = os.path.relpath(os.path.join(dirpath, fn), repo_root)
+                        if rel not in candidates:
+                            candidates.append(rel)
+    # Also grep for the target name in test files (covers symbol case and additional matches)
+    name = os.path.basename(target)
+    if name.endswith(default_ext):
+        name = name[:-len(default_ext)]
+    if re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", name):
+        pattern = re.compile(rf"\b{re.escape(name)}\b")
+        for dirpath, _, files in os.walk(test_root):
+            for fn in files:
+                if not fn.endswith(default_ext):
+                    continue
+                full = os.path.join(dirpath, fn)
+                try:
+                    with open(full, encoding="utf-8", errors="ignore") as f:
+                        if pattern.search(f.read()):
+                            rel = os.path.relpath(full, repo_root)
+                            if rel not in candidates:
+                                candidates.append(rel)
+                except OSError:
+                    continue
+                if len(candidates) >= 20:
+                    break
+            if len(candidates) >= 20:
+                break
+    if not candidates:
+        return f"No tests found for '{target}' under {os.path.relpath(test_root, repo_root)}"
+    out = [f"Tests for '{target}':"]
+    for rel in candidates[:20]:
+        out.append(f"  {rel}")
+    return _truncate("\n".join(out))
+
+
+class ToolRunner:
+    """Dispatches tool calls to the right implementation. Stateless across calls."""
+
+    def __init__(self, cfg, repo_root):
+        self._cfg = cfg
+        self._repo_root = repo_root
+
+    def run(self, name, args):
+        """Execute a tool call. Returns a string. Never raises."""
+        if not isinstance(args, dict):
+            return f"ERROR: tool args must be an object, got {type(args).__name__}"
+        try:
+            if name == "grep_codebase":
+                return grep_codebase(
+                    pattern=args.get("pattern", ""),
+                    path_glob=args.get("path_glob", ""),
+                    repo_root=self._repo_root,
+                    src_dir=self._cfg.codebase_src_dir,
+                    default_ext=self._cfg.codebase_file_ext,
+                )
+            if name == "read_file":
+                return read_file(
+                    path=args.get("path", ""),
+                    start_line=args.get("start_line", 1),
+                    end_line=args.get("end_line", -2),
+                    repo_root=self._repo_root,
+                )
+            if name == "list_dir":
+                return list_dir(
+                    path=args.get("path", ""),
+                    repo_root=self._repo_root,
+                )
+            if name == "find_callers":
+                return find_callers(
+                    symbol=args.get("symbol", ""),
+                    repo_root=self._repo_root,
+                    src_dir=self._cfg.codebase_src_dir,
+                    default_ext=self._cfg.codebase_file_ext,
+                )
+            if name == "find_tests_for":
+                return find_tests_for(
+                    target=args.get("target", ""),
+                    repo_root=self._repo_root,
+                    src_dir=self._cfg.codebase_src_dir,
+                    default_ext=self._cfg.codebase_file_ext,
+                )
+            return f"ERROR: unknown tool '{name}'"
+        except Exception as e:
+            logger.error("Tool %s raised: %s", name, type(e).__name__)
+            return f"ERROR: tool {name} failed: {type(e).__name__}: {e}"

--- a/src/scripts/tests/conftest.py
+++ b/src/scripts/tests/conftest.py
@@ -14,7 +14,12 @@ def isolate_sm_env(monkeypatch):
         "SM_ISSUE_RESPOND_PROMPT",
         "SM_PR_FILE_REVIEW_PROMPT",
         "SM_PR_FILE_REVIEW_REPORT_PROMPT",
+        "SM_PR_INVESTIGATOR_PROMPT",
+        "SM_PR_CRITIC_PROMPT",
         "SM_FOLLOWUP_PROMPT",
         "PR_FILE_REVIEW_REPORT_PROMPT",
+        "PR_INVESTIGATOR_PROMPT",
+        "PR_CRITIC_PROMPT",
+        "BOT_AGENT_PIPELINE",
     ):
         monkeypatch.delenv(var, raising=False)

--- a/src/scripts/tests/conftest.py
+++ b/src/scripts/tests/conftest.py
@@ -16,10 +16,12 @@ def isolate_sm_env(monkeypatch):
         "SM_PR_FILE_REVIEW_REPORT_PROMPT",
         "SM_PR_INVESTIGATOR_PROMPT",
         "SM_PR_CRITIC_PROMPT",
+        "SM_PR_REPORTER_PROMPT",
         "SM_FOLLOWUP_PROMPT",
         "PR_FILE_REVIEW_REPORT_PROMPT",
         "PR_INVESTIGATOR_PROMPT",
         "PR_CRITIC_PROMPT",
+        "PR_REPORTER_PROMPT",
         "BOT_AGENT_PIPELINE",
     ):
         monkeypatch.delenv(var, raising=False)

--- a/src/scripts/tests/test_agent_loop.py
+++ b/src/scripts/tests/test_agent_loop.py
@@ -1,0 +1,341 @@
+"""Tests for issue_bot.agent_loop — the multi-turn tool-use loop."""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from issue_bot.agent_loop import run, AgentCaps
+
+
+PRICING = {
+    "input_per_million": 15.0,
+    "output_per_million": 75.0,
+    "cache_read_per_million": 1.5,
+    "cache_write_per_million": 18.75,
+}
+
+
+class FakeBedrockClient:
+    """Records calls; returns canned responses in sequence."""
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    def converse_with_tools(self, system_prompt, messages, tool_specs, max_tokens=8000, temperature=0.3):
+        self.calls.append({
+            "system_prompt": system_prompt,
+            "messages": [m for m in messages],
+            "tool_specs": tool_specs,
+            "max_tokens": max_tokens,
+        })
+        if not self._responses:
+            return None
+        return self._responses.pop(0)
+
+
+class FakeToolRunner:
+    """Returns the same canned text for every tool call."""
+    def __init__(self, response="tool result"):
+        self.response = response
+        self.calls = []
+
+    def run(self, name, args):
+        self.calls.append({"name": name, "args": args})
+        return self.response
+
+
+def _resp(content_blocks, stop_reason="end_turn", usage=None):
+    return {
+        "stopReason": stop_reason,
+        "output": {"message": {"role": "assistant", "content": content_blocks}},
+        "usage": usage or {"inputTokens": 100, "outputTokens": 50, "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0},
+    }
+
+
+def test_terminates_when_model_emits_text():
+    bedrock = FakeBedrockClient([_resp([{"text": "investigation done"}])])
+    tr = FakeToolRunner()
+    cost = {"cost_usd": 0.0, "cap_usd": 1.0, "cap_hit": False}
+    result = run(
+        bedrock_client=bedrock, agent_name="investigator",
+        system_prompt="sys", user_prompt="user",
+        tool_specs=[], tool_runner=tr,
+        caps=AgentCaps(max_turns=5), cost_tracker=cost, pricing=PRICING,
+    )
+    assert result.text == "investigation done"
+    assert result.turns == 1
+    assert result.tool_calls == 0
+    assert not result.max_turns_reached
+    assert tr.calls == []
+
+
+def test_executes_tool_call_then_terminates():
+    bedrock = FakeBedrockClient([
+        _resp(
+            [{"toolUse": {"toolUseId": "t1", "name": "grep_codebase", "input": {"pattern": "Foo"}}}],
+            stop_reason="tool_use",
+        ),
+        _resp([{"text": "found Foo, done"}]),
+    ])
+    tr = FakeToolRunner("Foo.scala:1:case class Foo")
+    cost = {"cost_usd": 0.0, "cap_usd": 1.0, "cap_hit": False}
+    result = run(
+        bedrock_client=bedrock, agent_name="investigator",
+        system_prompt="sys", user_prompt="user",
+        tool_specs=[], tool_runner=tr,
+        caps=AgentCaps(max_turns=5), cost_tracker=cost, pricing=PRICING,
+    )
+    assert result.text == "found Foo, done"
+    assert result.turns == 2
+    assert result.tool_calls == 1
+    assert tr.calls[0]["name"] == "grep_codebase"
+
+
+def test_hits_max_turns():
+    # Always returns tool_use; never terminates
+    tu_resp = _resp(
+        [{"toolUse": {"toolUseId": "t", "name": "grep_codebase", "input": {"pattern": "x"}}}],
+        stop_reason="tool_use",
+    )
+    bedrock = FakeBedrockClient([tu_resp] * 10)
+    tr = FakeToolRunner()
+    cost = {"cost_usd": 0.0, "cap_usd": 100.0, "cap_hit": False}
+    result = run(
+        bedrock_client=bedrock, agent_name="investigator",
+        system_prompt="sys", user_prompt="user",
+        tool_specs=[], tool_runner=tr,
+        caps=AgentCaps(max_turns=3), cost_tracker=cost, pricing=PRICING,
+    )
+    assert result.max_turns_reached is True
+    assert result.turns == 3
+
+
+def test_per_tool_budget_returns_error_then_continues():
+    bedrock = FakeBedrockClient([
+        _resp(
+            [{"toolUse": {"toolUseId": "t1", "name": "grep_codebase", "input": {"pattern": "a"}}}],
+            stop_reason="tool_use",
+        ),
+        _resp(
+            [{"toolUse": {"toolUseId": "t2", "name": "grep_codebase", "input": {"pattern": "b"}}}],
+            stop_reason="tool_use",
+        ),
+        _resp([{"text": "done"}]),
+    ])
+    tr = FakeToolRunner()
+    cost = {"cost_usd": 0.0, "cap_usd": 100.0, "cap_hit": False}
+    caps = AgentCaps(max_turns=5, per_tool_max_calls={"grep_codebase": 1})
+    result = run(
+        bedrock_client=bedrock, agent_name="investigator",
+        system_prompt="sys", user_prompt="user",
+        tool_specs=[], tool_runner=tr,
+        caps=caps, cost_tracker=cost, pricing=PRICING,
+    )
+    # Second grep should have hit the per-tool budget; the runner should have
+    # been called once (real call) — the second is short-circuited to a budget
+    # message that the model reads as toolResult.
+    assert len(tr.calls) == 1
+    assert result.text == "done"
+
+
+def test_total_tool_call_budget():
+    """max_tool_calls cap stops further tool executions."""
+    tu_resp = _resp(
+        [{"toolUse": {"toolUseId": "t", "name": "grep_codebase", "input": {"pattern": "x"}}}],
+        stop_reason="tool_use",
+    )
+    bedrock = FakeBedrockClient([tu_resp, tu_resp, tu_resp, _resp([{"text": "done"}])])
+    tr = FakeToolRunner()
+    cost = {"cost_usd": 0.0, "cap_usd": 100.0, "cap_hit": False}
+    caps = AgentCaps(max_turns=10, max_tool_calls=2)
+    result = run(
+        bedrock_client=bedrock, agent_name="investigator",
+        system_prompt="sys", user_prompt="user",
+        tool_specs=[], tool_runner=tr,
+        caps=caps, cost_tracker=cost, pricing=PRICING,
+    )
+    # First two calls run; third is short-circuited
+    assert len(tr.calls) == 2
+
+
+def test_cost_cap_triggers_termination():
+    bedrock = FakeBedrockClient([
+        _resp(
+            [{"toolUse": {"toolUseId": "t", "name": "grep_codebase", "input": {"pattern": "x"}}}],
+            stop_reason="tool_use",
+            usage={"inputTokens": 1_000_000, "outputTokens": 0, "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0},
+        ),
+        _resp([{"text": "no"}]),
+    ])
+    tr = FakeToolRunner()
+    cost = {"cost_usd": 0.0, "cap_usd": 1.0, "cap_hit": False}  # cap = $1
+    caps = AgentCaps(max_turns=10)
+    result = run(
+        bedrock_client=bedrock, agent_name="investigator",
+        system_prompt="sys", user_prompt="user",
+        tool_specs=[], tool_runner=tr,
+        caps=caps, cost_tracker=cost, pricing=PRICING,
+    )
+    # First turn cost = 1M * $15/M = $15 → exceeds $1 cap
+    assert cost["cap_hit"] is True
+    # Loop should have terminated before a second bedrock call (after the tools execute)
+    assert result.cost_cap_hit is True
+
+
+def test_bedrock_returns_none_terminates():
+    bedrock = FakeBedrockClient([None])
+    tr = FakeToolRunner()
+    cost = {"cost_usd": 0.0, "cap_usd": 100.0, "cap_hit": False}
+    result = run(
+        bedrock_client=bedrock, agent_name="investigator",
+        system_prompt="sys", user_prompt="user",
+        tool_specs=[], tool_runner=tr,
+        caps=AgentCaps(max_turns=5), cost_tracker=cost, pricing=PRICING,
+    )
+    assert result.error is not None
+    assert "None" in result.error or "circuit" in result.error.lower() or "transient" in result.error.lower()
+
+
+def test_multiple_tool_calls_in_one_turn():
+    bedrock = FakeBedrockClient([
+        _resp(
+            [
+                {"toolUse": {"toolUseId": "t1", "name": "grep_codebase", "input": {"pattern": "A"}}},
+                {"toolUse": {"toolUseId": "t2", "name": "read_file", "input": {"path": "x.scala"}}},
+            ],
+            stop_reason="tool_use",
+        ),
+        _resp([{"text": "done"}]),
+    ])
+    tr = FakeToolRunner()
+    cost = {"cost_usd": 0.0, "cap_usd": 100.0, "cap_hit": False}
+    result = run(
+        bedrock_client=bedrock, agent_name="investigator",
+        system_prompt="sys", user_prompt="user",
+        tool_specs=[], tool_runner=tr,
+        caps=AgentCaps(max_turns=5), cost_tracker=cost, pricing=PRICING,
+    )
+    assert len(tr.calls) == 2
+    assert result.tool_calls == 2
+
+
+def test_tool_trace_records_each_call():
+    bedrock = FakeBedrockClient([
+        _resp(
+            [{"toolUse": {"toolUseId": "t1", "name": "grep_codebase", "input": {"pattern": "Foo"}}}],
+            stop_reason="tool_use",
+        ),
+        _resp([{"text": "done"}]),
+    ])
+    tr = FakeToolRunner("result text")
+    cost = {"cost_usd": 0.0, "cap_usd": 100.0, "cap_hit": False}
+    result = run(
+        bedrock_client=bedrock, agent_name="my-agent",
+        system_prompt="sys", user_prompt="user",
+        tool_specs=[], tool_runner=tr,
+        caps=AgentCaps(max_turns=5), cost_tracker=cost, pricing=PRICING,
+    )
+    assert len(result.tool_trace) == 1
+    entry = result.tool_trace[0]
+    assert entry["agent"] == "my-agent"
+    assert entry["tool"] == "grep_codebase"
+    assert entry["args"] == {"pattern": "Foo"}
+
+
+def test_token_accounting():
+    bedrock = FakeBedrockClient([
+        _resp(
+            [{"toolUse": {"toolUseId": "t", "name": "grep_codebase", "input": {"pattern": "x"}}}],
+            stop_reason="tool_use",
+            usage={"inputTokens": 100, "outputTokens": 50, "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0},
+        ),
+        _resp(
+            [{"text": "done"}],
+            usage={"inputTokens": 200, "outputTokens": 30, "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0},
+        ),
+    ])
+    tr = FakeToolRunner()
+    cost = {"cost_usd": 0.0, "cap_usd": 100.0, "cap_hit": False}
+    result = run(
+        bedrock_client=bedrock, agent_name="investigator",
+        system_prompt="sys", user_prompt="user",
+        tool_specs=[], tool_runner=tr,
+        caps=AgentCaps(max_turns=5), cost_tracker=cost, pricing=PRICING,
+    )
+    assert result.input_tokens == 300
+    assert result.output_tokens == 80
+
+
+def test_max_turns_recovers_text_from_assistant_message():
+    """When max_turns hits and the last assistant turn carried text alongside
+    tool_use blocks, that text must be recovered (not replaced by boilerplate).
+    """
+    # Each turn: assistant emits text + tool_use; user appends toolResult.
+    # After max_turns, the last assistant message has both text and tool_use blocks.
+    tu_with_text = _resp(
+        [
+            {"text": "I am still investigating; partial finding C1 is..."},
+            {"toolUse": {"toolUseId": "t", "name": "grep_codebase", "input": {"pattern": "x"}}},
+        ],
+        stop_reason="tool_use",
+    )
+    bedrock = FakeBedrockClient([tu_with_text] * 5)
+    tr = FakeToolRunner()
+    cost = {"cost_usd": 0.0, "cap_usd": 100.0, "cap_hit": False}
+    result = run(
+        bedrock_client=bedrock, agent_name="investigator",
+        system_prompt="sys", user_prompt="user",
+        tool_specs=[], tool_runner=tr,
+        caps=AgentCaps(max_turns=2), cost_tracker=cost, pricing=PRICING,
+    )
+    assert result.max_turns_reached is True
+    # Text must have been recovered, not replaced with boilerplate
+    assert "partial finding C1" in result.text
+    assert "max_turns" not in result.text
+
+
+def test_max_turns_falls_back_to_boilerplate_if_no_text():
+    """If no assistant message ever carried text, the boilerplate fires."""
+    tu_only = _resp(
+        [{"toolUse": {"toolUseId": "t", "name": "grep_codebase", "input": {"pattern": "x"}}}],
+        stop_reason="tool_use",
+    )
+    bedrock = FakeBedrockClient([tu_only] * 5)
+    tr = FakeToolRunner()
+    cost = {"cost_usd": 0.0, "cap_usd": 100.0, "cap_hit": False}
+    result = run(
+        bedrock_client=bedrock, agent_name="investigator",
+        system_prompt="sys", user_prompt="user",
+        tool_specs=[], tool_runner=tr,
+        caps=AgentCaps(max_turns=2), cost_tracker=cost, pricing=PRICING,
+    )
+    assert result.max_turns_reached is True
+    assert "max_turns" in result.text
+
+
+def test_shared_cost_tracker_across_agents():
+    """Two agent loops share a cost_tracker to enforce a global budget."""
+    bedrock = FakeBedrockClient([
+        _resp(
+            [{"text": "agent 1 done"}],
+            usage={"inputTokens": 30_000, "outputTokens": 0, "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0},
+        ),
+        _resp(
+            [{"text": "agent 2 done"}],
+            usage={"inputTokens": 30_000, "outputTokens": 0, "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0},
+        ),
+    ])
+    tr = FakeToolRunner()
+    cost = {"cost_usd": 0.0, "cap_usd": 100.0, "cap_hit": False}
+    r1 = run(bedrock_client=bedrock, agent_name="a", system_prompt="s", user_prompt="u",
+             tool_specs=[], tool_runner=tr, caps=AgentCaps(max_turns=2),
+             cost_tracker=cost, pricing=PRICING)
+    r2 = run(bedrock_client=bedrock, agent_name="b", system_prompt="s", user_prompt="u",
+             tool_specs=[], tool_runner=tr, caps=AgentCaps(max_turns=2),
+             cost_tracker=cost, pricing=PRICING)
+    assert r1.text == "agent 1 done"
+    assert r2.text == "agent 2 done"
+    # Cumulative cost should equal sum of both (60K input tokens × $15/M = $0.90)
+    assert cost["cost_usd"] == pytest.approx(0.90, abs=0.001)

--- a/src/scripts/tests/test_agent_loop.py
+++ b/src/scripts/tests/test_agent_loop.py
@@ -237,35 +237,9 @@ def test_max_turns_falls_back_to_boilerplate_if_no_text():
     assert "max_turns" in result.text
 
 
-def test_fatal_flag_only_set_on_fatal_errors():
-    """Bedrock errors / empty responses are fatal; structural caps are not.
-    The pipeline relies on this distinction to decide between escalating
-    and accepting partial output.
-    """
-    # Fatal: bedrock returns None
-    bedrock_none = FakeBedrockClient([None])
-    r1 = _run(bedrock_none, FakeToolRunner())
-    assert r1.error is not None
-    assert r1.fatal is True
-
-    # Non-fatal: hits max_turns with valid text
-    tu_with_text = _resp(
-        [
-            {"text": "VERDICT: C1 | UPHELD | ok"},
-            {"toolUse": {"toolUseId": "t", "name": "grep_codebase", "input": {"pattern": "x"}}},
-        ],
-        stop_reason="tool_use",
-    )
-    bedrock_loop = FakeBedrockClient([tu_with_text] * 5)
-    r2 = _run(bedrock_loop, FakeToolRunner(), caps=AgentCaps(max_turns=2))
-    assert r2.max_turns_reached is True
-    assert r2.fatal is False
-    assert "VERDICT" in r2.text
-
-
 def test_wall_clock_cap_terminates_loop():
-    """A pipeline_deadline that has already passed terminates immediately
-    and is NOT marked fatal — partial findings should still flow downstream.
+    """A pipeline_deadline already in the past terminates the loop and
+    leaves an error label so callers can see why it stopped.
     """
     import time as _time
     tu = _resp(
@@ -281,4 +255,3 @@ def test_wall_clock_cap_terminates_loop():
         pipeline_deadline=_time.monotonic() - 1,  # already in the past
     )
     assert result.error and "wall-clock" in result.error
-    assert result.fatal is False

--- a/src/scripts/tests/test_agent_loop.py
+++ b/src/scripts/tests/test_agent_loop.py
@@ -255,3 +255,83 @@ def test_wall_clock_cap_terminates_loop():
         pipeline_deadline=_time.monotonic() - 1,  # already in the past
     )
     assert result.error and "wall-clock" in result.error
+
+
+# -----------------------------------------------------------------------------
+# User-content composition: trusted vs untrusted text and guardrail wrapping.
+# -----------------------------------------------------------------------------
+
+class _GuardedFakeClient(FakeBedrockClient):
+    """Fake client that reports it has a guardrail configured."""
+    has_guardrail = True
+
+
+class _UnguardedFakeClient(FakeBedrockClient):
+    """Fake client that explicitly reports no guardrail."""
+    has_guardrail = False
+
+
+def test_user_prompt_alone_yields_single_text_block():
+    """No untrusted_user_prompt → single canonical text block, regardless
+    of guardrail (helper layer wraps it later if needed)."""
+    bedrock = _UnguardedFakeClient([_resp([{"text": "ok"}])])
+    run(
+        bedrock_client=bedrock, agent_name="critic",
+        system_prompt="sys", user_prompt="trusted-only",
+        tool_specs=[], tool_runner=FakeToolRunner(),
+        caps=AgentCaps(max_turns=1),
+    )
+    content = bedrock.calls[0]["messages"][0]["content"]
+    assert content == [{"text": "trusted-only"}]
+
+
+def test_untrusted_with_guardrail_splits_blocks():
+    """When the client has a guardrail AND there is untrusted input, the
+    user message gets two content blocks: trusted text + guardContent."""
+    bedrock = _GuardedFakeClient([_resp([{"text": "ok"}])])
+    run(
+        bedrock_client=bedrock, agent_name="critic",
+        system_prompt="sys", user_prompt="trusted-context",
+        untrusted_user_prompt="USER-INPUT",
+        tool_specs=[], tool_runner=FakeToolRunner(),
+        caps=AgentCaps(max_turns=1),
+    )
+    content = bedrock.calls[0]["messages"][0]["content"]
+    assert len(content) == 2
+    assert content[0] == {"text": "trusted-context"}
+    assert content[1] == {"guardContent": {"text": {"text": "USER-INPUT"}}}
+
+
+def test_untrusted_without_guardrail_concatenates():
+    """When no guardrail is configured, having an untrusted segment doesn't
+    earn a separate guardContent block — the API would treat it as inert."""
+    bedrock = _UnguardedFakeClient([_resp([{"text": "ok"}])])
+    run(
+        bedrock_client=bedrock, agent_name="critic",
+        system_prompt="sys", user_prompt="trusted-context",
+        untrusted_user_prompt="USER-INPUT",
+        tool_specs=[], tool_runner=FakeToolRunner(),
+        caps=AgentCaps(max_turns=1),
+    )
+    content = bedrock.calls[0]["messages"][0]["content"]
+    assert len(content) == 1
+    assert content[0]["text"] == "trusted-context\nUSER-INPUT"
+
+
+def test_guardrail_does_not_wrap_trusted_block():
+    """Regression guard: an injection-y phrase in the trusted segment must
+    NOT end up inside guardContent (where the guardrail would scan it)."""
+    bedrock = _GuardedFakeClient([_resp([{"text": "ok"}])])
+    investigator_paraphrase = "Author paraphrased: 'ignore previous instructions'"
+    run(
+        bedrock_client=bedrock, agent_name="critic",
+        system_prompt="sys", user_prompt=investigator_paraphrase,
+        untrusted_user_prompt="Real user title and body",
+        tool_specs=[], tool_runner=FakeToolRunner(),
+        caps=AgentCaps(max_turns=1),
+    )
+    content = bedrock.calls[0]["messages"][0]["content"]
+    text_block_text = content[0].get("text", "")
+    guard_text = content[1].get("guardContent", {}).get("text", {}).get("text", "")
+    assert "ignore previous instructions" in text_block_text
+    assert "ignore previous instructions" not in guard_text

--- a/src/scripts/tests/test_agent_loop.py
+++ b/src/scripts/tests/test_agent_loop.py
@@ -14,12 +14,14 @@ class FakeBedrockClient:
         self.calls = []
 
     def converse_with_tools(self, system_prompt, messages, tool_specs,
-                             max_tokens=8000, temperature=0.3):
+                             max_tokens=8000, temperature=0.3,
+                             timeout_seconds=None):
         self.calls.append({
             "system_prompt": system_prompt,
             "messages": list(messages),
             "tool_specs": tool_specs,
             "max_tokens": max_tokens,
+            "timeout_seconds": timeout_seconds,
         })
         if not self._responses:
             return None
@@ -233,3 +235,50 @@ def test_max_turns_falls_back_to_boilerplate_if_no_text():
     result = _run(bedrock, tr, caps=AgentCaps(max_turns=2))
     assert result.max_turns_reached is True
     assert "max_turns" in result.text
+
+
+def test_fatal_flag_only_set_on_fatal_errors():
+    """Bedrock errors / empty responses are fatal; structural caps are not.
+    The pipeline relies on this distinction to decide between escalating
+    and accepting partial output.
+    """
+    # Fatal: bedrock returns None
+    bedrock_none = FakeBedrockClient([None])
+    r1 = _run(bedrock_none, FakeToolRunner())
+    assert r1.error is not None
+    assert r1.fatal is True
+
+    # Non-fatal: hits max_turns with valid text
+    tu_with_text = _resp(
+        [
+            {"text": "VERDICT: C1 | UPHELD | ok"},
+            {"toolUse": {"toolUseId": "t", "name": "grep_codebase", "input": {"pattern": "x"}}},
+        ],
+        stop_reason="tool_use",
+    )
+    bedrock_loop = FakeBedrockClient([tu_with_text] * 5)
+    r2 = _run(bedrock_loop, FakeToolRunner(), caps=AgentCaps(max_turns=2))
+    assert r2.max_turns_reached is True
+    assert r2.fatal is False
+    assert "VERDICT" in r2.text
+
+
+def test_wall_clock_cap_terminates_loop():
+    """A pipeline_deadline that has already passed terminates immediately
+    and is NOT marked fatal — partial findings should still flow downstream.
+    """
+    import time as _time
+    tu = _resp(
+        [{"toolUse": {"toolUseId": "t", "name": "grep_codebase", "input": {"pattern": "x"}}}],
+        stop_reason="tool_use",
+    )
+    bedrock = FakeBedrockClient([tu] * 5)
+    result = run(
+        bedrock_client=bedrock, agent_name="critic",
+        system_prompt="sys", user_prompt="user",
+        tool_specs=[], tool_runner=FakeToolRunner(),
+        caps=AgentCaps(max_turns=10),
+        pipeline_deadline=_time.monotonic() - 1,  # already in the past
+    )
+    assert result.error and "wall-clock" in result.error
+    assert result.fatal is False

--- a/src/scripts/tests/test_agent_loop.py
+++ b/src/scripts/tests/test_agent_loop.py
@@ -2,19 +2,9 @@
 import os
 import sys
 
-import pytest
-
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 
 from issue_bot.agent_loop import run, AgentCaps
-
-
-PRICING = {
-    "input_per_million": 15.0,
-    "output_per_million": 75.0,
-    "cache_read_per_million": 1.5,
-    "cache_write_per_million": 18.75,
-}
 
 
 class FakeBedrockClient:
@@ -23,10 +13,11 @@ class FakeBedrockClient:
         self._responses = list(responses)
         self.calls = []
 
-    def converse_with_tools(self, system_prompt, messages, tool_specs, max_tokens=8000, temperature=0.3):
+    def converse_with_tools(self, system_prompt, messages, tool_specs,
+                             max_tokens=8000, temperature=0.3):
         self.calls.append({
             "system_prompt": system_prompt,
-            "messages": [m for m in messages],
+            "messages": list(messages),
             "tool_specs": tool_specs,
             "max_tokens": max_tokens,
         })
@@ -50,20 +41,27 @@ def _resp(content_blocks, stop_reason="end_turn", usage=None):
     return {
         "stopReason": stop_reason,
         "output": {"message": {"role": "assistant", "content": content_blocks}},
-        "usage": usage or {"inputTokens": 100, "outputTokens": 50, "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0},
+        "usage": usage or {
+            "inputTokens": 100, "outputTokens": 50,
+            "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0,
+        },
     }
+
+
+def _run(bedrock, tool_runner, caps=None, agent_name="investigator"):
+    """Helper to invoke the loop with default params for tests."""
+    return run(
+        bedrock_client=bedrock, agent_name=agent_name,
+        system_prompt="sys", user_prompt="user",
+        tool_specs=[], tool_runner=tool_runner,
+        caps=caps or AgentCaps(max_turns=5),
+    )
 
 
 def test_terminates_when_model_emits_text():
     bedrock = FakeBedrockClient([_resp([{"text": "investigation done"}])])
     tr = FakeToolRunner()
-    cost = {"cost_usd": 0.0, "cap_usd": 1.0, "cap_hit": False}
-    result = run(
-        bedrock_client=bedrock, agent_name="investigator",
-        system_prompt="sys", user_prompt="user",
-        tool_specs=[], tool_runner=tr,
-        caps=AgentCaps(max_turns=5), cost_tracker=cost, pricing=PRICING,
-    )
+    result = _run(bedrock, tr)
     assert result.text == "investigation done"
     assert result.turns == 1
     assert result.tool_calls == 0
@@ -80,13 +78,7 @@ def test_executes_tool_call_then_terminates():
         _resp([{"text": "found Foo, done"}]),
     ])
     tr = FakeToolRunner("Foo.scala:1:case class Foo")
-    cost = {"cost_usd": 0.0, "cap_usd": 1.0, "cap_hit": False}
-    result = run(
-        bedrock_client=bedrock, agent_name="investigator",
-        system_prompt="sys", user_prompt="user",
-        tool_specs=[], tool_runner=tr,
-        caps=AgentCaps(max_turns=5), cost_tracker=cost, pricing=PRICING,
-    )
+    result = _run(bedrock, tr)
     assert result.text == "found Foo, done"
     assert result.turns == 2
     assert result.tool_calls == 1
@@ -94,20 +86,13 @@ def test_executes_tool_call_then_terminates():
 
 
 def test_hits_max_turns():
-    # Always returns tool_use; never terminates
     tu_resp = _resp(
         [{"toolUse": {"toolUseId": "t", "name": "grep_codebase", "input": {"pattern": "x"}}}],
         stop_reason="tool_use",
     )
     bedrock = FakeBedrockClient([tu_resp] * 10)
     tr = FakeToolRunner()
-    cost = {"cost_usd": 0.0, "cap_usd": 100.0, "cap_hit": False}
-    result = run(
-        bedrock_client=bedrock, agent_name="investigator",
-        system_prompt="sys", user_prompt="user",
-        tool_specs=[], tool_runner=tr,
-        caps=AgentCaps(max_turns=3), cost_tracker=cost, pricing=PRICING,
-    )
+    result = _run(bedrock, tr, caps=AgentCaps(max_turns=3))
     assert result.max_turns_reached is True
     assert result.turns == 3
 
@@ -125,77 +110,44 @@ def test_per_tool_budget_returns_error_then_continues():
         _resp([{"text": "done"}]),
     ])
     tr = FakeToolRunner()
-    cost = {"cost_usd": 0.0, "cap_usd": 100.0, "cap_hit": False}
     caps = AgentCaps(max_turns=5, per_tool_max_calls={"grep_codebase": 1})
-    result = run(
-        bedrock_client=bedrock, agent_name="investigator",
-        system_prompt="sys", user_prompt="user",
-        tool_specs=[], tool_runner=tr,
-        caps=caps, cost_tracker=cost, pricing=PRICING,
-    )
-    # Second grep should have hit the per-tool budget; the runner should have
-    # been called once (real call) — the second is short-circuited to a budget
-    # message that the model reads as toolResult.
+    result = _run(bedrock, tr, caps=caps)
+    # Second grep hits the per-tool budget; the runner is only called once
+    # because the second is short-circuited to a budget message.
     assert len(tr.calls) == 1
     assert result.text == "done"
 
 
 def test_total_tool_call_budget():
-    """max_tool_calls cap stops further tool executions."""
     tu_resp = _resp(
         [{"toolUse": {"toolUseId": "t", "name": "grep_codebase", "input": {"pattern": "x"}}}],
         stop_reason="tool_use",
     )
     bedrock = FakeBedrockClient([tu_resp, tu_resp, tu_resp, _resp([{"text": "done"}])])
     tr = FakeToolRunner()
-    cost = {"cost_usd": 0.0, "cap_usd": 100.0, "cap_hit": False}
     caps = AgentCaps(max_turns=10, max_tool_calls=2)
-    result = run(
-        bedrock_client=bedrock, agent_name="investigator",
-        system_prompt="sys", user_prompt="user",
-        tool_specs=[], tool_runner=tr,
-        caps=caps, cost_tracker=cost, pricing=PRICING,
-    )
-    # First two calls run; third is short-circuited
+    _run(bedrock, tr, caps=caps)
     assert len(tr.calls) == 2
-
-
-def test_cost_cap_triggers_termination():
-    bedrock = FakeBedrockClient([
-        _resp(
-            [{"toolUse": {"toolUseId": "t", "name": "grep_codebase", "input": {"pattern": "x"}}}],
-            stop_reason="tool_use",
-            usage={"inputTokens": 1_000_000, "outputTokens": 0, "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0},
-        ),
-        _resp([{"text": "no"}]),
-    ])
-    tr = FakeToolRunner()
-    cost = {"cost_usd": 0.0, "cap_usd": 1.0, "cap_hit": False}  # cap = $1
-    caps = AgentCaps(max_turns=10)
-    result = run(
-        bedrock_client=bedrock, agent_name="investigator",
-        system_prompt="sys", user_prompt="user",
-        tool_specs=[], tool_runner=tr,
-        caps=caps, cost_tracker=cost, pricing=PRICING,
-    )
-    # First turn cost = 1M * $15/M = $15 → exceeds $1 cap
-    assert cost["cap_hit"] is True
-    # Loop should have terminated before a second bedrock call (after the tools execute)
-    assert result.cost_cap_hit is True
 
 
 def test_bedrock_returns_none_terminates():
     bedrock = FakeBedrockClient([None])
     tr = FakeToolRunner()
-    cost = {"cost_usd": 0.0, "cap_usd": 100.0, "cap_hit": False}
-    result = run(
-        bedrock_client=bedrock, agent_name="investigator",
-        system_prompt="sys", user_prompt="user",
-        tool_specs=[], tool_runner=tr,
-        caps=AgentCaps(max_turns=5), cost_tracker=cost, pricing=PRICING,
-    )
+    result = _run(bedrock, tr)
     assert result.error is not None
-    assert "None" in result.error or "circuit" in result.error.lower() or "transient" in result.error.lower()
+    assert "None" in result.error or "transient" in result.error.lower()
+    assert result.max_turns_reached is False
+
+
+def test_bedrock_exception_terminates():
+    class ExplodingClient:
+        def converse_with_tools(self, **_):
+            raise RuntimeError("boom")
+    tr = FakeToolRunner()
+    result = _run(ExplodingClient(), tr)
+    assert result.error is not None
+    assert "RuntimeError" in result.error
+    assert result.max_turns_reached is False
 
 
 def test_multiple_tool_calls_in_one_turn():
@@ -210,13 +162,7 @@ def test_multiple_tool_calls_in_one_turn():
         _resp([{"text": "done"}]),
     ])
     tr = FakeToolRunner()
-    cost = {"cost_usd": 0.0, "cap_usd": 100.0, "cap_hit": False}
-    result = run(
-        bedrock_client=bedrock, agent_name="investigator",
-        system_prompt="sys", user_prompt="user",
-        tool_specs=[], tool_runner=tr,
-        caps=AgentCaps(max_turns=5), cost_tracker=cost, pricing=PRICING,
-    )
+    result = _run(bedrock, tr)
     assert len(tr.calls) == 2
     assert result.tool_calls == 2
 
@@ -230,13 +176,7 @@ def test_tool_trace_records_each_call():
         _resp([{"text": "done"}]),
     ])
     tr = FakeToolRunner("result text")
-    cost = {"cost_usd": 0.0, "cap_usd": 100.0, "cap_hit": False}
-    result = run(
-        bedrock_client=bedrock, agent_name="my-agent",
-        system_prompt="sys", user_prompt="user",
-        tool_specs=[], tool_runner=tr,
-        caps=AgentCaps(max_turns=5), cost_tracker=cost, pricing=PRICING,
-    )
+    result = _run(bedrock, tr, agent_name="my-agent")
     assert len(result.tool_trace) == 1
     entry = result.tool_trace[0]
     assert entry["agent"] == "my-agent"
@@ -249,21 +189,17 @@ def test_token_accounting():
         _resp(
             [{"toolUse": {"toolUseId": "t", "name": "grep_codebase", "input": {"pattern": "x"}}}],
             stop_reason="tool_use",
-            usage={"inputTokens": 100, "outputTokens": 50, "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0},
+            usage={"inputTokens": 100, "outputTokens": 50,
+                   "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0},
         ),
         _resp(
             [{"text": "done"}],
-            usage={"inputTokens": 200, "outputTokens": 30, "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0},
+            usage={"inputTokens": 200, "outputTokens": 30,
+                   "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0},
         ),
     ])
     tr = FakeToolRunner()
-    cost = {"cost_usd": 0.0, "cap_usd": 100.0, "cap_hit": False}
-    result = run(
-        bedrock_client=bedrock, agent_name="investigator",
-        system_prompt="sys", user_prompt="user",
-        tool_specs=[], tool_runner=tr,
-        caps=AgentCaps(max_turns=5), cost_tracker=cost, pricing=PRICING,
-    )
+    result = _run(bedrock, tr)
     assert result.input_tokens == 300
     assert result.output_tokens == 80
 
@@ -272,8 +208,6 @@ def test_max_turns_recovers_text_from_assistant_message():
     """When max_turns hits and the last assistant turn carried text alongside
     tool_use blocks, that text must be recovered (not replaced by boilerplate).
     """
-    # Each turn: assistant emits text + tool_use; user appends toolResult.
-    # After max_turns, the last assistant message has both text and tool_use blocks.
     tu_with_text = _resp(
         [
             {"text": "I am still investigating; partial finding C1 is..."},
@@ -283,59 +217,19 @@ def test_max_turns_recovers_text_from_assistant_message():
     )
     bedrock = FakeBedrockClient([tu_with_text] * 5)
     tr = FakeToolRunner()
-    cost = {"cost_usd": 0.0, "cap_usd": 100.0, "cap_hit": False}
-    result = run(
-        bedrock_client=bedrock, agent_name="investigator",
-        system_prompt="sys", user_prompt="user",
-        tool_specs=[], tool_runner=tr,
-        caps=AgentCaps(max_turns=2), cost_tracker=cost, pricing=PRICING,
-    )
+    result = _run(bedrock, tr, caps=AgentCaps(max_turns=2))
     assert result.max_turns_reached is True
-    # Text must have been recovered, not replaced with boilerplate
     assert "partial finding C1" in result.text
     assert "max_turns" not in result.text
 
 
 def test_max_turns_falls_back_to_boilerplate_if_no_text():
-    """If no assistant message ever carried text, the boilerplate fires."""
     tu_only = _resp(
         [{"toolUse": {"toolUseId": "t", "name": "grep_codebase", "input": {"pattern": "x"}}}],
         stop_reason="tool_use",
     )
     bedrock = FakeBedrockClient([tu_only] * 5)
     tr = FakeToolRunner()
-    cost = {"cost_usd": 0.0, "cap_usd": 100.0, "cap_hit": False}
-    result = run(
-        bedrock_client=bedrock, agent_name="investigator",
-        system_prompt="sys", user_prompt="user",
-        tool_specs=[], tool_runner=tr,
-        caps=AgentCaps(max_turns=2), cost_tracker=cost, pricing=PRICING,
-    )
+    result = _run(bedrock, tr, caps=AgentCaps(max_turns=2))
     assert result.max_turns_reached is True
     assert "max_turns" in result.text
-
-
-def test_shared_cost_tracker_across_agents():
-    """Two agent loops share a cost_tracker to enforce a global budget."""
-    bedrock = FakeBedrockClient([
-        _resp(
-            [{"text": "agent 1 done"}],
-            usage={"inputTokens": 30_000, "outputTokens": 0, "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0},
-        ),
-        _resp(
-            [{"text": "agent 2 done"}],
-            usage={"inputTokens": 30_000, "outputTokens": 0, "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0},
-        ),
-    ])
-    tr = FakeToolRunner()
-    cost = {"cost_usd": 0.0, "cap_usd": 100.0, "cap_hit": False}
-    r1 = run(bedrock_client=bedrock, agent_name="a", system_prompt="s", user_prompt="u",
-             tool_specs=[], tool_runner=tr, caps=AgentCaps(max_turns=2),
-             cost_tracker=cost, pricing=PRICING)
-    r2 = run(bedrock_client=bedrock, agent_name="b", system_prompt="s", user_prompt="u",
-             tool_specs=[], tool_runner=tr, caps=AgentCaps(max_turns=2),
-             cost_tracker=cost, pricing=PRICING)
-    assert r1.text == "agent 1 done"
-    assert r2.text == "agent 2 done"
-    # Cumulative cost should equal sum of both (60K input tokens × $15/M = $0.90)
-    assert cost["cost_usd"] == pytest.approx(0.90, abs=0.001)

--- a/src/scripts/tests/test_bot.py
+++ b/src/scripts/tests/test_bot.py
@@ -538,6 +538,142 @@ class TestSplitPrompt:
         assert "guardrailConfig" in kwargs
         assert kwargs["guardrailConfig"]["guardrailIdentifier"] == "gr-123"
 
+    def test_invoke_with_usage_returns_usage_dict(self):
+        client = self._make_client(guardrail_id="gr-123")
+        self._mock_converse(client)
+        client._client.converse.return_value = {
+            "stopReason": "end_turn",
+            "output": {"message": {"content": [{"text": "ok"}]}},
+            "usage": {"inputTokens": 42, "outputTokens": 7,
+                      "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0},
+        }
+        text, usage = client.invoke_with_usage("system", "user")
+        assert text == "ok"
+        assert usage["inputTokens"] == 42
+
+    def test_invoke_with_usage_does_not_set_cache_point(self):
+        """Reporter (sole caller of invoke_with_usage) embeds the per-PR diff
+        in its system prompt so the cache prefix never repeats. Setting
+        cachePoint would only pay the 1.25x cache-write premium without ever
+        yielding a read."""
+        client = self._make_client(guardrail_id="gr-123")
+        self._mock_converse(client)
+        client.invoke_with_usage("instructions + diff", "Title: t\nBody: b")
+        kwargs = client._client.converse.call_args[1]
+        system = kwargs["system"]
+        assert len(system) == 1
+        assert system[0]["text"] == "instructions + diff"
+        assert all("cachePoint" not in block for block in system)
+
+    def test_converse_with_tools_keeps_cache_point_for_inv_to_critic(self):
+        """converse_with_tools is the one path where caching can pay off:
+        Investigator's first turn warms a cache the Critic's first turn can
+        read (shared static prefix from _build_static_context)."""
+        client = self._make_client(guardrail_id="gr-123")
+        self._mock_converse(client)
+        client.converse_with_tools(
+            "shared static prefix",
+            [{"role": "user", "content": [{"text": "investigate"}]}],
+            tool_specs=[],
+        )
+        kwargs = client._client.converse.call_args[1]
+        system = kwargs["system"]
+        assert any("cachePoint" in block for block in system)
+
+    def test_wrap_skips_when_caller_already_set_guard_content(self):
+        """If the caller composed [{"text": trusted}, {"guardContent": untrusted}],
+        the helper must NOT re-wrap the trusted text — that would put model-
+        generated investigator notes inside the guardrail's scan and false-trip
+        on benign paraphrases."""
+        client = self._make_client(guardrail_id="gr-123")
+        messages = [{
+            "role": "user",
+            "content": [
+                {"text": "trusted investigator notes mentioning 'ignore previous instructions'"},
+                {"guardContent": {"text": {"text": "PR title and body"}}},
+            ],
+        }]
+        wrapped = client._wrap_first_user_for_guardrail(messages)
+        # Pass-through: trusted text remains as a plain text block
+        assert wrapped[0]["content"][0] == messages[0]["content"][0]
+        # The pre-existing guardContent block stays as-is
+        assert wrapped[0]["content"][1] == messages[0]["content"][1]
+
+    def test_wrap_still_wraps_when_only_text_blocks(self):
+        """Backwards-compatible: when the caller did NOT set a guardContent
+        block, the helper still wraps text blocks (legacy invoke() pattern)."""
+        client = self._make_client(guardrail_id="gr-123")
+        messages = [{"role": "user", "content": [{"text": "user input"}]}]
+        wrapped = client._wrap_first_user_for_guardrail(messages)
+        assert "guardContent" in wrapped[0]["content"][0]
+        assert wrapped[0]["content"][0]["guardContent"]["text"]["text"] == "user input"
+
+    def test_wrap_no_op_when_no_guardrail(self):
+        client = self._make_client()  # no guardrail
+        messages = [{"role": "user", "content": [{"text": "user input"}]}]
+        wrapped = client._wrap_first_user_for_guardrail(messages)
+        assert wrapped == messages
+
+    def test_has_guardrail_property(self):
+        assert self._make_client(guardrail_id="gr-1").has_guardrail is True
+        assert self._make_client().has_guardrail is False
+
+    def test_client_for_timeout_uses_default_when_none(self):
+        client = self._make_client()
+        # No override → returns the default client; same identity.
+        assert client._client_for_timeout(None) is client._client
+
+    def test_client_for_timeout_uses_default_when_override_at_or_above(self):
+        """An override >= the default timeout doesn't earn a fresh client —
+        the default already permits at least that long."""
+        client = self._make_client()
+        # Default timeout is 10s in _make_client's FakeCfg.
+        assert client._client_for_timeout(10) is client._client
+        assert client._client_for_timeout(99) is client._client
+
+    def test_client_for_timeout_builds_fresh_client_for_smaller_override(self):
+        """A smaller override constructs a fresh client with that timeout
+        so the Reporter call can be bounded at the remaining wall-clock."""
+        import unittest.mock as mock
+        client = self._make_client()
+        with mock.patch("issue_bot.bedrock_client.boto3.client") as mock_boto:
+            mock_boto.return_value = mock.MagicMock()
+            out = client._client_for_timeout(5)
+            assert out is mock_boto.return_value
+            # The fresh client got a Config with read_timeout=5
+            args, kwargs = mock_boto.call_args
+            cfg = kwargs["config"]
+            assert cfg.read_timeout == 5
+            assert cfg.connect_timeout <= 5
+
+    def test_client_for_timeout_floors_zero_or_negative(self):
+        """0 / negative are illegal at the boto layer; clamp to 1."""
+        import unittest.mock as mock
+        client = self._make_client()
+        with mock.patch("issue_bot.bedrock_client.boto3.client") as mock_boto:
+            mock_boto.return_value = mock.MagicMock()
+            client._client_for_timeout(0)
+            cfg = mock_boto.call_args[1]["config"]
+            assert cfg.read_timeout == 1
+
+    def test_invoke_with_usage_passes_timeout_to_per_call_client(self):
+        """The plumb-through: a small timeout_seconds on invoke_with_usage
+        must reach _client_for_timeout and use the fresh client for the call."""
+        import unittest.mock as mock
+        client = self._make_client(guardrail_id="gr-1")
+        # Default timeout is 10 (from FakeCfg). Override to 3 → fresh client.
+        fresh = mock.MagicMock()
+        fresh.converse.return_value = {
+            "stopReason": "end_turn",
+            "output": {"message": {"content": [{"text": "ok"}]}},
+            "usage": {"inputTokens": 1, "outputTokens": 1},
+        }
+        with mock.patch.object(client, "_client_for_timeout",
+                                return_value=fresh) as mock_picker:
+            client.invoke_with_usage("system", "user", timeout_seconds=3)
+        mock_picker.assert_called_once_with(3)
+        fresh.converse.assert_called_once()
+
     def test_no_guardrail_no_config(self):
         client = self._make_client()
         self._mock_converse(client)

--- a/src/scripts/tests/test_critic.py
+++ b/src/scripts/tests/test_critic.py
@@ -603,6 +603,488 @@ def test_metrics_totals_equal_sum_of_stages(tmp_path, monkeypatch):
     assert m["totals"]["output_tokens"] == expected_out
 
 
+def test_reporter_skipped_when_pipeline_deadline_exceeded(monkeypatch):
+    """Direct unit test of _run_critic_and_reporter: with the deadline
+    already in the past after the Critic finishes, the Reporter must be
+    skipped and the helper must return skip_reason 'reporter_deadline_exceeded'.
+
+    Direct call (not via analyze()) so we can drive the Critic happy-path
+    independently of the Investigator's deadline check.
+    """
+    import time as _time
+    import unittest.mock as mock
+    from issue_bot.main import _run_critic_and_reporter
+    from issue_bot import agent_loop
+    from issue_bot.config import Config
+
+    monkeypatch.setenv("GITHUB_TOKEN", "fake")
+    monkeypatch.setenv("EVENT_TYPE", "pull_request_target")
+    monkeypatch.setenv("ISSUE_NUMBER", "1")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "awslabs/test")
+    cfg = Config()
+
+    investigator_notes = (
+        "ID: C1\nFILE: f.py\nLINE: 1\nHYPOTHESIS: real bug\n"
+        "FALSIFICATION_ATTEMPT: searched\nSTATUS: CONFIRMED\n"
+        "SEVERITY: BUG\nCOMMENT: real bug\nEVIDENCE: line 1\nTRIGGER: x\n"
+    )
+
+    fake_critic = agent_loop.AgentResult(
+        text="VERDICT: C1 | UPHELD | verified",
+        turns=1, tool_calls=0, tool_output_chars=0,
+        input_tokens=10, output_tokens=5,
+    )
+
+    bedrock = mock.MagicMock()
+    # Reporter (invoke_with_usage) MUST NOT be called.
+    bedrock.invoke_with_usage = mock.MagicMock(return_value=("never", {}))
+
+    # Patch agent_loop.run so the "Critic" returns a real verdict without
+    # actually doing a Bedrock call.
+    with mock.patch("issue_bot.main.agent_loop.run", return_value=fake_critic):
+        crit_result, skip_reason, comments, rep_metrics = _run_critic_and_reporter(
+            cfg=cfg, bedrock=bedrock, tool_runner=None,
+            critic_system="Critique.", critic_caps=agent_loop.AgentCaps(max_turns=1),
+            reporter_system="Report.",
+            diff="diff", title="T", body="B",
+            investigator_text=investigator_notes,
+            pipeline_deadline=_time.monotonic() - 1.0,  # already past
+        )
+
+    assert bedrock.invoke_with_usage.call_count == 0
+    assert skip_reason == "reporter_deadline_exceeded"
+    assert comments == []
+    # Same string in both places: dashboards filtering on either field
+    # see the same event without drift.
+    assert rep_metrics["skip_reason"] == "reporter_deadline_exceeded"
+
+
+def test_reporter_deadline_does_not_mislabel_critic_skip_reason(monkeypatch):
+    """Regression: when the Reporter is skipped due to wall-clock deadline,
+    the Critic actually ran successfully — its metrics row must NOT be
+    tagged with a reporter-side skip_reason. The skip_reason belongs on the
+    Reporter's metrics row (and the artifact's top-level reason field).
+    """
+    import time as _time
+    import unittest.mock as mock
+    from issue_bot.main import _run_agent_pipeline
+    from issue_bot import agent_loop
+    from issue_bot.config import Config
+
+    monkeypatch.setenv("GITHUB_TOKEN", "fake")
+    monkeypatch.setenv("EVENT_TYPE", "pull_request_target")
+    monkeypatch.setenv("ISSUE_NUMBER", "1")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "awslabs/test")
+    monkeypatch.setenv("PR_INVESTIGATOR_PROMPT", "Investigate.")
+    monkeypatch.setenv("PR_CRITIC_PROMPT", "Critique.")
+    monkeypatch.setenv("PR_REPORTER_PROMPT", "Report.")
+    cfg = Config()
+
+    investigator_notes = (
+        "ID: C1\nSTATUS: CONFIRMED\nSEVERITY: BUG\nCOMMENT: c\nEVIDENCE: e\n"
+    )
+    fake_inv = agent_loop.AgentResult(
+        text=investigator_notes, turns=1, input_tokens=10, output_tokens=5,
+    )
+    fake_critic = agent_loop.AgentResult(
+        text="VERDICT: C1 | UPHELD | verified", turns=1, input_tokens=10, output_tokens=5,
+    )
+
+    artifact_holder = {}
+
+    def capture_artifact(payload):
+        artifact_holder.update(payload)
+
+    bedrock = mock.MagicMock()
+    bedrock.invoke_with_usage = mock.MagicMock(return_value=("never", {}))
+
+    gh = mock.MagicMock()
+    gh.repo_root = "."
+    gh.get_pr_diff.return_value = "diff"
+    gh.get_pr_review_comments.return_value = []
+    gh.get_pr_files.return_value = [{"filename": "f.py", "changes": 5}]
+    gh.get_compare_diff.return_value = ""
+    gh.get_ci_status.return_value = (True, "")
+
+    item = {"head": {"sha": "abc"}}
+    cfg.event_after = "abc"
+
+    # Force deadline-exceeded path: monkeypatch pipeline_wall_clock_seconds to 0
+    cfg.pipeline_wall_clock_seconds = 0
+
+    with mock.patch("issue_bot.main.agent_loop.run", side_effect=[fake_inv, fake_critic]), \
+         mock.patch("issue_bot.main._write_artifact", side_effect=capture_artifact):
+        _run_agent_pipeline(
+            cfg=cfg, gh=gh, bedrock=bedrock, number=1, title="T", body="B",
+            html_url="https://github.com/x", item=item, context="",
+            codebase_map="", comments_data=[], is_pr_update=False,
+        )
+
+    # Reporter NOT invoked due to expired deadline.
+    assert bedrock.invoke_with_usage.call_count == 0
+    # Guard against the patch silently no-op'ing if _write_artifact gets
+    # renamed: an empty holder would otherwise pass the .get() asserts below.
+    assert artifact_holder, "no artifact captured — check the patch target"
+    # Pipeline ESCALATEd with the right top-level reason.
+    assert artifact_holder["action"] == "ESCALATE"
+    assert artifact_holder["reason"] == "reporter_deadline_exceeded"
+    # Critic stage row carries its real metrics, not a reporter-side skip_reason.
+    crit_metrics = artifact_holder["metrics"]["critic"]
+    assert crit_metrics.get("skip_reason") != "reporter_deadline_exceeded", (
+        "Critic mislabeled with a reporter-side skip_reason — pollutes per-stage analytics."
+    )
+    # Reporter row carries the deadline reason; same string as artifact reason.
+    rep_metrics = artifact_holder["metrics"]["reporter"]
+    assert rep_metrics["skip_reason"] == "reporter_deadline_exceeded"
+
+
+def test_reporter_skipped_when_remaining_below_safety_threshold(monkeypatch):
+    """If remaining wall-clock budget is below cfg.reporter_min_remaining_seconds,
+    the Reporter is skipped pre-emptively. This bounds the worst case where
+    the Reporter could otherwise run for its full bedrock_timeout (240s)
+    starting just before the deadline and blow the workflow cap (600s).
+    """
+    import time as _time
+    import unittest.mock as mock
+    from issue_bot.main import _run_critic_and_reporter
+    from issue_bot import agent_loop
+    from issue_bot.config import Config
+
+    monkeypatch.setenv("GITHUB_TOKEN", "fake")
+    monkeypatch.setenv("EVENT_TYPE", "pull_request_target")
+    monkeypatch.setenv("ISSUE_NUMBER", "1")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "awslabs/test")
+    monkeypatch.setenv("BOT_REPORTER_MIN_REMAINING_S", "60")
+    cfg = Config()
+    assert cfg.reporter_min_remaining_seconds == 60
+
+    fake_critic = agent_loop.AgentResult(text="VERDICT: C1 | UPHELD | ok")
+    bedrock = mock.MagicMock()
+    bedrock.invoke_with_usage = mock.MagicMock(return_value=("never", {}))
+
+    # 30s remaining < 60s threshold → skip pre-emptively
+    with mock.patch("issue_bot.main.agent_loop.run", return_value=fake_critic):
+        _, skip_reason, _, _ = _run_critic_and_reporter(
+            cfg=cfg, bedrock=bedrock, tool_runner=None,
+            critic_system="Critique.", critic_caps=agent_loop.AgentCaps(max_turns=1),
+            reporter_system="Report.",
+            diff="diff", title="T", body="B",
+            investigator_text="ID: C1\nSTATUS: CONFIRMED\n",
+            pipeline_deadline=_time.monotonic() + 30,
+        )
+
+    assert bedrock.invoke_with_usage.call_count == 0
+    assert skip_reason == "reporter_deadline_exceeded"
+
+
+def test_reporter_min_remaining_seconds_default(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "fake")
+    monkeypatch.setenv("EVENT_TYPE", "pull_request_target")
+    monkeypatch.setenv("ISSUE_NUMBER", "1")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "awslabs/test")
+    monkeypatch.delenv("BOT_REPORTER_MIN_REMAINING_S", raising=False)
+    from issue_bot.config import Config
+    cfg = Config()
+    # Default tuned to >= realistic Reporter latency (20-45s on slow days)
+    # so a Reporter that starts within budget can finish within budget.
+    assert cfg.reporter_min_remaining_seconds == 60
+
+
+def test_reporter_call_passes_remaining_budget_as_timeout(monkeypatch):
+    """When the Reporter does run, its bedrock call gets a per-call timeout
+    capped at the remaining wall-clock budget so a slow Bedrock day can't
+    blow the GHA workflow cap (600s)."""
+    import time as _time
+    import unittest.mock as mock
+    from issue_bot.main import _run_critic_and_reporter
+    from issue_bot import agent_loop
+    from issue_bot.config import Config
+
+    monkeypatch.setenv("GITHUB_TOKEN", "fake")
+    monkeypatch.setenv("EVENT_TYPE", "pull_request_target")
+    monkeypatch.setenv("ISSUE_NUMBER", "1")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "awslabs/test")
+    cfg = Config()
+
+    fake_critic = agent_loop.AgentResult(text="VERDICT: C1 | UPHELD | ok")
+    bedrock = mock.MagicMock()
+    bedrock.invoke_with_usage = mock.MagicMock(return_value=(
+        json.dumps({"analysis": []}),
+        {"inputTokens": 5, "outputTokens": 2,
+         "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0},
+    ))
+
+    deadline = _time.monotonic() + 90  # 90s remaining
+    with mock.patch("issue_bot.main.agent_loop.run", return_value=fake_critic):
+        _run_critic_and_reporter(
+            cfg=cfg, bedrock=bedrock, tool_runner=None,
+            critic_system="Critique.", critic_caps=agent_loop.AgentCaps(max_turns=1),
+            reporter_system="Report.",
+            diff="diff", title="T", body="B",
+            investigator_text="ID: C1\nSTATUS: CONFIRMED\n",
+            pipeline_deadline=deadline,
+        )
+
+    assert bedrock.invoke_with_usage.call_count == 1
+    call_kwargs = bedrock.invoke_with_usage.call_args[1]
+    timeout = call_kwargs.get("timeout_seconds")
+    # Deadline was set 90s out and only ms have elapsed inside the test.
+    # Tight bounds catch off-by-one or wrong-units regressions in the
+    # deadline math; loose bounds (e.g., 1 <= timeout <= 90) would let
+    # a buggy value of 5s pass.
+    assert timeout is not None
+    assert 85 <= timeout <= 90
+
+
+def test_reporter_failure_escalates_does_not_post_clean(monkeypatch):
+    """If the Reporter call returns None (Bedrock unavailable, timeout,
+    throttled), the pipeline must ESCALATE, not RESPOND with empty findings.
+    Otherwise confirmed findings would be silently dropped — the same
+    impact as a Critic failure, and treated the same way.
+    """
+    import time as _time
+    import unittest.mock as mock
+    from issue_bot.main import _run_critic_and_reporter
+    from issue_bot import agent_loop
+    from issue_bot.config import Config
+
+    monkeypatch.setenv("GITHUB_TOKEN", "fake")
+    monkeypatch.setenv("EVENT_TYPE", "pull_request_target")
+    monkeypatch.setenv("ISSUE_NUMBER", "1")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "awslabs/test")
+    cfg = Config()
+
+    fake_critic = agent_loop.AgentResult(text="VERDICT: C1 | UPHELD | ok")
+    bedrock = mock.MagicMock()
+    # Reporter call fails (Bedrock returned None for any reason).
+    bedrock.invoke_with_usage = mock.MagicMock(return_value=(None, {}))
+
+    with mock.patch("issue_bot.main.agent_loop.run", return_value=fake_critic):
+        crit_result, event, comments, rep_metrics = _run_critic_and_reporter(
+            cfg=cfg, bedrock=bedrock, tool_runner=None,
+            critic_system="Critique.", critic_caps=agent_loop.AgentCaps(max_turns=1),
+            reporter_system="Report.",
+            diff="diff", title="T", body="B",
+            investigator_text="ID: C1\nSTATUS: CONFIRMED\n",
+            pipeline_deadline=_time.monotonic() + 600,  # ample budget
+        )
+
+    assert event == "reporter_failed"
+    assert comments == []
+    assert rep_metrics["skip_reason"] == "bedrock_unavailable"
+
+
+def test_reporter_malformed_output_escalates(monkeypatch):
+    """If the Reporter returns text that fails JSON parsing, we cannot trust
+    the findings list. Escalate rather than risk posting nothing on real
+    findings."""
+    import time as _time
+    import unittest.mock as mock
+    from issue_bot.main import _run_critic_and_reporter
+    from issue_bot import agent_loop
+    from issue_bot.config import Config
+
+    monkeypatch.setenv("GITHUB_TOKEN", "fake")
+    monkeypatch.setenv("EVENT_TYPE", "pull_request_target")
+    monkeypatch.setenv("ISSUE_NUMBER", "1")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "awslabs/test")
+    cfg = Config()
+
+    fake_critic = agent_loop.AgentResult(text="VERDICT: C1 | UPHELD | ok")
+    bedrock = mock.MagicMock()
+    # Returns non-JSON text — parser will fail.
+    bedrock.invoke_with_usage = mock.MagicMock(return_value=(
+        "<<not json>>",
+        {"inputTokens": 5, "outputTokens": 1,
+         "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0},
+    ))
+
+    with mock.patch("issue_bot.main.agent_loop.run", return_value=fake_critic):
+        _, event, comments, rep_metrics = _run_critic_and_reporter(
+            cfg=cfg, bedrock=bedrock, tool_runner=None,
+            critic_system="Critique.", critic_caps=agent_loop.AgentCaps(max_turns=1),
+            reporter_system="Report.",
+            diff="diff", title="T", body="B",
+            investigator_text="ID: C1\nSTATUS: CONFIRMED\n",
+            pipeline_deadline=_time.monotonic() + 600,
+        )
+
+    assert event == "reporter_failed"
+    assert comments == []
+    assert rep_metrics["parse_failed"] is True
+
+
+def test_unknown_pipeline_event_escalates_does_not_mislabel_critic(monkeypatch):
+    """Forward-compat: if _run_critic_and_reporter ever returns an unknown
+    event name (typo, future event missing from both classification sets),
+    the pipeline must ESCALATE with reason='unknown_pipeline_event' and NOT
+    re-tag metrics["critic"] with that string."""
+    import unittest.mock as mock
+    from issue_bot.main import _run_agent_pipeline
+    from issue_bot import agent_loop
+    from issue_bot.config import Config
+
+    monkeypatch.setenv("GITHUB_TOKEN", "fake")
+    monkeypatch.setenv("EVENT_TYPE", "pull_request_target")
+    monkeypatch.setenv("ISSUE_NUMBER", "1")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "awslabs/test")
+    monkeypatch.setenv("PR_INVESTIGATOR_PROMPT", "Investigate.")
+    monkeypatch.setenv("PR_CRITIC_PROMPT", "Critique.")
+    monkeypatch.setenv("PR_REPORTER_PROMPT", "Report.")
+    cfg = Config()
+
+    fake_inv = agent_loop.AgentResult(
+        text="ID: C1\nSTATUS: CONFIRMED\nSEVERITY: BUG\nCOMMENT: c\nEVIDENCE: e\n",
+        turns=1, input_tokens=10, output_tokens=5,
+    )
+    fake_critic = agent_loop.AgentResult(
+        text="VERDICT: C1 | UPHELD | ok", turns=1, input_tokens=10, output_tokens=5,
+    )
+
+    artifact_holder = {}
+    bedrock = mock.MagicMock()
+    gh = mock.MagicMock()
+    gh.repo_root = "."
+    gh.get_pr_diff.return_value = "diff"
+    gh.get_pr_review_comments.return_value = []
+    gh.get_pr_files.return_value = [{"filename": "f.py", "changes": 5}]
+    gh.get_compare_diff.return_value = ""
+    gh.get_ci_status.return_value = (True, "")
+
+    item = {"head": {"sha": "abc"}}
+    cfg.event_after = "abc"
+
+    # Patch _run_critic_and_reporter to return a typo'd event name.
+    bad_metrics = {
+        "skipped": False, "skip_reason": "garbage_value", "turns": 0, "tool_calls": 0,
+        "tool_output_chars": 0, "input_tokens": 0, "output_tokens": 0,
+        "cache_read_tokens": 0, "cache_write_tokens": 0,
+        "max_turns_reached": False, "error": None, "parse_failed": False,
+    }
+
+    def capture_artifact(payload):
+        artifact_holder.update(payload)
+
+    with mock.patch("issue_bot.main.agent_loop.run", return_value=fake_inv), \
+         mock.patch("issue_bot.main._run_critic_and_reporter",
+                    return_value=(fake_critic, "garbage_event_typo", [], bad_metrics)), \
+         mock.patch("issue_bot.main._write_artifact", side_effect=capture_artifact):
+        _run_agent_pipeline(
+            cfg=cfg, gh=gh, bedrock=bedrock, number=1, title="T", body="B",
+            html_url="https://github.com/x", item=item, context="",
+            codebase_map="", comments_data=[], is_pr_update=False,
+        )
+
+    assert artifact_holder, "no artifact captured — check the patch target"
+    assert artifact_holder["action"] == "ESCALATE"
+    assert artifact_holder["reason"] == "unknown_pipeline_event"
+    # Critic ran — its skip_reason must NOT be "unknown_pipeline_event".
+    assert artifact_holder["metrics"]["critic"].get("skip_reason") not in (
+        "unknown_pipeline_event", "garbage_event_typo",
+    )
+
+
+def test_reporter_runs_when_deadline_in_future(monkeypatch):
+    """Sanity check the inverse: a deadline comfortably in the future does
+    NOT cause the Reporter to be skipped."""
+    import time as _time
+    import unittest.mock as mock
+    from issue_bot.main import _run_critic_and_reporter
+    from issue_bot import agent_loop
+    from issue_bot.config import Config
+
+    monkeypatch.setenv("GITHUB_TOKEN", "fake")
+    monkeypatch.setenv("EVENT_TYPE", "pull_request_target")
+    monkeypatch.setenv("ISSUE_NUMBER", "1")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "awslabs/test")
+    cfg = Config()
+
+    investigator_notes = (
+        "ID: C1\nSTATUS: CONFIRMED\nSEVERITY: BUG\nCOMMENT: c\nEVIDENCE: e\n"
+    )
+    fake_critic = agent_loop.AgentResult(text="VERDICT: C1 | UPHELD | ok")
+
+    bedrock = mock.MagicMock()
+    bedrock.invoke_with_usage = mock.MagicMock(return_value=(
+        json.dumps({"analysis": []}),
+        {"inputTokens": 5, "outputTokens": 2, "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0},
+    ))
+
+    with mock.patch("issue_bot.main.agent_loop.run", return_value=fake_critic):
+        _, skip_reason, _, _ = _run_critic_and_reporter(
+            cfg=cfg, bedrock=bedrock, tool_runner=None,
+            critic_system="Critique.", critic_caps=agent_loop.AgentCaps(max_turns=1),
+            reporter_system="Report.",
+            diff="diff", title="T", body="B",
+            investigator_text=investigator_notes,
+            # Comfortably above reporter_min_remaining_seconds (default 60).
+            pipeline_deadline=_time.monotonic() + 600,
+        )
+    assert bedrock.invoke_with_usage.call_count == 1
+    assert skip_reason is None
+
+
+def test_investigator_diff_truncation_on_large_diff(tmp_path, monkeypatch):
+    """When the diff > BOT_AGENT_MAX_DIFF_CHARS, the Investigator's user
+    message must contain the truncation marker, not the full diff. Same
+    cap as the Critic to bound input tokens on giant PRs."""
+    import unittest.mock as mock
+    _setup_pipeline_env(tmp_path, monkeypatch, event_action="opened")
+    # Lower the cap to make the test fast; default is 200K.
+    monkeypatch.setenv("BOT_AGENT_MAX_DIFF_CHARS", "5000")
+    huge_diff = "diff --git a/f.py b/f.py\n" + ("+ x\n" * 4000)  # ~16K chars
+    captured = []
+
+    with mock.patch("issue_bot.github_client.GitHubClient.get_pr") as mock_pr, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_comments") as mock_comments, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_pr_diff") as mock_diff, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_pr_review_comments") as mock_rc, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_pr_files") as mock_files, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_codebase_map") as mock_map, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_ci_status") as mock_ci, \
+         mock.patch("issue_bot.knowledge_base.KnowledgeBase.load"), \
+         mock.patch("issue_bot.knowledge_base.KnowledgeBase.build_context") as mock_kb, \
+         mock.patch("issue_bot.bedrock_client.BedrockClient.__init__", return_value=None), \
+         mock.patch("issue_bot.bedrock_client.BedrockClient.converse_with_tools") as mock_ctools, \
+         mock.patch("issue_bot.bedrock_client.BedrockClient.invoke_with_usage") as mock_invoke:
+
+        mock_pr.return_value = {
+            "user": {"login": "contributor"}, "title": "T", "body": "B",
+            "state": "open", "html_url": "https://github.com/x", "head": {"sha": "abc"},
+        }
+        mock_comments.return_value = []
+        mock_diff.return_value = huge_diff
+        mock_rc.return_value = []
+        mock_files.return_value = [{"filename": "f.py", "changes": 5}]
+        mock_map.return_value = ""
+        mock_kb.return_value = ""
+        mock_ci.return_value = (True, "")
+        mock_invoke.return_value = (json.dumps({"analysis": []}),
+                                     {"inputTokens": 1, "outputTokens": 1,
+                                      "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0})
+
+        def converse(system_prompt, messages, tool_specs, max_tokens=8000,
+                     temperature=0.3, timeout_seconds=None):
+            captured.append({"system": system_prompt[:80], "messages": messages})
+            text = (
+                "No confirmed issues found." if "Investigate" in system_prompt
+                else "ALL_DISPROVED: nothing to verify"
+            )
+            return _bedrock_text_resp(text)
+
+        mock_ctools.side_effect = converse
+        from issue_bot.main import analyze
+        analyze()
+
+    # Investigator is the FIRST converse call.
+    inv_call = captured[0]
+    inv_user = inv_call["messages"][0]["content"][0]
+    text = inv_user.get("text", "") if isinstance(inv_user, dict) else str(inv_user)
+    assert "diff truncated at 5000 chars" in text
+    # Must be < raw diff (16K) — truncated.
+    assert len(text) < 16_000
+
+
 def test_metrics_schema_uniform_across_stages(tmp_path, monkeypatch):
     """Every stage's metrics dict carries the same canonical key set so
     dashboards iterating stages don't KeyError."""

--- a/src/scripts/tests/test_critic.py
+++ b/src/scripts/tests/test_critic.py
@@ -83,7 +83,9 @@ def _run_pipeline(tmp_path, monkeypatch, mock,
         # Investigator: one tool_use turn, then final text
         # Critic: one tool_use turn, then final text
         # The fast path skips critic entirely if no CONFIRMED findings.
-        def converse_side_effect(system_prompt, messages, tool_specs, max_tokens=8000, temperature=0.3):
+        def converse_side_effect(system_prompt, messages, tool_specs,
+                                 max_tokens=8000, temperature=0.3,
+                                 timeout_seconds=None):
             # Identify which agent by scanning the system prompt
             if "Investigate" in system_prompt:
                 return _bedrock_text_resp(investigator_text)
@@ -417,7 +419,8 @@ def test_critic_diff_truncation_on_large_diff(tmp_path, monkeypatch):
         mock_ci.return_value = (True, "")
         mock_invoke.return_value = (json.dumps({"analysis": []}), {"inputTokens": 1, "outputTokens": 1, "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0})
 
-        def converse(system_prompt, messages, tool_specs, max_tokens=8000, temperature=0.3):
+        def converse(system_prompt, messages, tool_specs, max_tokens=8000,
+                     temperature=0.3, timeout_seconds=None):
             captured_messages.append({"system": system_prompt[:200], "messages": messages})
             text = (
                 "ID: C1\nSTATUS: CONFIRMED\nSEVERITY: BUG\nCOMMENT: c\nEVIDENCE: e\n"
@@ -514,6 +517,7 @@ def test_critic_overturn_rate_calculated(tmp_path, monkeypatch):
 def test_critic_failure_escalates_does_not_post_clean(tmp_path, monkeypatch):
     """If the Critic returns empty/error, the pipeline must ESCALATE rather
     than synthesize a fake 'all disproved' verdict and silently drop findings.
+    Reporter must NOT be invoked. Investigator narrative is preserved.
     """
     import unittest.mock as mock
     investigator_notes = (
@@ -521,7 +525,7 @@ def test_critic_failure_escalates_does_not_post_clean(tmp_path, monkeypatch):
         "FALSIFICATION_ATTEMPT: searched\nSTATUS: CONFIRMED\n"
         "SEVERITY: BUG\nCOMMENT: real bug\nEVIDENCE: line 1\nTRIGGER: x\n"
     )
-    artifact, _, _ = _run_pipeline(
+    artifact, mock_invoke, _ = _run_pipeline(
         tmp_path, monkeypatch, mock,
         investigator_text=investigator_notes,
         critic_text="",  # critic returned empty (e.g. crashed)
@@ -530,6 +534,11 @@ def test_critic_failure_escalates_does_not_post_clean(tmp_path, monkeypatch):
     assert artifact["action"] == "ESCALATE"
     assert artifact["reason"] == "critic_failed"
     assert artifact["inline_comments"] == []
+    # Reporter must NOT have been invoked: posting empty reporter output
+    # would have lost the investigator's findings silently.
+    assert mock_invoke.call_count == 0
+    # Investigator narrative is preserved so an operator can triage.
+    assert artifact.get("investigator_summary", "").startswith("ID: C1")
 
 
 def test_metrics_totals_equal_sum_of_stages(tmp_path, monkeypatch):

--- a/src/scripts/tests/test_critic.py
+++ b/src/scripts/tests/test_critic.py
@@ -31,7 +31,7 @@ def _setup_pipeline_env(tmp_path, monkeypatch, event_action="opened"):
     monkeypatch.setenv("KB_S3_KEY", "")
     monkeypatch.setenv("PR_INVESTIGATOR_PROMPT", "Investigate. Today: {current_date}")
     monkeypatch.setenv("PR_CRITIC_PROMPT", "Critique. Today: {current_date}")
-    monkeypatch.setenv("PR_FILE_REVIEW_REPORT_PROMPT", "Report. Today: {current_date}")
+    monkeypatch.setenv("PR_REPORTER_PROMPT", "Report. Today: {current_date}")
     monkeypatch.setenv("BOT_AGENT_PIPELINE", "1")
     monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
     import issue_bot.main as bot_main
@@ -461,7 +461,7 @@ def test_pipeline_fails_closed_on_missing_investigator_prompt(tmp_path, monkeypa
     monkeypatch.setenv("KB_S3_KEY", "")
     monkeypatch.setenv("BOT_AGENT_PIPELINE", "1")
     monkeypatch.setenv("PR_CRITIC_PROMPT", "Critique. {current_date}")
-    monkeypatch.setenv("PR_FILE_REVIEW_REPORT_PROMPT", "Report. {current_date}")
+    monkeypatch.setenv("PR_REPORTER_PROMPT", "Report. {current_date}")
     # Set the LEGACY prompt to ensure the silent-fallback path is NOT taken
     monkeypatch.setenv("PR_FILE_REVIEW_PROMPT", "Legacy review. {current_date}")
     # Investigator prompt deliberately NOT set

--- a/src/scripts/tests/test_critic.py
+++ b/src/scripts/tests/test_critic.py
@@ -285,7 +285,6 @@ def test_pipeline_metrics_record_token_usage(tmp_path, monkeypatch):
     assert metrics["investigator"]["output_tokens"] == 50
     assert "totals" in metrics
     assert metrics["totals"]["input_tokens"] == 100
-    assert metrics["totals"]["cost_usd"] >= 0
 
 
 def test_pipeline_handles_missing_prompts(tmp_path, monkeypatch):

--- a/src/scripts/tests/test_critic.py
+++ b/src/scripts/tests/test_critic.py
@@ -379,6 +379,112 @@ def test_reporter_cost_in_totals(tmp_path, monkeypatch):
     assert metrics["totals"]["output_tokens"] == 120
 
 
+def test_critic_diff_truncation_on_large_diff(tmp_path, monkeypatch):
+    """When the diff > 200K chars, Critic's user message must contain the
+    truncation marker, not the full diff."""
+    import unittest.mock as mock
+    _setup_pipeline_env(tmp_path, monkeypatch, event_action="opened")
+    huge_diff = "diff --git a/f.py b/f.py\n" + ("+ x\n" * 60000)  # ~240K chars
+    investigator_notes = (
+        "ID: C1\nFILE: f.py\nLINE: 1\nHYPOTHESIS: h\n"
+        "FALSIFICATION_ATTEMPT: fa\nSTATUS: CONFIRMED\n"
+        "SEVERITY: BUG\nCOMMENT: c\nEVIDENCE: e\nTRIGGER: t\n"
+    )
+    captured_messages = []
+
+    with mock.patch("issue_bot.github_client.GitHubClient.get_pr") as mock_pr, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_comments") as mock_comments, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_pr_diff") as mock_diff, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_pr_review_comments") as mock_rc, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_pr_files") as mock_files, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_codebase_map") as mock_map, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_ci_status") as mock_ci, \
+         mock.patch("issue_bot.knowledge_base.KnowledgeBase.load"), \
+         mock.patch("issue_bot.knowledge_base.KnowledgeBase.build_context") as mock_kb, \
+         mock.patch("issue_bot.bedrock_client.BedrockClient.__init__", return_value=None), \
+         mock.patch("issue_bot.bedrock_client.BedrockClient.converse_with_tools") as mock_ctools, \
+         mock.patch("issue_bot.bedrock_client.BedrockClient.invoke_with_usage") as mock_invoke:
+
+        mock_pr.return_value = {
+            "user": {"login": "contributor"}, "title": "T", "body": "B",
+            "state": "open", "html_url": "https://github.com/x", "head": {"sha": "abc"},
+        }
+        mock_comments.return_value = []
+        mock_diff.return_value = huge_diff
+        mock_rc.return_value = []
+        mock_files.return_value = [{"filename": "f.py", "changes": 10}]
+        mock_map.return_value = ""
+        mock_kb.return_value = ""
+        mock_ci.return_value = (True, "")
+        mock_invoke.return_value = (json.dumps({"analysis": []}), {"inputTokens": 1, "outputTokens": 1, "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0})
+
+        def converse(system_prompt, messages, tool_specs, max_tokens=8000, temperature=0.3):
+            captured_messages.append({"system": system_prompt[:200], "messages": messages})
+            text = (
+                "ID: C1\nSTATUS: CONFIRMED\nSEVERITY: BUG\nCOMMENT: c\nEVIDENCE: e\n"
+                if "Investigate" in system_prompt
+                else "VERDICT: C1 | UPHELD | ok"
+            )
+            return _bedrock_text_resp(text)
+
+        mock_ctools.side_effect = converse
+        from issue_bot.main import analyze
+        analyze()
+
+    # Find the Critic's call (second converse) and verify its first user message
+    # contains the truncation marker, not the full huge diff
+    critic_call = captured_messages[1]
+    user_msg_text = critic_call["messages"][0]["content"][0]
+    if isinstance(user_msg_text, dict):
+        text = user_msg_text.get("text", "") or user_msg_text.get("guardContent", {}).get("text", {}).get("text", "")
+    else:
+        text = str(user_msg_text)
+    assert "diff truncated at 200000 chars" in text
+    assert len(text) < 220_000  # should be truncated, not 240K
+
+
+def test_pipeline_fails_closed_on_missing_investigator_prompt(tmp_path, monkeypatch):
+    """If PR_INVESTIGATOR_PROMPT and SM are unset, escalate (do not silently
+    fall back to the legacy review prompt)."""
+    import unittest.mock as mock
+    monkeypatch.setenv("GITHUB_TOKEN", "fake")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "awslabs/test")
+    monkeypatch.setenv("ISSUE_NUMBER", "100")
+    monkeypatch.setenv("EVENT_TYPE", "pull_request_target")
+    monkeypatch.setenv("EVENT_ACTION", "opened")
+    monkeypatch.setenv("EVENT_BEFORE", "")
+    monkeypatch.setenv("EVENT_AFTER", "")
+    monkeypatch.setenv("GITHUB_ACTOR", "contributor")
+    monkeypatch.setenv("KB_S3_BUCKET", "")
+    monkeypatch.setenv("KB_S3_KEY", "")
+    monkeypatch.setenv("BOT_AGENT_PIPELINE", "1")
+    monkeypatch.setenv("PR_CRITIC_PROMPT", "Critique. {current_date}")
+    monkeypatch.setenv("PR_FILE_REVIEW_REPORT_PROMPT", "Report. {current_date}")
+    # Set the LEGACY prompt to ensure the silent-fallback path is NOT taken
+    monkeypatch.setenv("PR_FILE_REVIEW_PROMPT", "Legacy review. {current_date}")
+    # Investigator prompt deliberately NOT set
+    import issue_bot.main as bot_main
+    monkeypatch.setattr(bot_main, "ARTIFACT_PATH", str(tmp_path / "result.json"))
+
+    with mock.patch("issue_bot.github_client.GitHubClient.get_pr") as mock_pr, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_comments") as mock_comments, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_codebase_map"), \
+         mock.patch("issue_bot.knowledge_base.KnowledgeBase.load"), \
+         mock.patch("issue_bot.knowledge_base.KnowledgeBase.build_context", return_value=""), \
+         mock.patch("issue_bot.bedrock_client.BedrockClient.__init__", return_value=None):
+
+        mock_pr.return_value = {
+            "user": {"login": "contributor"}, "title": "T", "body": "B",
+            "state": "open", "html_url": "https://github.com/x", "head": {"sha": "abc"},
+        }
+        mock_comments.return_value = []
+        bot_main.analyze()
+        with open(str(tmp_path / "result.json")) as f:
+            artifact = json.load(f)
+        assert artifact["action"] == "ESCALATE"
+        assert "investigator" in artifact["reason"]
+
+
 def test_critic_overturn_rate_calculated(tmp_path, monkeypatch):
     import unittest.mock as mock
     # Three findings, one upheld, two overturned → rate = 2/3

--- a/src/scripts/tests/test_critic.py
+++ b/src/scripts/tests/test_critic.py
@@ -541,6 +541,41 @@ def test_critic_failure_escalates_does_not_post_clean(tmp_path, monkeypatch):
     assert artifact.get("investigator_summary", "").startswith("ID: C1")
 
 
+def test_critic_with_structural_cap_text_reaches_reporter(tmp_path, monkeypatch):
+    """A Critic that hits a structural cap (max_tool_calls etc.) produces an
+    error string AND valid partial verdicts. The pipeline must NOT escalate
+    on that — the Reporter should receive the partial text and apply its
+    normal UPHELD filter. Regression guard for the bug-class this PR targets.
+    """
+    import unittest.mock as mock
+    investigator_notes = (
+        "ID: C1\nFILE: f.py\nLINE: 1\nHYPOTHESIS: real bug\n"
+        "FALSIFICATION_ATTEMPT: searched\nSTATUS: CONFIRMED\n"
+        "SEVERITY: BUG\nCOMMENT: real bug\nEVIDENCE: line 1\nTRIGGER: x\n"
+    )
+    # Critic emits a valid VERDICT line before cap-terminating; the loop
+    # would surface this as result.text + result.error="structural cap hit".
+    critic_text = "VERDICT: C1 | UPHELD | verified line 1 (structural cap hit)"
+    reporter_json = json.dumps({"analysis": [
+        {"file": "f.py", "line": 1, "hypothesis": "real bug",
+         "falsification_attempt": "searched", "disproved": False,
+         "finding": {"severity": "BUG", "comment": "real bug",
+                     "evidence": "line 1", "trigger": "x"}},
+    ]})
+    artifact, mock_invoke, _ = _run_pipeline(
+        tmp_path, monkeypatch, mock,
+        investigator_text=investigator_notes,
+        critic_text=critic_text,
+        reporter_json=reporter_json,
+    )
+    # Pipeline RESPONDS, not ESCALATES — partial verdict text is enough to
+    # drive the Reporter and post valid findings.
+    assert artifact["action"] == "RESPOND"
+    assert mock_invoke.call_count == 1
+    assert len(artifact["inline_comments"]) == 1
+    assert artifact["inline_comments"][0]["file"] == "f.py"
+
+
 def test_metrics_totals_equal_sum_of_stages(tmp_path, monkeypatch):
     """metrics.totals.input_tokens must equal the sum of per-stage tokens
     so dashboards reading totals don't drift from per-stage views.

--- a/src/scripts/tests/test_critic.py
+++ b/src/scripts/tests/test_critic.py
@@ -1,0 +1,407 @@
+"""Tests for the Investigator + Critic + Reporter pipeline integration in main.py.
+
+Mocks Bedrock and GitHub to drive the pipeline end-to-end with the
+BOT_AGENT_PIPELINE flag enabled. Verifies:
+  - clean PRs hit the fast path (skip Critic and Reporter)
+  - PRs with confirmed findings invoke Critic and Reporter
+  - Critic OVERTURNED findings are dropped
+  - Critic UPHELD findings reach the artifact
+  - Pipeline metrics and prompt_ids are recorded
+  - Adaptive caps are computed from PR size
+"""
+import json
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+
+def _setup_pipeline_env(tmp_path, monkeypatch, event_action="opened"):
+    monkeypatch.setenv("GITHUB_TOKEN", "fake")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "awslabs/test")
+    monkeypatch.setenv("ISSUE_NUMBER", "100")
+    monkeypatch.setenv("EVENT_TYPE", "pull_request_target")
+    monkeypatch.setenv("EVENT_ACTION", event_action)
+    monkeypatch.setenv("EVENT_BEFORE", "")
+    monkeypatch.setenv("EVENT_AFTER", "")
+    monkeypatch.setenv("GITHUB_ACTOR", "contributor")
+    monkeypatch.setenv("KB_S3_BUCKET", "")
+    monkeypatch.setenv("KB_S3_KEY", "")
+    monkeypatch.setenv("PR_INVESTIGATOR_PROMPT", "Investigate. Today: {current_date}")
+    monkeypatch.setenv("PR_CRITIC_PROMPT", "Critique. Today: {current_date}")
+    monkeypatch.setenv("PR_FILE_REVIEW_REPORT_PROMPT", "Report. Today: {current_date}")
+    monkeypatch.setenv("BOT_AGENT_PIPELINE", "1")
+    monkeypatch.setenv("GITHUB_WORKSPACE", str(tmp_path))
+    import issue_bot.main as bot_main
+    monkeypatch.setattr(bot_main, "ARTIFACT_PATH", str(tmp_path / "result.json"))
+
+
+def _run_pipeline(tmp_path, monkeypatch, mock,
+                  investigator_text, critic_text, reporter_json,
+                  event_action="opened", event_before="", event_after=""):
+    """Invoke the pipeline with mocked bedrock; return artifact dict + mocks."""
+    _setup_pipeline_env(tmp_path, monkeypatch, event_action=event_action)
+    if event_before or event_after:
+        monkeypatch.setenv("EVENT_BEFORE", event_before)
+        monkeypatch.setenv("EVENT_AFTER", event_after)
+    with mock.patch("issue_bot.github_client.GitHubClient.get_pr") as mock_pr, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_comments") as mock_comments, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_pr_diff") as mock_diff, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_pr_review_comments") as mock_rc, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_compare_diff") as mock_compare, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_pr_files") as mock_files, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_codebase_map") as mock_map, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_ci_status") as mock_ci, \
+         mock.patch("issue_bot.knowledge_base.KnowledgeBase.load"), \
+         mock.patch("issue_bot.knowledge_base.KnowledgeBase.build_context") as mock_kb, \
+         mock.patch("issue_bot.bedrock_client.BedrockClient.__init__", return_value=None), \
+         mock.patch("issue_bot.bedrock_client.BedrockClient.converse_with_tools") as mock_ctools, \
+         mock.patch("issue_bot.bedrock_client.BedrockClient.invoke_with_usage") as mock_invoke:
+
+        mock_pr.return_value = {
+            "user": {"login": "contributor"}, "title": "Add feature",
+            "body": "What this PR does", "state": "open",
+            "html_url": "https://github.com/x", "head": {"sha": "abc123"},
+        }
+        mock_comments.return_value = (
+            [{"user": {"login": "github-actions[bot]"}, "body": "prior"}]
+            if event_action == "synchronize" else []
+        )
+        mock_diff.return_value = "diff --git a/f.py b/f.py\n+new line\n"
+        mock_rc.return_value = []
+        mock_compare.return_value = (
+            "diff --git a/f.py b/f.py\n+new line\n"
+            if event_action == "synchronize" else ""
+        )
+        mock_files.return_value = [{"filename": "f.py", "changes": 50}]
+        mock_map.return_value = ""
+        mock_kb.return_value = ""
+        mock_ci.return_value = (True, "")
+
+        # Investigator: one tool_use turn, then final text
+        # Critic: one tool_use turn, then final text
+        # The fast path skips critic entirely if no CONFIRMED findings.
+        def converse_side_effect(system_prompt, messages, tool_specs, max_tokens=8000, temperature=0.3):
+            # Identify which agent by scanning the system prompt
+            if "Investigate" in system_prompt:
+                return _bedrock_text_resp(investigator_text)
+            if "Critique" in system_prompt:
+                return _bedrock_text_resp(critic_text)
+            return _bedrock_text_resp("???")
+
+        mock_ctools.side_effect = converse_side_effect
+        # Reporter uses invoke_with_usage which returns (text, usage_dict).
+        mock_invoke.return_value = (
+            reporter_json,
+            {"inputTokens": 50, "outputTokens": 20, "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0},
+        )
+
+        from issue_bot.main import analyze
+        analyze()
+
+        with open(str(tmp_path / "result.json")) as f:
+            return json.load(f), mock_invoke, mock_ctools
+
+
+def _bedrock_text_resp(text):
+    """Construct a Bedrock Converse response with end_turn and a single text block."""
+    return {
+        "stopReason": "end_turn",
+        "output": {"message": {"role": "assistant", "content": [{"text": text}]}},
+        "usage": {"inputTokens": 100, "outputTokens": 50,
+                  "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0},
+    }
+
+
+def test_clean_pr_fast_path_skips_critic_and_reporter(tmp_path, monkeypatch):
+    import unittest.mock as mock
+    investigator_notes = "No confirmed issues found."
+    artifact, mock_invoke, mock_ctools = _run_pipeline(
+        tmp_path, monkeypatch, mock,
+        investigator_text=investigator_notes,
+        critic_text="should not be called",
+        reporter_json='{"analysis": []}',
+    )
+    assert artifact["action"] == "RESPOND"
+    assert "No issues found" in artifact["response"]
+    assert artifact["inline_comments"] == []
+    # Critic and Reporter both skipped
+    assert mock_ctools.call_count == 1, "Only the investigator should have been called"
+    assert mock_invoke.call_count == 0, "Reporter should not have been invoked"
+    assert artifact["metrics"]["critic"]["skipped"] is True
+    assert artifact["metrics"]["critic"]["skip_reason"] == "no_confirmed_findings"
+    assert artifact["metrics"]["reporter"]["skipped"] is True
+    assert artifact["pipeline"] == "agentic"
+
+
+def test_confirmed_finding_triggers_critic_and_reporter(tmp_path, monkeypatch):
+    import unittest.mock as mock
+    investigator_notes = (
+        "ID: C1\n"
+        "FILE: f.py\n"
+        "LINE: 1\n"
+        "HYPOTHESIS: real bug\n"
+        "FALSIFICATION_ATTEMPT: searched, none found\n"
+        "STATUS: CONFIRMED\n"
+        "SEVERITY: BUG\n"
+        "COMMENT: real bug\n"
+        "EVIDENCE: line 1\n"
+        "TRIGGER: x\n"
+    )
+    critic_verdicts = "VERDICT: C1 | UPHELD | verified line 1"
+    reporter_json = json.dumps({"analysis": [
+        {"file": "f.py", "line": 1, "hypothesis": "real bug",
+         "falsification_attempt": "searched", "disproved": False,
+         "finding": {"severity": "BUG", "comment": "real bug",
+                     "evidence": "line 1", "trigger": "x"}},
+    ]})
+    artifact, mock_invoke, mock_ctools = _run_pipeline(
+        tmp_path, monkeypatch, mock,
+        investigator_text=investigator_notes,
+        critic_text=critic_verdicts,
+        reporter_json=reporter_json,
+    )
+    assert artifact["action"] == "RESPOND"
+    assert len(artifact["inline_comments"]) == 1
+    assert artifact["inline_comments"][0]["file"] == "f.py"
+    # Investigator + Critic = 2 converse_with_tools calls
+    assert mock_ctools.call_count == 2
+    # Reporter ran via legacy invoke (single-shot, schema-enforced)
+    assert mock_invoke.call_count == 1
+    assert artifact["metrics"]["critic"]["skipped"] is False
+    assert artifact["metrics"]["critic_overturn_rate"] == 0.0
+
+
+def test_overturned_finding_dropped_by_reporter(tmp_path, monkeypatch):
+    import unittest.mock as mock
+    investigator_notes = (
+        "ID: C1\nFILE: f.py\nLINE: 1\nHYPOTHESIS: maybe\n"
+        "FALSIFICATION_ATTEMPT: weak\nSTATUS: CONFIRMED\n"
+        "SEVERITY: BUG\nCOMMENT: c\nEVIDENCE: e\nTRIGGER: t\n"
+    )
+    critic_verdicts = "VERDICT: C1 | OVERTURNED | could not find the cited line"
+    # Reporter respects the verdict and emits empty analysis
+    reporter_json = json.dumps({"analysis": []})
+    artifact, _, _ = _run_pipeline(
+        tmp_path, monkeypatch, mock,
+        investigator_text=investigator_notes,
+        critic_text=critic_verdicts,
+        reporter_json=reporter_json,
+    )
+    assert artifact["action"] == "RESPOND"
+    assert artifact["inline_comments"] == []
+    assert artifact["metrics"]["critic_overturn_rate"] == 1.0
+
+
+def test_pipeline_records_prompt_ids_per_agent(tmp_path, monkeypatch):
+    import unittest.mock as mock
+    artifact, _, _ = _run_pipeline(
+        tmp_path, monkeypatch, mock,
+        investigator_text="No confirmed issues found.",
+        critic_text="",
+        reporter_json="",
+    )
+    assert "prompt_ids" in artifact
+    assert "investigator" in artifact["prompt_ids"]
+    assert "critic" in artifact["prompt_ids"]
+    assert "reporter" in artifact["prompt_ids"]
+    # All three should be 8-char SHA prefixes
+    for k, v in artifact["prompt_ids"].items():
+        assert isinstance(v, str)
+        assert len(v) in (3, 8)  # "n/a" or hash
+
+
+def test_pipeline_falls_back_to_legacy_when_flag_off(tmp_path, monkeypatch):
+    """When BOT_AGENT_PIPELINE is unset, the legacy flow runs."""
+    import unittest.mock as mock
+    monkeypatch.setenv("GITHUB_TOKEN", "fake")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "awslabs/test")
+    monkeypatch.setenv("ISSUE_NUMBER", "100")
+    monkeypatch.setenv("EVENT_TYPE", "pull_request_target")
+    monkeypatch.setenv("EVENT_ACTION", "opened")
+    monkeypatch.setenv("EVENT_BEFORE", "")
+    monkeypatch.setenv("EVENT_AFTER", "")
+    monkeypatch.setenv("GITHUB_ACTOR", "contributor")
+    monkeypatch.setenv("KB_S3_BUCKET", "")
+    monkeypatch.setenv("KB_S3_KEY", "")
+    monkeypatch.setenv("PR_FILE_REVIEW_PROMPT", "Legacy review. Today: {current_date}")
+    monkeypatch.setenv("PR_FILE_REVIEW_REPORT_PROMPT", "Legacy report. Today: {current_date}")
+    # NO BOT_AGENT_PIPELINE set
+    import issue_bot.main as bot_main
+    monkeypatch.setattr(bot_main, "ARTIFACT_PATH", str(tmp_path / "result.json"))
+
+    with mock.patch("issue_bot.github_client.GitHubClient.get_pr") as mock_pr, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_comments") as mock_comments, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_pr_diff") as mock_diff, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_pr_review_comments") as mock_rc, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_pr_files") as mock_files, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_file_content") as mock_content, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_codebase_map") as mock_map, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_ci_status") as mock_ci, \
+         mock.patch("issue_bot.knowledge_base.KnowledgeBase.load"), \
+         mock.patch("issue_bot.knowledge_base.KnowledgeBase.build_context") as mock_kb, \
+         mock.patch("issue_bot.bedrock_client.BedrockClient.__init__", return_value=None), \
+         mock.patch("issue_bot.bedrock_client.BedrockClient.converse_with_tools") as mock_ctools, \
+         mock.patch("issue_bot.bedrock_client.BedrockClient.invoke") as mock_invoke:
+
+        mock_pr.return_value = {
+            "user": {"login": "contributor"}, "title": "T", "body": "B",
+            "state": "open", "html_url": "https://github.com/x", "head": {"sha": "abc123"},
+        }
+        mock_comments.return_value = []
+        mock_diff.return_value = "diff"
+        mock_rc.return_value = []
+        mock_files.return_value = [{"filename": "f.py", "changes": 1}]
+        mock_content.return_value = "content"
+        mock_map.return_value = ""
+        mock_kb.return_value = ""
+        mock_ci.return_value = (True, "")
+        mock_invoke.side_effect = ["No confirmed issues found.", json.dumps({"analysis": []})]
+        bot_main.analyze()
+
+        with open(str(tmp_path / "result.json")) as f:
+            artifact = json.load(f)
+
+        # Legacy path uses invoke (twice), not converse_with_tools
+        assert mock_ctools.call_count == 0
+        assert mock_invoke.call_count == 2
+        # Legacy artifact has no "pipeline" field
+        assert "pipeline" not in artifact
+
+
+def test_pipeline_metrics_record_token_usage(tmp_path, monkeypatch):
+    import unittest.mock as mock
+    artifact, _, _ = _run_pipeline(
+        tmp_path, monkeypatch, mock,
+        investigator_text="No confirmed issues found.",
+        critic_text="",
+        reporter_json="",
+    )
+    metrics = artifact["metrics"]
+    assert "investigator" in metrics
+    assert metrics["investigator"]["input_tokens"] == 100
+    assert metrics["investigator"]["output_tokens"] == 50
+    assert "totals" in metrics
+    assert metrics["totals"]["input_tokens"] == 100
+    assert metrics["totals"]["cost_usd"] >= 0
+
+
+def test_pipeline_handles_missing_prompts(tmp_path, monkeypatch):
+    """If any prompt fails to load, escalate."""
+    import unittest.mock as mock
+    monkeypatch.setenv("GITHUB_TOKEN", "fake")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "awslabs/test")
+    monkeypatch.setenv("ISSUE_NUMBER", "100")
+    monkeypatch.setenv("EVENT_TYPE", "pull_request_target")
+    monkeypatch.setenv("EVENT_ACTION", "opened")
+    monkeypatch.setenv("EVENT_BEFORE", "")
+    monkeypatch.setenv("EVENT_AFTER", "")
+    monkeypatch.setenv("GITHUB_ACTOR", "contributor")
+    monkeypatch.setenv("KB_S3_BUCKET", "")
+    monkeypatch.setenv("KB_S3_KEY", "")
+    monkeypatch.setenv("BOT_AGENT_PIPELINE", "1")
+    # Only set the investigator prompt — critic and reporter are missing
+    monkeypatch.setenv("PR_INVESTIGATOR_PROMPT", "Inv. Today: {current_date}")
+    import issue_bot.main as bot_main
+    monkeypatch.setattr(bot_main, "ARTIFACT_PATH", str(tmp_path / "result.json"))
+
+    with mock.patch("issue_bot.github_client.GitHubClient.get_pr") as mock_pr, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_comments") as mock_comments, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_codebase_map"), \
+         mock.patch("issue_bot.knowledge_base.KnowledgeBase.load"), \
+         mock.patch("issue_bot.knowledge_base.KnowledgeBase.build_context", return_value=""), \
+         mock.patch("issue_bot.bedrock_client.BedrockClient.__init__", return_value=None):
+
+        mock_pr.return_value = {
+            "user": {"login": "contributor"}, "title": "T", "body": "B",
+            "state": "open", "html_url": "https://github.com/x", "head": {"sha": "abc"},
+        }
+        mock_comments.return_value = []
+        bot_main.analyze()
+        with open(str(tmp_path / "result.json")) as f:
+            artifact = json.load(f)
+        assert artifact["action"] == "ESCALATE"
+        assert "prompt_load_failed" in artifact["reason"]
+
+
+def test_pipeline_filters_invalid_line_numbers(tmp_path, monkeypatch):
+    """Reporter output with line=0 should be filtered out."""
+    import unittest.mock as mock
+    investigator_notes = (
+        "ID: C1\nFILE: f.py\nLINE: 1\nHYPOTHESIS: h\n"
+        "FALSIFICATION_ATTEMPT: fa\nSTATUS: CONFIRMED\n"
+        "SEVERITY: BUG\nCOMMENT: c\nEVIDENCE: e\nTRIGGER: t\n"
+    )
+    critic_text = "VERDICT: C1 | UPHELD | verified"
+    reporter_json = json.dumps({"analysis": [
+        {"file": "f.py", "line": 0, "hypothesis": "h",
+         "falsification_attempt": "fa", "disproved": False,
+         "finding": {"severity": "BUG", "comment": "c", "evidence": "e"}},
+    ]})
+    artifact, _, _ = _run_pipeline(
+        tmp_path, monkeypatch, mock,
+        investigator_text=investigator_notes,
+        critic_text=critic_text,
+        reporter_json=reporter_json,
+    )
+    assert artifact["inline_comments"] == []
+
+
+def test_reporter_cost_in_totals(tmp_path, monkeypatch):
+    """Reporter token usage must be added to metrics.totals."""
+    import unittest.mock as mock
+    investigator_notes = (
+        "ID: C1\nFILE: f.py\nLINE: 1\nHYPOTHESIS: h\n"
+        "FALSIFICATION_ATTEMPT: fa\nSTATUS: CONFIRMED\n"
+        "SEVERITY: BUG\nCOMMENT: c\nEVIDENCE: e\nTRIGGER: t\n"
+    )
+    critic_text = "VERDICT: C1 | UPHELD | verified"
+    reporter_json = json.dumps({"analysis": [
+        {"file": "f.py", "line": 1, "hypothesis": "h",
+         "falsification_attempt": "fa", "disproved": False,
+         "finding": {"severity": "BUG", "comment": "c", "evidence": "e"}},
+    ]})
+    artifact, _, _ = _run_pipeline(
+        tmp_path, monkeypatch, mock,
+        investigator_text=investigator_notes,
+        critic_text=critic_text,
+        reporter_json=reporter_json,
+    )
+    # Investigator + Critic each contribute 100 inputTokens (mocked).
+    # Reporter contributes 50 inputTokens, 20 outputTokens (mocked).
+    metrics = artifact["metrics"]
+    assert metrics["reporter"]["input_tokens"] == 50
+    assert metrics["reporter"]["output_tokens"] == 20
+    # totals = inv (100/50) + crit (100/50) + rep (50/20)
+    assert metrics["totals"]["input_tokens"] == 250
+    assert metrics["totals"]["output_tokens"] == 120
+
+
+def test_critic_overturn_rate_calculated(tmp_path, monkeypatch):
+    import unittest.mock as mock
+    # Three findings, one upheld, two overturned → rate = 2/3
+    investigator_notes = "\n".join([
+        f"ID: C{i}\nFILE: f.py\nLINE: {i}\nHYPOTHESIS: h\n"
+        "FALSIFICATION_ATTEMPT: fa\nSTATUS: CONFIRMED\n"
+        "SEVERITY: BUG\nCOMMENT: c\nEVIDENCE: e\nTRIGGER: t\n"
+        for i in (1, 2, 3)
+    ])
+    critic_text = "\n".join([
+        "VERDICT: C1 | UPHELD | ok",
+        "VERDICT: C2 | OVERTURNED | not real",
+        "VERDICT: C3 | OVERTURNED | also not real",
+    ])
+    reporter_json = json.dumps({"analysis": [
+        {"file": "f.py", "line": 1, "hypothesis": "h",
+         "falsification_attempt": "fa", "disproved": False,
+         "finding": {"severity": "BUG", "comment": "c", "evidence": "e"}},
+    ]})
+    artifact, _, _ = _run_pipeline(
+        tmp_path, monkeypatch, mock,
+        investigator_text=investigator_notes,
+        critic_text=critic_text,
+        reporter_json=reporter_json,
+    )
+    assert artifact["metrics"]["critic_overturn_rate"] == pytest.approx(2 / 3, abs=0.01)

--- a/src/scripts/tests/test_critic.py
+++ b/src/scripts/tests/test_critic.py
@@ -510,3 +510,73 @@ def test_critic_overturn_rate_calculated(tmp_path, monkeypatch):
         reporter_json=reporter_json,
     )
     assert artifact["metrics"]["critic_overturn_rate"] == pytest.approx(2 / 3, abs=0.01)
+
+def test_critic_failure_escalates_does_not_post_clean(tmp_path, monkeypatch):
+    """If the Critic returns empty/error, the pipeline must ESCALATE rather
+    than synthesize a fake 'all disproved' verdict and silently drop findings.
+    """
+    import unittest.mock as mock
+    investigator_notes = (
+        "ID: C1\nFILE: f.py\nLINE: 1\nHYPOTHESIS: real bug\n"
+        "FALSIFICATION_ATTEMPT: searched\nSTATUS: CONFIRMED\n"
+        "SEVERITY: BUG\nCOMMENT: real bug\nEVIDENCE: line 1\nTRIGGER: x\n"
+    )
+    artifact, _, _ = _run_pipeline(
+        tmp_path, monkeypatch, mock,
+        investigator_text=investigator_notes,
+        critic_text="",  # critic returned empty (e.g. crashed)
+        reporter_json="",
+    )
+    assert artifact["action"] == "ESCALATE"
+    assert artifact["reason"] == "critic_failed"
+    assert artifact["inline_comments"] == []
+
+
+def test_metrics_totals_equal_sum_of_stages(tmp_path, monkeypatch):
+    """metrics.totals.input_tokens must equal the sum of per-stage tokens
+    so dashboards reading totals don't drift from per-stage views.
+    """
+    import unittest.mock as mock
+    investigator_notes = (
+        "ID: C1\nFILE: f.py\nLINE: 1\nHYPOTHESIS: h\n"
+        "FALSIFICATION_ATTEMPT: fa\nSTATUS: CONFIRMED\n"
+        "SEVERITY: BUG\nCOMMENT: c\nEVIDENCE: e\nTRIGGER: t\n"
+    )
+    artifact, _, _ = _run_pipeline(
+        tmp_path, monkeypatch, mock,
+        investigator_text=investigator_notes,
+        critic_text="VERDICT: C1 | UPHELD | ok",
+        reporter_json=json.dumps({"analysis": [
+            {"file": "f.py", "line": 1, "hypothesis": "h",
+             "falsification_attempt": "fa", "disproved": False,
+             "finding": {"severity": "BUG", "comment": "c", "evidence": "e"}},
+        ]}),
+    )
+    m = artifact["metrics"]
+    expected_in = m["investigator"]["input_tokens"] + m["critic"]["input_tokens"] + m["reporter"]["input_tokens"]
+    expected_out = m["investigator"]["output_tokens"] + m["critic"]["output_tokens"] + m["reporter"]["output_tokens"]
+    assert m["totals"]["input_tokens"] == expected_in
+    assert m["totals"]["output_tokens"] == expected_out
+
+
+def test_metrics_schema_uniform_across_stages(tmp_path, monkeypatch):
+    """Every stage's metrics dict carries the same canonical key set so
+    dashboards iterating stages don't KeyError."""
+    import unittest.mock as mock
+    investigator_notes = "No confirmed issues found."
+    artifact, _, _ = _run_pipeline(
+        tmp_path, monkeypatch, mock,
+        investigator_text=investigator_notes,
+        critic_text="",
+        reporter_json="",
+    )
+    canonical_keys = {
+        "skipped", "skip_reason", "turns", "tool_calls", "tool_output_chars",
+        "input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
+        "max_turns_reached", "error", "parse_failed",
+    }
+    for stage in ("investigator", "critic", "reporter"):
+        assert set(artifact["metrics"][stage].keys()) >= canonical_keys, (
+            f"stage {stage} missing keys: {canonical_keys - set(artifact['metrics'][stage].keys())}"
+        )
+

--- a/src/scripts/tests/test_pipeline_helpers.py
+++ b/src/scripts/tests/test_pipeline_helpers.py
@@ -194,3 +194,99 @@ def _setup_minimal_env(monkeypatch):
     monkeypatch.setenv("EVENT_TYPE", "pull_request_target")
     monkeypatch.setenv("ISSUE_NUMBER", "1")
     monkeypatch.setenv("GITHUB_REPOSITORY", "awslabs/test")
+
+
+from issue_bot.main import _truncate_diff_for_user_prompt, _format_pr_input
+
+
+def test_truncate_diff_under_cap_passthrough():
+    diff = "diff --git a/f.py b/f.py\n+x\n"
+    assert _truncate_diff_for_user_prompt(diff, 1000) == diff
+
+
+def test_truncate_diff_over_cap_truncates_with_marker():
+    diff = "x" * 500
+    out = _truncate_diff_for_user_prompt(diff, 100)
+    assert len(out) < 500
+    assert "diff truncated at 100 chars" in out
+
+
+def test_truncate_diff_at_exact_boundary_passthrough():
+    diff = "x" * 100
+    assert _truncate_diff_for_user_prompt(diff, 100) == diff
+
+
+def test_format_pr_input_shape_is_canonical():
+    """Investigator and Critic must frame PR title/body identically so the
+    guardrail wraps the same shape on both."""
+    out = _format_pr_input("Add feature", "What this does")
+    assert out == "<pr>\nTitle: Add feature\nBody: What this does\n</pr>"
+
+
+def test_agent_max_diff_chars_default(monkeypatch):
+    monkeypatch.delenv("BOT_AGENT_MAX_DIFF_CHARS", raising=False)
+    _setup_minimal_env(monkeypatch)
+    from issue_bot.config import Config
+    cfg = Config()
+    assert cfg.agent_max_diff_chars == 200_000
+
+
+def test_agent_max_diff_chars_env_override(monkeypatch):
+    monkeypatch.setenv("BOT_AGENT_MAX_DIFF_CHARS", "50000")
+    _setup_minimal_env(monkeypatch)
+    from issue_bot.config import Config
+    cfg = Config()
+    assert cfg.agent_max_diff_chars == 50_000
+
+
+def test_agent_max_diff_chars_falls_back_on_garbage(monkeypatch):
+    monkeypatch.setenv("BOT_AGENT_MAX_DIFF_CHARS", "not-a-number")
+    _setup_minimal_env(monkeypatch)
+    from issue_bot.config import Config
+    cfg = Config()
+    assert cfg.agent_max_diff_chars == 200_000
+
+
+@pytest.mark.parametrize("bad_value", ["0", "-1", "-200000"])
+def test_agent_max_diff_chars_non_positive_falls_back(monkeypatch, bad_value):
+    """A non-positive value would silently make _truncate_diff_for_user_prompt
+    drop the entire diff (diff[:0] == ''), leaving the model with no context
+    and inviting hallucinated findings. Must fail safe to the default."""
+    monkeypatch.setenv("BOT_AGENT_MAX_DIFF_CHARS", bad_value)
+    _setup_minimal_env(monkeypatch)
+    from issue_bot.config import Config
+    cfg = Config()
+    assert cfg.agent_max_diff_chars == 200_000
+
+
+from issue_bot.main import (
+    _CRITIC_STAGE_EVENTS, _ESCALATE_EVENTS, _KNOWN_PIPELINE_EVENTS,
+)
+
+
+def test_pipeline_event_classification_complete():
+    """Every known event must be classifiable as either critic-stage or
+    escalate (or both). An event in neither set would be silently ignored
+    by _run_agent_pipeline and let the pipeline post a clean review while
+    dropping confirmed findings."""
+    classified = _CRITIC_STAGE_EVENTS | _ESCALATE_EVENTS
+    unclassified = _KNOWN_PIPELINE_EVENTS - classified
+    assert unclassified == frozenset(), (
+        f"Events not classified into _CRITIC_STAGE_EVENTS or _ESCALATE_EVENTS: "
+        f"{sorted(unclassified)}. Add them so the pipeline routes them correctly."
+    )
+
+
+def test_pipeline_event_known_set_includes_documented_events():
+    """The known-event set must include every value _run_critic_and_reporter
+    documents in its docstring as a possible return."""
+    documented = {
+        "no_confirmed_findings",
+        "critic_failed",
+        "reporter_deadline_exceeded",
+        "reporter_failed",
+        "unknown_pipeline_event",
+    }
+    assert documented <= _KNOWN_PIPELINE_EVENTS, (
+        f"Documented events not in known set: {documented - _KNOWN_PIPELINE_EVENTS}"
+    )

--- a/src/scripts/tests/test_pipeline_helpers.py
+++ b/src/scripts/tests/test_pipeline_helpers.py
@@ -137,23 +137,13 @@ def test_agent_pipeline_flag_on_for_positive_values(monkeypatch, value):
     assert cfg.agent_pipeline is True, f"Expected ON for value={value!r}"
 
 
-def test_int_env_falls_back_on_garbage(monkeypatch, caplog):
-    """Garbage env input must NOT crash module import; falls back to default
-    with a warning."""
+def test_int_env_falls_back_on_garbage(monkeypatch):
+    """Garbage env input must NOT crash module import; falls back to default."""
     monkeypatch.setenv("BOT_INVESTIGATOR_MAX_TURNS", "15m")
     _setup_minimal_env(monkeypatch)
     from issue_bot.config import Config
     cfg = Config()
     assert cfg.investigator_max_turns == 15  # default
-
-
-def test_int_env_clamps_below_minimum(monkeypatch):
-    """Negative or absurdly low values clamp to the configured minimum."""
-    monkeypatch.setenv("BOT_INVESTIGATOR_MAX_TURNS", "-5")
-    _setup_minimal_env(monkeypatch)
-    from issue_bot.config import Config
-    cfg = Config()
-    assert cfg.investigator_max_turns >= 1
 
 
 from issue_bot.main import _canonicalize_path, _extract_diff_files
@@ -180,6 +170,14 @@ def test_canonicalize_path_idempotent():
 def test_canonicalize_path_handles_empty():
     assert _canonicalize_path("") == ""
     assert _canonicalize_path(None) == ""
+
+
+def test_canonicalize_path_dot_paths_become_empty():
+    # posixpath.normpath collapses these to "." which must NOT pass through
+    # as a member of incremental_files or a c["file"] value.
+    assert _canonicalize_path(".") == ""
+    assert _canonicalize_path("./") == ""
+    assert _canonicalize_path(".//") == ""
 
 
 def test_extract_diff_files_returns_canonical_paths():

--- a/src/scripts/tests/test_pipeline_helpers.py
+++ b/src/scripts/tests/test_pipeline_helpers.py
@@ -1,0 +1,145 @@
+"""Tests for helpers in main.py used by the agent pipeline.
+
+These cover the regressions surfaced by adversarial review:
+  - flag parser: BOT_AGENT_PIPELINE accepts only positive values
+  - _has_confirmed_findings: anchored, strict
+  - _critic_overturn_rate: anchored, ignores rationale substrings
+"""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from issue_bot.main import _has_confirmed_findings, _critic_overturn_rate
+
+
+def test_has_confirmed_findings_simple():
+    notes = "ID: C1\nSTATUS: CONFIRMED\nCOMMENT: bug"
+    assert _has_confirmed_findings(notes) is True
+
+
+def test_has_confirmed_findings_disproved_only():
+    notes = "ID: C1\nSTATUS: DISPROVED\nCOMMENT: not a bug"
+    assert _has_confirmed_findings(notes) is False
+
+
+def test_has_confirmed_findings_empty():
+    assert _has_confirmed_findings("") is False
+    assert _has_confirmed_findings(None) is False
+
+
+def test_has_confirmed_findings_ignores_substring_in_comment():
+    """A COMMENT field mentioning CONFIRMED on a DISPROVED finding must NOT match."""
+    notes = (
+        "ID: C1\n"
+        "STATUS: DISPROVED\n"
+        "COMMENT: I had initially CONFIRMED this but found counter-evidence\n"
+    )
+    assert _has_confirmed_findings(notes) is False
+
+
+def test_has_confirmed_findings_case_insensitive():
+    assert _has_confirmed_findings("status: confirmed") is True
+    assert _has_confirmed_findings("Status: Confirmed") is True
+
+
+def test_has_confirmed_findings_mixed():
+    """Both CONFIRMED and DISPROVED present → still True."""
+    notes = (
+        "ID: C1\nSTATUS: DISPROVED\n"
+        "ID: C2\nSTATUS: CONFIRMED\n"
+        "ID: C3\nSTATUS: DISPROVED\n"
+    )
+    assert _has_confirmed_findings(notes) is True
+
+
+def test_has_confirmed_findings_status_with_extra_text():
+    """STATUS: CONFIRMED-DEFERRED should NOT match (anchored at end of CONFIRMED)."""
+    notes = "STATUS: CONFIRMED-DEFERRED\n"
+    assert _has_confirmed_findings(notes) is False
+
+
+def test_critic_overturn_rate_basic():
+    text = "VERDICT: C1 | UPHELD | ok\nVERDICT: C2 | OVERTURNED | not real\n"
+    assert _critic_overturn_rate(text) == 0.5
+
+
+def test_critic_overturn_rate_all_upheld():
+    text = "VERDICT: C1 | UPHELD | ok\nVERDICT: C2 | UPHELD | ok\n"
+    assert _critic_overturn_rate(text) == 0.0
+
+
+def test_critic_overturn_rate_all_overturned():
+    text = "VERDICT: C1 | OVERTURNED | no\nVERDICT: C2 | OVERTURNED | no\n"
+    assert _critic_overturn_rate(text) == 1.0
+
+
+def test_critic_overturn_rate_no_verdicts():
+    assert _critic_overturn_rate("") is None
+    assert _critic_overturn_rate("ALL_DISPROVED: nothing to verify") is None
+
+
+def test_critic_overturn_rate_ignores_substring_in_rationale():
+    """An UPHELD verdict whose rationale contains 'OVERTURNED' must count as UPHELD only."""
+    text = "VERDICT: C1 | UPHELD | OVERTURNED reasoning was wrong, finding holds\n"
+    # Anchored at line start: only UPHELD counts. Overturn rate = 0.
+    assert _critic_overturn_rate(text) == 0.0
+
+
+def test_critic_overturn_rate_ignores_substring_in_other_overturned_rationale():
+    text = "VERDICT: C1 | OVERTURNED | the UPHELD-style claim is wrong\n"
+    assert _critic_overturn_rate(text) == 1.0
+
+
+def test_critic_overturn_rate_handles_mixed_case():
+    text = "verdict: c1 | upheld | ok\nVERDICT: C2 | OVERTURNED | no\n"
+    # Both should match (case-insensitive)
+    assert _critic_overturn_rate(text) == 0.5
+
+
+def test_critic_overturn_rate_skips_lines_without_verdict_prefix():
+    text = (
+        "Some preamble that mentions UPHELD findings\n"
+        "VERDICT: C1 | UPHELD | ok\n"
+        "Some explanation\n"
+    )
+    # Only the anchored line counts
+    assert _critic_overturn_rate(text) == 0.0
+
+
+def test_agent_pipeline_flag_off_when_unset(monkeypatch):
+    """Conservative parser: pipeline OFF when flag unset."""
+    monkeypatch.delenv("BOT_AGENT_PIPELINE", raising=False)
+    _setup_minimal_env(monkeypatch)
+    from issue_bot.config import Config
+    cfg = Config()
+    assert cfg.agent_pipeline is False
+
+
+@pytest.mark.parametrize("value", ["", "false", "False", "FALSE", "0", "no", "NO", "off", "OFF", "  ", "disable"])
+def test_agent_pipeline_flag_off_for_negative_values(monkeypatch, value):
+    """Anything that isn't in the positive allowlist keeps pipeline OFF."""
+    monkeypatch.setenv("BOT_AGENT_PIPELINE", value)
+    _setup_minimal_env(monkeypatch)
+    from issue_bot.config import Config
+    cfg = Config()
+    assert cfg.agent_pipeline is False, f"Expected OFF for value={value!r}"
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "True", "yes", "YES", "on", "ON", "  1  ", "  true  "])
+def test_agent_pipeline_flag_on_for_positive_values(monkeypatch, value):
+    monkeypatch.setenv("BOT_AGENT_PIPELINE", value)
+    _setup_minimal_env(monkeypatch)
+    from issue_bot.config import Config
+    cfg = Config()
+    assert cfg.agent_pipeline is True, f"Expected ON for value={value!r}"
+
+
+def _setup_minimal_env(monkeypatch):
+    """Set env vars Config requires (avoids sys.exit during construction)."""
+    monkeypatch.setenv("GITHUB_TOKEN", "fake")
+    monkeypatch.setenv("EVENT_TYPE", "pull_request_target")
+    monkeypatch.setenv("ISSUE_NUMBER", "1")
+    monkeypatch.setenv("GITHUB_REPOSITORY", "awslabs/test")

--- a/src/scripts/tests/test_pipeline_helpers.py
+++ b/src/scripts/tests/test_pipeline_helpers.py
@@ -137,6 +137,59 @@ def test_agent_pipeline_flag_on_for_positive_values(monkeypatch, value):
     assert cfg.agent_pipeline is True, f"Expected ON for value={value!r}"
 
 
+def test_int_env_falls_back_on_garbage(monkeypatch, caplog):
+    """Garbage env input must NOT crash module import; falls back to default
+    with a warning."""
+    monkeypatch.setenv("BOT_INVESTIGATOR_MAX_TURNS", "15m")
+    _setup_minimal_env(monkeypatch)
+    from issue_bot.config import Config
+    cfg = Config()
+    assert cfg.investigator_max_turns == 15  # default
+
+
+def test_int_env_clamps_below_minimum(monkeypatch):
+    """Negative or absurdly low values clamp to the configured minimum."""
+    monkeypatch.setenv("BOT_INVESTIGATOR_MAX_TURNS", "-5")
+    _setup_minimal_env(monkeypatch)
+    from issue_bot.config import Config
+    cfg = Config()
+    assert cfg.investigator_max_turns >= 1
+
+
+from issue_bot.main import _canonicalize_path, _extract_diff_files
+
+
+def test_canonicalize_path_strips_leading_dot_slash():
+    assert _canonicalize_path("./src/foo.py") == "src/foo.py"
+
+
+def test_canonicalize_path_collapses_double_slash():
+    assert _canonicalize_path("src//foo.py") == "src/foo.py"
+
+
+def test_canonicalize_path_handles_backslashes():
+    assert _canonicalize_path("src\\foo.py") == "src/foo.py"
+
+
+def test_canonicalize_path_idempotent():
+    p = "src/main/scala/X.scala"
+    assert _canonicalize_path(p) == p
+    assert _canonicalize_path(_canonicalize_path(p)) == p
+
+
+def test_canonicalize_path_handles_empty():
+    assert _canonicalize_path("") == ""
+    assert _canonicalize_path(None) == ""
+
+
+def test_extract_diff_files_returns_canonical_paths():
+    diff = "diff --git a/./src/foo.py b/./src/foo.py\n@@ ...\n+x\n"
+    files = _extract_diff_files(diff)
+    # Stored canonically (no './' prefix) so Reporter c["file"] comparisons work
+    assert "src/foo.py" in files
+    assert "./src/foo.py" not in files
+
+
 def _setup_minimal_env(monkeypatch):
     """Set env vars Config requires (avoids sys.exit during construction)."""
     monkeypatch.setenv("GITHUB_TOKEN", "fake")

--- a/src/scripts/tests/test_tools.py
+++ b/src/scripts/tests/test_tools.py
@@ -1,0 +1,267 @@
+"""Tests for issue_bot.tools — the agentic pipeline's tool implementations."""
+import os
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from issue_bot.tools import (
+    grep_codebase,
+    read_file,
+    list_dir,
+    find_callers,
+    find_tests_for,
+    ToolRunner,
+    TOOL_SPECS,
+)
+
+
+@pytest.fixture
+def repo(tmp_path):
+    """Create a fake repo layout for tool tests."""
+    src = tmp_path / "src" / "main" / "scala"
+    src.mkdir(parents=True)
+    test = tmp_path / "src" / "test" / "scala"
+    test.mkdir(parents=True)
+    (src / "Foo.scala").write_text(
+        "case class Foo(x: Int)\n"
+        "object Foo {\n"
+        "  def bar(): Int = 42\n"
+        "}\n"
+    )
+    (src / "Bar.scala").write_text(
+        "import com.example.Foo\n"
+        "class Bar { def use(): Foo = Foo(1) }\n"
+    )
+    (src / "Unused.scala").write_text("// nothing here\n")
+    (test / "FooTest.scala").write_text(
+        "class FooTest {\n"
+        "  def testFoo(): Unit = { Foo(2) }\n"
+        "}\n"
+    )
+    return tmp_path
+
+
+def test_grep_codebase_finds_symbol(repo):
+    out = grep_codebase("Foo", "", str(repo), "src/main/scala", ".scala")
+    assert "Foo.scala" in out
+    assert "Bar.scala" in out
+    assert "Found" in out
+
+
+def test_grep_codebase_no_matches(repo):
+    out = grep_codebase("ThisDoesNotExist", "", str(repo), "src/main/scala", ".scala")
+    assert "No matches" in out
+
+
+def test_grep_codebase_invalid_regex(repo):
+    out = grep_codebase("[invalid(", "", str(repo), "src/main/scala", ".scala")
+    assert "ERROR" in out
+    assert "regex" in out.lower()
+
+
+def test_grep_codebase_missing_dir(tmp_path):
+    out = grep_codebase("anything", "", str(tmp_path), "missing/dir", ".scala")
+    assert "ERROR" in out
+
+
+def test_grep_codebase_empty_pattern(repo):
+    out = grep_codebase("", "", str(repo), "src/main/scala", ".scala")
+    assert "ERROR" in out
+
+
+def test_read_file_basic(repo):
+    out = read_file("src/main/scala/Foo.scala", 1, 4, str(repo))
+    assert "case class Foo" in out
+    assert "1│" in out  # line numbers
+    assert "lines 1-4" in out
+
+
+def test_read_file_default_end(repo):
+    out = read_file("src/main/scala/Foo.scala", 1, -2, str(repo))
+    assert "case class Foo" in out
+
+
+def test_read_file_path_traversal_rejected(repo):
+    out = read_file("../../etc/passwd", 1, 10, str(repo))
+    assert "ERROR" in out
+
+
+def test_read_file_absolute_path_rejected(repo):
+    out = read_file("/etc/passwd", 1, 10, str(repo))
+    assert "ERROR" in out
+
+
+def test_read_file_dotdot_rejected(repo):
+    out = read_file("foo/../bar", 1, 10, str(repo))
+    assert "ERROR" in out
+
+
+def test_read_file_missing(repo):
+    out = read_file("src/main/scala/DoesNotExist.scala", 1, 10, str(repo))
+    assert "ERROR" in out
+    assert "not found" in out
+
+
+def test_read_file_caps_at_200_lines(repo):
+    """A 1000-line file should return at most 200 lines per call."""
+    big = repo / "src" / "main" / "scala" / "Big.scala"
+    big.write_text("\n".join(f"line {i}" for i in range(1, 1001)) + "\n")
+    out = read_file("src/main/scala/Big.scala", 1, -1, str(repo))
+    # When end_line=-1, the function uses the file's full length but should still cap
+    # at 200 lines per call. Check by counting line-prefix occurrences.
+    line_count = sum(1 for ln in out.splitlines() if "│" in ln)
+    assert line_count == 200, f"expected 200 lines, got {line_count}"
+
+
+def test_list_dir(repo):
+    out = list_dir("src/main/scala", str(repo))
+    assert "Foo.scala" in out
+    assert "Bar.scala" in out
+
+
+def test_list_dir_path_traversal_rejected(repo):
+    out = list_dir("../..", str(repo))
+    assert "ERROR" in out
+
+
+def test_list_dir_not_a_directory(repo):
+    out = list_dir("src/main/scala/Foo.scala", str(repo))
+    assert "ERROR" in out
+
+
+def test_find_callers_ranks_by_count(repo):
+    """Both Foo.scala and Bar.scala reference Foo; the file with more refs ranks higher."""
+    # Add a third file that uses Foo many times to nail down the ordering
+    extra = repo / "src" / "main" / "scala" / "Many.scala"
+    extra.write_text("\n".join(["// Foo Foo Foo Foo Foo"] * 5))
+    out = find_callers("Foo", str(repo), "src/main/scala", ".scala")
+    assert "Foo.scala" in out
+    assert "Bar.scala" in out
+    assert "Many.scala" in out
+    # Many.scala has the most references and should appear first
+    many_idx = out.index("Many.scala")
+    foo_idx = out.index("Foo.scala")
+    bar_idx = out.index("Bar.scala")
+    assert many_idx < foo_idx
+    assert many_idx < bar_idx
+
+
+def test_find_callers_invalid_symbol(repo):
+    out = find_callers("not a valid identifier!", str(repo), "src/main/scala", ".scala")
+    assert "ERROR" in out
+
+
+def test_find_callers_no_matches(repo):
+    out = find_callers("DoesNotExistAnywhere", str(repo), "src/main/scala", ".scala")
+    assert "No files reference" in out
+
+
+def test_find_tests_for_source_path(repo):
+    out = find_tests_for("src/main/scala/Foo.scala", str(repo), "src/main/scala", ".scala")
+    assert "FooTest.scala" in out
+
+
+def test_find_tests_for_symbol(repo):
+    out = find_tests_for("Foo", str(repo), "src/main/scala", ".scala")
+    assert "FooTest.scala" in out
+
+
+def test_find_tests_for_no_match(repo):
+    out = find_tests_for("Nonexistent", str(repo), "src/main/scala", ".scala")
+    assert "No tests found" in out
+
+
+class FakeCfg:
+    def __init__(self, root):
+        self.codebase_src_dir = "src/main/scala"
+        self.codebase_file_ext = ".scala"
+
+
+def test_tool_runner_dispatches_grep(repo):
+    runner = ToolRunner(FakeCfg(repo), str(repo))
+    out = runner.run("grep_codebase", {"pattern": "Foo"})
+    assert "Foo.scala" in out
+
+
+def test_tool_runner_dispatches_read_file(repo):
+    runner = ToolRunner(FakeCfg(repo), str(repo))
+    out = runner.run("read_file", {"path": "src/main/scala/Foo.scala", "start_line": 1, "end_line": 2})
+    assert "case class Foo" in out
+
+
+def test_tool_runner_unknown_tool(repo):
+    runner = ToolRunner(FakeCfg(repo), str(repo))
+    out = runner.run("not_a_real_tool", {})
+    assert "ERROR" in out
+    assert "unknown" in out.lower()
+
+
+def test_tool_runner_non_dict_args(repo):
+    runner = ToolRunner(FakeCfg(repo), str(repo))
+    out = runner.run("read_file", "not a dict")
+    assert "ERROR" in out
+
+
+def test_tool_runner_missing_required_args(repo):
+    runner = ToolRunner(FakeCfg(repo), str(repo))
+    # Missing 'pattern' should not raise; tool should return ERROR string
+    out = runner.run("grep_codebase", {})
+    assert "ERROR" in out
+
+
+def test_tool_runner_never_raises(repo):
+    """Tools must never raise — they return error strings instead."""
+    runner = ToolRunner(FakeCfg(repo), str(repo))
+    # Throw garbage at every tool
+    for name in ("grep_codebase", "read_file", "list_dir", "find_callers", "find_tests_for"):
+        out = runner.run(name, {"path": None, "pattern": None, "symbol": None, "target": None})
+        assert isinstance(out, str)
+
+
+def test_tool_specs_well_formed():
+    """TOOL_SPECS must conform to Bedrock's expected shape."""
+    assert isinstance(TOOL_SPECS, list) and len(TOOL_SPECS) >= 5
+    for spec in TOOL_SPECS:
+        assert "toolSpec" in spec
+        ts = spec["toolSpec"]
+        assert "name" in ts and isinstance(ts["name"], str)
+        assert "description" in ts and isinstance(ts["description"], str)
+        assert "inputSchema" in ts
+        assert "json" in ts["inputSchema"]
+        schema = ts["inputSchema"]["json"]
+        assert schema["type"] == "object"
+        assert "properties" in schema
+        assert "required" in schema
+
+
+def test_grep_truncation_marker_on_huge_match(repo):
+    """If grep returns >50K chars, output must be truncated with a marker."""
+    huge = repo / "src" / "main" / "scala" / "Huge.scala"
+    huge.write_text(("matchme " * 1000 + "\n") * 100)  # many matches per line
+    out = grep_codebase("matchme", "", str(repo), "src/main/scala", ".scala")
+    if len(out) >= 50_000:
+        assert "truncated" in out.lower()
+
+
+def test_read_file_end_line_negative_one_yields_full_file(repo):
+    """end_line=-1 should yield to-end-of-file (capped at 200 lines/call)."""
+    # Create a 250-line file
+    big = repo / "src" / "main" / "scala" / "Mid.scala"
+    big.write_text("\n".join(f"line {i}" for i in range(1, 251)) + "\n")
+    out = read_file("src/main/scala/Mid.scala", 1, -1, str(repo))
+    # With 250 total lines, the cap of 200 lines/call should apply, but the
+    # reported `end` should be 200 (not the default of start+199 which is
+    # also 200, so check the visible end line is 200).
+    line_count = sum(1 for ln in out.splitlines() if "│" in ln)
+    assert line_count == 200
+    assert "lines 1-200 of 250" in out
+
+    # When end_line=-1 and start is past the cap, slice should still work
+    out2 = read_file("src/main/scala/Mid.scala", 100, -1, str(repo))
+    assert "lines 100-250 of 250" in out2 or "lines 100-299" in out2  # depending on cap interaction
+    # Actually, end_line=-1 on small remainder should reach EOF
+    # 250 - 100 + 1 = 151 lines, under the 200-line cap, so we get full remainder
+    line_count2 = sum(1 for ln in out2.splitlines() if "│" in ln)
+    assert line_count2 == 151

--- a/src/scripts/tests/test_tools.py
+++ b/src/scripts/tests/test_tools.py
@@ -245,23 +245,28 @@ def test_grep_truncation_marker_on_huge_match(repo):
         assert "truncated" in out.lower()
 
 
-def test_read_file_end_line_negative_one_yields_full_file(repo):
-    """end_line=-1 should yield to-end-of-file (capped at 200 lines/call)."""
-    # Create a 250-line file
+def test_read_file_end_line_negative_one_caps_at_200_lines_for_large_files(repo):
+    """end_line=-1 on a >200-line file: the per-call cap (200) wins."""
     big = repo / "src" / "main" / "scala" / "Mid.scala"
     big.write_text("\n".join(f"line {i}" for i in range(1, 251)) + "\n")
     out = read_file("src/main/scala/Mid.scala", 1, -1, str(repo))
-    # With 250 total lines, the cap of 200 lines/call should apply, but the
-    # reported `end` should be 200 (not the default of start+199 which is
-    # also 200, so check the visible end line is 200).
     line_count = sum(1 for ln in out.splitlines() if "│" in ln)
     assert line_count == 200
     assert "lines 1-200 of 250" in out
 
-    # When end_line=-1 and start is past the cap, slice should still work
-    out2 = read_file("src/main/scala/Mid.scala", 100, -1, str(repo))
-    assert "lines 100-250 of 250" in out2 or "lines 100-299" in out2  # depending on cap interaction
-    # Actually, end_line=-1 on small remainder should reach EOF
-    # 250 - 100 + 1 = 151 lines, under the 200-line cap, so we get full remainder
-    line_count2 = sum(1 for ln in out2.splitlines() if "│" in ln)
-    assert line_count2 == 151
+
+def test_read_file_end_line_negative_one_reaches_eof_when_remainder_fits(repo):
+    """end_line=-1 with start past the cap: remainder is < 200 lines, so EOF wins."""
+    big = repo / "src" / "main" / "scala" / "Mid.scala"
+    big.write_text("\n".join(f"line {i}" for i in range(1, 251)) + "\n")
+    out = read_file("src/main/scala/Mid.scala", 100, -1, str(repo))
+    line_count = sum(1 for ln in out.splitlines() if "│" in ln)
+    assert line_count == 151  # 250 - 100 + 1
+    assert "lines 100-250 of 250" in out
+
+
+def test_read_file_end_line_none_uses_default(repo):
+    """end_line=None should behave the same as omitting the arg."""
+    out = read_file("src/main/scala/Foo.scala", 1, None, str(repo))
+    assert "case class Foo" in out
+    assert "lines 1-" in out


### PR DESCRIPTION
## Summary

Adds a 3-stage agentic PR review pipeline (Investigator → Critic → Reporter) behind the `BOT_AGENT_PIPELINE` flag. When the flag is unset (default), the existing two-phase flow runs unchanged. The motivation is PR #722, where the bot returned "No issues found" on a `ClassCastException` regression in `StateProvider.scala` because that file wasn't in the diff and the bot had no way to read it. The new pipeline gives the model tools to navigate the codebase.

**Investigator** — tool-use loop with `grep_codebase`, `read_file`, `list_dir`, `find_callers`, `find_tests_for`. Reads downstream files affected by the change, builds hypotheses, attempts to disprove each. Emits `HYPOTHESIS` / `FALSIFICATION_ATTEMPT` / `STATUS: CONFIRMED|DISPROVED` blocks.

**Critic** — tool-use loop with fresh context (no investigator system prompt or tool trace). Tries to disprove each `CONFIRMED` finding by reading the actual code. Emits `VERDICT: <id> | UPHELD|OVERTURNED | <rationale>` lines.

**Reporter** — single-shot, schema-enforced. Reads investigator notes plus critic verdicts, emits only `UPHELD` findings as JSON.

If the Investigator emits no `CONFIRMED` concerns, both Critic and Reporter are skipped. If the Critic produces no usable text (Bedrock error, empty response), the pipeline ESCALATEs with the investigator's narrative preserved in the artifact rather than synthesizing a fake "all disproved" verdict.

### What changed

- `src/scripts/issue_bot/tools.py` (new) — five tool implementations plus `TOOL_SPECS` and `DEFAULT_PER_TOOL_CALL_CAPS`. Path-traversal safety, output truncation, never-raise contract.
- `src/scripts/issue_bot/agent_loop.py` (new) — multi-turn Bedrock Converse loop with structural budgets (turns, tool calls, tool output chars, per-tool caps), pipeline-wide wall-clock deadline, max-turns text recovery.
- `src/scripts/issue_bot/main.py` — `_handle_pr` branches on `cfg.agent_pipeline`. New `_run_agent_pipeline` orchestrates the three stages; helpers for prompt loading (fail-closed), incremental-diff handling, cap building, prompt-injection-safe message construction, metrics aggregation, artifact writing. Legacy two-phase code path unchanged.
- `src/scripts/issue_bot/bedrock_client.py` — adds `converse_with_tools` (multi-turn with toolConfig) and `invoke_with_usage` (single-shot returning `(text, usage_dict)` so callers can record token counts). Existing `invoke()` unchanged.
- `src/scripts/issue_bot/prompts.py` — adds `get_pr_investigator_prompt`, `get_pr_critic_prompt`, `get_pr_reporter_prompt`. The agentic Reporter has its own SM secret (`pr-reporter-prompt`) distinct from the legacy two-phase Reporter (`pr-file-review-report-prompt`) so updating one doesn't break the other.
- `src/scripts/issue_bot/config.py` — adds the agent flag (conservative allowlist parser: `1`/`true`/`yes`/`on`), per-stage caps (`BOT_INVESTIGATOR_MAX_TURNS=15`, `BOT_CRITIC_MAX_TURNS=10`, etc.), and `BOT_PIPELINE_WALL_CLOCK_S=480`. `_int_env` helper falls back to defaults on garbage input.
- `.github/workflows/issue-bot.yml` — wires `SM_PR_INVESTIGATOR_PROMPT`, `SM_PR_CRITIC_PROMPT`, `SM_PR_REPORTER_PROMPT`, and `BOT_AGENT_PIPELINE` (sourced from `vars.*`, not `secrets.*`).
- `src/scripts/issue_bot/schemas/pr_review_response.json` — unchanged from PR #719.
- `src/scripts/tests/` — 57 new tests across `test_tools.py` (32), `test_agent_loop.py` (15), `test_critic.py` (16), `test_pipeline_helpers.py` (15). 205 tests total.
- `src/scripts/tests/conftest.py` — extended autouse fixture to strip the new `SM_*` and `PR_*` env vars.

### Defensive choices worth calling out

- **Fail-closed prompts**: missing investigator/critic/reporter SM secret ESCALATEs with logged error. No silent fallback to legacy prompts (which would mask misconfiguration as a clean PR).
- **Path canonicalization** via `posixpath.normpath` so `_extract_diff_files` and `c["file"]` from the Reporter compare equal — prevents silent finding drops on incremental re-reviews.
- **Critic-fail vs structural-cap distinction**: `crit_result.text` empty → escalate; `crit_result.text` non-empty (even with `error` set from a structural cap) → flow to Reporter. Regression-tested.
- **Tag-injection neutralization**: `</investigator_notes>` and `</critic_verdicts>` in model output are rewritten before downstream stages see them.
- **Conservative flag parser**: anything that isn't `1`/`true`/`yes`/`on` (case-insensitive, whitespace-stripped) keeps the legacy flow active. Setting `BOT_AGENT_PIPELINE=no` or under `secrets.*` instead of `vars.*` does NOT enable the pipeline.

### Out of band (already applied)

- New SM secrets created in `deequ-bot/` namespace: `pr-investigator-prompt`, `pr-critic-prompt`, `pr-reporter-prompt`. Existing `pr-file-review-prompt` and `pr-file-review-report-prompt` unchanged so the legacy two-phase flow is unaffected.
- pydeequ-bot and dqdl-bot intentionally NOT updated — those repos stay on the two-phase flow until Deequ has 4-6 weeks of production data on the new pipeline.
- IAM policy `DeequBotBedrockAccess` already uses `deequ-bot/*` wildcard, so the new secrets are reachable without policy changes.

### Cost / latency

This PR's primary goal is quality, not cost. The agentic flow makes more Bedrock calls than the legacy two-phase flow because the Investigator's tool-use loop fetches files on demand (5-15 turns per review). Latency on a complex PR is bounded by `BOT_PIPELINE_WALL_CLOCK_S=480` and the workflow's 10-minute job timeout. Real cost on this codebase will be measured during Stage 2 dry-run, not estimated up front. A separate, small follow-up PR addresses a measured cache-write inefficiency in the existing two-phase flow that has nothing to do with the agentic pipeline (cost-only, byte-identity tested).

### Rollout

Stage 1 (this PR): land code behind the flag, off by default — no real PR sees the new pipeline yet.
Stage 2: maintainer runs `workflow_dispatch` with `BOT_AGENT_PIPELINE=1 dry_run=true` on a curated bench (PR #717, #720, #722, plus ~10 historical) to validate against known outcomes. The same Stage 2 cycle should also A/B-test Opus 4.6 vs 4.7 by flipping `BEDROCK_MODEL_ID` between runs — they are the same price and 4.7 has vendor-published quality lift, but those vendor case studies are not Deequ-specific so they don't justify a blind cutover.
Stage 3: set `BOT_AGENT_PIPELINE=1` as a repository **variable** (not secret) to enable on real PRs. Maintainer reviews artifacts for 2 weeks before steady state.
Cross-repo: pydeequ-bot and dqdl-bot only after 4-6 weeks of Deequ production data.

The legacy two-phase flow stays in source for fast rollback throughout.

## Test plan

- [ ] All 205 tests pass locally and in CI
- [ ] PR opens with flag unset triggers the legacy two-phase flow (no behavior change)
- [ ] `workflow_dispatch BOT_AGENT_PIPELINE=1` on PR #722 catches the `StateProvider.scala` `ClassCastException` regression
- [ ] `workflow_dispatch BOT_AGENT_PIPELINE=1` on PR #720 catches the `flatten()` finding the current bot already catches
- [ ] `workflow_dispatch BOT_AGENT_PIPELINE=1` on a clean PR returns "No issues found." with the clean marker
- [ ] Auto-approve workflow still triggers on the clean marker

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.