### PR TITLE
Produce single bin for constant-value columns instead of zero-width duplicates

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/HistogramBinned.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/HistogramBinned.scala
@@ -152,7 +152,8 @@ case class HistogramBinned(
     // Create binned data using DataFrame operations
     val binnedData = if (storedEdges.isEmpty) {
       filteredData.withColumn(column, lit(Histogram.NullFieldReplacement))
-    } else if (customEdges.isDefined || includeOverflowBins) {
+    } else if (customEdges.isDefined || includeOverflowBins ||
+               (storedEdges.length == 2 && storedEdges.head == storedEdges.last)) { // constant-value column
       val edges = storedEdges
 
       // Builds a balanced binary decision tree of when/otherwise expressions,
@@ -253,6 +254,12 @@ case class HistogramBinned(
 
     val minDouble = minVal.doubleValue()
     val maxDouble = maxVal.doubleValue()
+
+    // Single distinct value - one bin, ignore binCount
+    if (minDouble == maxDouble) {
+      return addOverflowEdges(Array(minDouble, maxDouble))
+    }
+
     val interiorBins = if (includeOverflowBins) binCount.get - 2 else binCount.get
     val binWidth = (maxDouble - minDouble) / interiorBins
 

--- a/src/test/scala/com/amazon/deequ/analyzers/HistogramBinnedTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/HistogramBinnedTest.scala
@@ -1031,6 +1031,62 @@ class HistogramBinnedTest extends AnyWordSpec with Matchers with SparkContextSpe
     }
   }
 
+  "HistogramBinned (min == max)" should {
+    "produce single bin when all values are identical" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(5.0, 5.0, 5.0, 5.0, 5.0).toDF("values")
+      val histogram = HistogramBinned("values", binCount = Some(10))
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      distribution.numberOfBins shouldBe 1
+      distribution.bins(0).binStart shouldBe 5.0
+      distribution.bins(0).binEnd shouldBe 5.0
+      distribution.bins(0).frequency shouldBe 5
+    }
+
+    "produce single bin with overflow when all values are identical" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(5.0, 5.0, 5.0).toDF("values")
+      val histogram = HistogramBinned("values", binCount = Some(5), includeOverflowBins = true)
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      // 1 data bin + 2 overflow = 3
+      distribution.numberOfBins shouldBe 3
+      distribution.bins(0).binStart shouldBe Double.NegativeInfinity
+      distribution.bins(0).frequency shouldBe 0
+      distribution.bins(1).binStart shouldBe 5.0
+      distribution.bins(1).binEnd shouldBe 5.0
+      distribution.bins(1).frequency shouldBe 3
+      distribution.bins(2).binEnd shouldBe Double.PositiveInfinity
+      distribution.bins(2).frequency shouldBe 0
+    }
+
+    "produce single bin with nulls when all non-null values are identical" in withSparkSession { spark =>
+      import spark.implicits._
+
+      val data = Seq(Some(5.0), None, Some(5.0), None, Some(5.0)).toDF("values")
+      val histogram = HistogramBinned("values", binCount = Some(10))
+      val result = histogram.calculate(data)
+
+      result.value.isSuccess shouldBe true
+      val distribution = result.value.get
+
+      distribution.numberOfBins shouldBe 1
+      distribution.bins(0).binStart shouldBe 5.0
+      distribution.bins(0).binEnd shouldBe 5.0
+      distribution.bins(0).frequency shouldBe 3
+      distribution.nullCount shouldBe 2
+    }
+  }
+
   "HistogramBinned state" should {
     "compute metric from state without calling computeStateFrom (no NPE)" in withSparkSession { spark =>
       import spark.implicits._


### PR DESCRIPTION
### Description of changes

When all non-null values in a column are identical, the equal-width bin computation produced zero-width duplicate edges (e.g., `[5.0, 5.0, 5.0, 5.0]`) because `binWidth = (max - min) / N = 0`. This created multiple empty bins with only the last one capturing data. Now detects this case and produces a single bin `[value, value]`.

#### Before

```
// Data: [5.0, 5.0, 5.0, 5.0, 5.0], binCount = 3
// Edges: [5.0, 5.0, 5.0, 5.0]
// Bin 0: [5.0, 5.0) → 0 values (impossible range)
// Bin 1: [5.0, 5.0) → 0 values (impossible range)
// Bin 2: [5.0, 5.0] → 5 values
```

#### After

```
// Data: [5.0, 5.0, 5.0, 5.0, 5.0], binCount = 3
// Edges: [5.0, 5.0]
// Bin 0: [5.0, 5.0] → 5 values
// numberOfBins = 1
```

#### Changes

- **HistogramBinned.scala**: detect `minDouble == maxDouble` in `computeEqualWidthEdges` and return single-bin edges. Works with and without overflow.

### Testing

- **Single bin for constant values**: all identical values produce 1 bin with correct frequency
- **Single bin with overflow**: constant values + overflow produces 3 bins (overflow + 1 data + overflow), overflow bins empty

```
mvn test -DwildcardSuites="com.amazon.deequ.analyzers.HistogramBinnedTest"
mvn test
```

##### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
