### PR TITLE
Add DuplicateRowCount to supported DQDL rules in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ Deequ also supports [DQDL](https://docs.aws.amazon.com/glue/latest/dg/dqdl.html)
 
 - **RowCount**: `RowCount < 100`
 - **ColumnCount**: `ColumnCount = 10`
+- **DuplicateRowCount**: `DuplicateRowCount "col1" "col2" = 0`
 - **ZerosCount**: `ZerosCount "column" = 0`
 - **Completeness**: `Completeness "column" > 0.9`
 - **IsComplete**: `IsComplete "column"`


### PR DESCRIPTION
 ### Description of changes

Adds `DuplicateRowCount` to the supported DQDL rules list in README. The analyzer was added in a previous PR #723 but not documented.

### Testing

Documentation only. No code changes.

##### By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
