### PR TITLE
fix: harden agent tools against path-scope leaks and symlink escapes; raise Investigator turn floor

### DIFF
--- a/src/scripts/issue_bot/main.py
+++ b/src/scripts/issue_bot/main.py
@@ -773,7 +773,10 @@ def _write_artifact(data):
     os.makedirs(os.path.dirname(ARTIFACT_PATH) or "/tmp", exist_ok=True)
     with open(ARTIFACT_PATH, "w") as f:
         json.dump(data, f)
-    logger.info(f"Artifact: action={data.get('action')}")
+    # Don't interpolate `data` fields into the log line — CodeQL's
+    # clear-text-logging rule flags any field of the artifact dict as
+    # sensitive. The artifact JSON itself has full triage context.
+    logger.info("Artifact written to %s", ARTIFACT_PATH)
 
 
 def _read_artifact():
@@ -963,9 +966,12 @@ def _load_pipeline_prompts(cfg, title, html_url, number):
     ) if not val]
     if not missing:
         return investigator, critic, reporter
+    # Log only the count: `missing` is taint-tracked from _read_from_sm
+    # and trips CodeQL's clear-text-logging rule despite being literal
+    # names. The artifact's `reason` field below carries the names.
     logger.error(
-        "Pipeline enabled but required prompt(s) missing: %s. Failing closed.",
-        ", ".join(missing),
+        "Pipeline enabled but %d required prompt(s) missing. Failing closed.",
+        len(missing),
     )
     _write_artifact({
         "action": "ESCALATE", "labels": [], "response": "",
@@ -987,12 +993,14 @@ def _maybe_compute_incremental(gh, cfg, is_pr_update):
 
 def _build_caps(cfg, pr_files):
     """Return (investigator_caps, critic_caps), sized to PR length within
-    user-configured ceilings. The Investigator floor is min(5, ceiling) and the
-    Critic floor is min(3, ceiling) so a user lowering the ceiling below the
-    default floor is still respected."""
+    user-configured ceilings. Diff-line count is a poor proxy for
+    investigation depth — a small typed-API change can ripple through many
+    files — so the Investigator floor is generous (10 turns). Critic floor
+    is min(3, ceiling) so a user lowering the ceiling below the default
+    floor is still respected."""
     diff_lines = sum(int(pf.get("changes", 0) or 0) for pf in pr_files)
     inv_ceiling = max(1, cfg.investigator_max_turns)
-    inv_floor = min(5, inv_ceiling)
+    inv_floor = min(10, inv_ceiling)
     investigator = agent_loop.AgentCaps(
         max_turns=_clamp(diff_lines // 30, inv_floor, inv_ceiling),
         max_tool_calls=cfg.investigator_max_tool_calls,

--- a/src/scripts/issue_bot/tools.py
+++ b/src/scripts/issue_bot/tools.py
@@ -19,6 +19,10 @@ logger = logging.getLogger("issue_bot")
 _MAX_RESULT_CHARS = 50_000
 _MAX_FILE_LINES_PER_CALL = 200
 _MAX_GREP_RESULTS = 50
+_MAX_FILES_FOR_CALLERS = 20
+_MAX_FILES_LINE_SNIPPETS = 10
+_MAX_LINES_PER_FILE = 5
+_MAX_SNIPPET_CHARS = 200
 
 # Default per-tool call budgets, co-located with TOOL_SPECS so a tool rename
 # requires updating both in one place. Tools omitted from this dict have no
@@ -52,7 +56,14 @@ TOOL_SPECS = [
                         },
                         "path_glob": {
                             "type": "string",
-                            "description": "File extension filter (e.g., '.scala', '.py'). Defaults to the codebase's primary extension.",
+                            "description": (
+                                "Optional scope. Accepts: empty (search all files of the "
+                                "codebase's primary extension); an extension like '.scala' "
+                                "or '.py'; or a repo-relative path to a single file or "
+                                "directory INSIDE the configured source directory. Paths "
+                                "outside the source dir (tests, docs, build artifacts) are "
+                                "rejected — use empty scope plus a more specific pattern instead."
+                            ),
                         },
                     },
                     "required": ["pattern"],
@@ -116,8 +127,11 @@ TOOL_SPECS = [
             "name": "find_callers",
             "description": (
                 "Find files that reference a class, trait, object, or method "
-                "name. Returns a list of files ranked by reference count. Use "
-                "when changing a type signature to discover impacted callers."
+                "name. Returns files ranked by reference count, each with the "
+                "specific line numbers and matching-line snippets. Use when "
+                "changing a type signature to discover impacted callers; the "
+                "inlined snippets often surface enough context to decide "
+                "whether a follow-up read_file is needed."
             ),
             "inputSchema": {
                 "json": {
@@ -187,6 +201,8 @@ def _safe_repo_path(repo_root, rel_path):
 def grep_codebase(pattern, path_glob, repo_root, src_dir, default_ext):
     """Search for a regex across the codebase. Returns 'path:line:text' lines.
 
+    See _resolve_grep_scope for the path_glob shapes accepted.
+
     The pattern is model-supplied; pathological patterns can ReDoS-pin a
     worker. Acceptable today (we own the model and the diffs it sees);
     revisit when this runs in less-trusted contexts.
@@ -197,29 +213,110 @@ def grep_codebase(pattern, path_glob, repo_root, src_dir, default_ext):
         regex = re.compile(pattern)
     except re.error as e:
         return f"ERROR: invalid regex: {e}"
-    ext = path_glob if (path_glob and path_glob.startswith(".")) else default_ext
-    search_root = os.path.join(repo_root, src_dir)
-    if not os.path.isdir(search_root):
-        return f"ERROR: search root '{src_dir}' does not exist in repo"
 
-    matches = list(_iter_matches(regex, search_root, repo_root, ext, _MAX_GREP_RESULTS))
+    search_root, ext, scope_label, single_file, err = _resolve_grep_scope(
+        path_glob, repo_root, src_dir, default_ext,
+    )
+    if err:
+        return err
+
+    if single_file:
+        matches = list(_iter_matches_in_file(regex, single_file, repo_root, _MAX_GREP_RESULTS))
+    else:
+        matches = list(_iter_matches(regex, search_root, repo_root, ext, _MAX_GREP_RESULTS))
     if not matches:
-        return f"No matches for pattern '{pattern}' in {src_dir}/**/*{ext}"
-    header = f"Found {len(matches)} match(es) (capped at {_MAX_GREP_RESULTS}):\n"
+        return f"No matches for pattern '{pattern}' in {scope_label}"
+    header = f"Found {len(matches)} match(es) (capped at {_MAX_GREP_RESULTS}) in {scope_label}:\n"
     return _truncate(header + "\n".join(matches))
 
 
+def _resolve_grep_scope(path_glob, repo_root, src_dir, default_ext):
+    """Resolve path_glob → (search_root, ext, scope_label, single_file, error).
+
+    Accepted path_glob shapes:
+      empty   → walk src_dir for default_ext.
+      ".X"    → walk src_dir for that extension.
+      path    → repo-relative file or directory; must resolve inside src_dir.
+
+    Path values that resolve outside src_dir are rejected so a path scope
+    can only narrow the default search, not broaden it.
+    """
+    real_root = os.path.realpath(repo_root)
+    default_root = os.path.realpath(os.path.join(repo_root, src_dir))
+    if not os.path.isdir(default_root):
+        return None, None, None, None, f"ERROR: search root '{src_dir}' does not exist in repo"
+    # Guard against operator misconfig where src_dir resolves outside the
+    # repo (e.g., a symlinked checkout). Silent-empty would mislead the
+    # model into "no callers" conclusions.
+    if not (default_root == real_root or default_root.startswith(real_root + os.sep)):
+        return None, None, None, None, (
+            f"ERROR: configured source dir '{src_dir}' resolves outside the repo root"
+        )
+
+    if not path_glob or not isinstance(path_glob, str):
+        return default_root, default_ext, f"{src_dir}/**/*{default_ext}", None, ""
+
+    # Extension filter: configured default (handles multi-dot like '.d.ts')
+    # or '.' + alphanumerics. Tighter than startswith('.') so '../...'
+    # falls through to path resolution and gets safety-checked.
+    if path_glob == default_ext or re.fullmatch(r"\.[A-Za-z0-9]+", path_glob):
+        return default_root, path_glob, f"{src_dir}/**/*{path_glob}", None, ""
+
+    abs_path, err = _safe_repo_path(repo_root, path_glob)
+    if err:
+        return None, None, None, None, err
+    # Inside src_dir, not just inside repo_root: 'src' would otherwise
+    # broaden scope to include tests/.
+    if not (abs_path == default_root or abs_path.startswith(default_root + os.sep)):
+        return None, None, None, None, (
+            f"ERROR: path_glob '{path_glob}' must be inside the source directory "
+            f"'{src_dir}' (got a path outside it)"
+        )
+    # Use the realpath-relative form for both file and dir scope labels so
+    # the header agrees with the match rows when the model passed an
+    # in-repo symlink as path_glob.
+    rel_label = os.path.relpath(abs_path, real_root)
+    if os.path.isfile(abs_path):
+        return None, default_ext, rel_label, abs_path, ""
+    if os.path.isdir(abs_path):
+        return abs_path, default_ext, f"{rel_label}/**/*{default_ext}", None, ""
+    return None, None, None, None, (
+        f"ERROR: path_glob '{path_glob}' is not an extension (start with '.') "
+        f"and does not resolve to a file or directory in the repo"
+    )
+
+
+def _is_inside(real_root, candidate_full_path):
+    """True iff candidate's realpath is at or under real_root. Used to skip
+    planted symlinks that would otherwise leak external file contents."""
+    try:
+        real_candidate = os.path.realpath(candidate_full_path)
+    except OSError:
+        return False
+    return real_candidate == real_root or real_candidate.startswith(real_root + os.sep)
+
+
 def _iter_matches(regex, search_root, repo_root, ext, limit):
-    """Yield up to `limit` regex matches as 'path:line:text' strings."""
+    """Yield up to `limit` regex matches as 'path:line:text' strings.
+    Symlinks pointing outside repo_root are skipped; in-repo symlinks
+    are deduped by realpath so each physical file is grepped once."""
+    real_root = os.path.realpath(repo_root)
+    seen = set()
     count = 0
     for dirpath, _, files in os.walk(search_root):
         for fn in files:
             if not fn.endswith(ext):
                 continue
             full = os.path.join(dirpath, fn)
+            if not _is_inside(real_root, full):
+                continue
+            real_full = os.path.realpath(full)
+            if real_full in seen:
+                continue
+            seen.add(real_full)
             try:
                 with open(full, encoding="utf-8", errors="ignore") as f:
-                    rel = os.path.relpath(full, repo_root)
+                    rel = os.path.relpath(full, real_root)
                     for lineno, line in enumerate(f, 1):
                         if regex.search(line):
                             yield f"{rel}:{lineno}:{line.rstrip()}"
@@ -228,6 +325,27 @@ def _iter_matches(regex, search_root, repo_root, ext, limit):
                                 return
             except OSError:
                 continue
+
+
+def _iter_matches_in_file(regex, abs_path, repo_root, limit):
+    """Yield matches from a single file. abs_path is expected to be
+    realpath-validated by the caller; the _is_inside re-check below is
+    defense-in-depth in case a future caller skips that step."""
+    real_root = os.path.realpath(repo_root)
+    if not _is_inside(real_root, abs_path):
+        return
+    rel = os.path.relpath(abs_path, real_root)
+    count = 0
+    try:
+        with open(abs_path, encoding="utf-8", errors="ignore") as f:
+            for lineno, line in enumerate(f, 1):
+                if regex.search(line):
+                    yield f"{rel}:{lineno}:{line.rstrip()}"
+                    count += 1
+                    if count >= limit:
+                        return
+    except OSError:
+        return
 
 
 def read_file(path, start_line, end_line, repo_root):
@@ -295,36 +413,66 @@ def list_dir(path, repo_root):
 
 
 def find_callers(symbol, repo_root, src_dir, default_ext):
-    """Find files that reference a symbol, ranked by count."""
+    """Find files referencing a symbol, ranked by count, with line snippets."""
     if not symbol or not isinstance(symbol, str):
         return "ERROR: symbol must be a non-empty string"
-    if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", symbol):
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", symbol):
         return f"ERROR: symbol '{symbol}' is not a valid identifier"
     pattern = re.compile(rf"\b{re.escape(symbol)}\b")
-    search_root = os.path.join(repo_root, src_dir)
+    real_root = os.path.realpath(repo_root)
+    # Walk under the canonical search_root so emitted paths share real_root's
+    # prefix; relpath then produces clean repo-relative output.
+    search_root = os.path.realpath(os.path.join(repo_root, src_dir))
     if not os.path.isdir(search_root):
         return f"ERROR: search root '{src_dir}' does not exist in repo"
-    counts = {}
+    if not (search_root == real_root or search_root.startswith(real_root + os.sep)):
+        return f"ERROR: configured source dir '{src_dir}' resolves outside the repo root"
+    file_hits = {}
+    seen = set()
     for dirpath, _, files in os.walk(search_root):
         for fn in files:
             if not fn.endswith(default_ext):
                 continue
             full = os.path.join(dirpath, fn)
+            if not _is_inside(real_root, full):
+                continue
+            real_full = os.path.realpath(full)
+            if real_full in seen:
+                continue
+            seen.add(real_full)
             try:
                 with open(full, encoding="utf-8", errors="ignore") as f:
-                    text = f.read()
+                    matches = []
+                    occurrences = 0
+                    for lineno, line in enumerate(f, 1):
+                        line_count = len(pattern.findall(line))
+                        if line_count:
+                            matches.append((lineno, line.rstrip()))
+                            occurrences += line_count
             except OSError:
                 continue
-            n = len(pattern.findall(text))
-            if n > 0:
-                rel = os.path.relpath(full, repo_root)
-                counts[rel] = n
-    if not counts:
+            if matches:
+                rel = os.path.relpath(full, real_root)
+                file_hits[rel] = (occurrences, matches)
+    if not file_hits:
         return f"No files reference '{symbol}' in {src_dir}"
-    ranked = sorted(counts.items(), key=lambda kv: -kv[1])
-    out = [f"Files referencing '{symbol}' (top {min(20, len(ranked))} by count):"]
-    for rel, n in ranked[:20]:
-        out.append(f"  {rel} ({n} reference{'s' if n != 1 else ''})")
+    ranked = sorted(file_hits.items(), key=lambda kv: -kv[1][0])
+    total = len(ranked)
+    shown_total = min(_MAX_FILES_FOR_CALLERS, total)
+    out = [f"Files referencing '{symbol}' ({shown_total} of {total} by count):"]
+    for rel, (occ, matches) in ranked[:_MAX_FILES_LINE_SNIPPETS]:
+        out.append(f"  {rel} ({occ} reference{'s' if occ != 1 else ''})")
+        for lineno, text in matches[:_MAX_LINES_PER_FILE]:
+            out.append(f"    line {lineno}: {text.strip()[:_MAX_SNIPPET_CHARS]}")
+        if len(matches) > _MAX_LINES_PER_FILE:
+            out.append(f"    ... [{len(matches) - _MAX_LINES_PER_FILE} more lines in this file]")
+    names_only = ranked[_MAX_FILES_LINE_SNIPPETS:_MAX_FILES_FOR_CALLERS]
+    if names_only:
+        out.append(f"  (additional {len(names_only)} files with fewer references, names only:)")
+        for rel, (occ, _) in names_only:
+            out.append(f"    {rel} ({occ} reference{'s' if occ != 1 else ''})")
+    if total > _MAX_FILES_FOR_CALLERS:
+        out.append(f"  ... [{total - _MAX_FILES_FOR_CALLERS} more files truncated]")
     return _truncate("\n".join(out))
 
 
@@ -337,22 +485,37 @@ def find_tests_for(target, repo_root, src_dir, default_ext):
     """
     if not target or not isinstance(target, str):
         return "ERROR: target must be a non-empty string"
-    test_root = os.path.join(repo_root, src_dir.replace("src/main", "src/test", 1))
-    if not os.path.isdir(test_root):
-        test_root = os.path.join(repo_root, "src", "test")
-        if not os.path.isdir(test_root):
-            return "ERROR: no test directory found at src/test"
+    real_root = os.path.realpath(repo_root)
+    # Mirror src_dir into the test tree only when the substitution actually
+    # changed the path; otherwise str.replace is a no-op and we'd walk the
+    # source tree as if it were tests.
+    mirrored = src_dir.replace("src/main", "src/test", 1)
+    test_root = None
+    if mirrored != src_dir:
+        candidate = os.path.realpath(os.path.join(repo_root, mirrored))
+        if os.path.isdir(candidate):
+            test_root = candidate
+    if test_root is None:
+        candidate = os.path.realpath(os.path.join(repo_root, "src", "test"))
+        if os.path.isdir(candidate):
+            test_root = candidate
+    if test_root is None:
+        return "ERROR: no test directory found at src/test"
+    if not (test_root == real_root or test_root.startswith(real_root + os.sep)):
+        return "ERROR: test directory resolves outside the repo root"
 
     name = os.path.basename(target)
     if name.endswith(default_ext):
         name = name[:-len(default_ext)]
-    if not re.match(r"^[A-Za-z_][A-Za-z0-9_]*$", name):
+    if not re.fullmatch(r"[A-Za-z_][A-Za-z0-9_]*", name):
         return f"ERROR: target '{target}' did not yield a valid identifier"
 
     convention_names = {f"{name}{suffix}{default_ext}" for suffix in ("Test", "Spec")}
     grep_pattern = re.compile(rf"\b{re.escape(name)}\b")
-    candidates = []
-    seen = set()
+    # real_full → (is_convention, rel). A convention-named hit overwrites a
+    # prior grep-match for the same physical file so symlink ordering in
+    # os.walk doesn't cause the non-conventional path to win.
+    by_real = {}
     limit = 20
 
     for dirpath, _, files in os.walk(test_root):
@@ -360,28 +523,43 @@ def find_tests_for(target, repo_root, src_dir, default_ext):
             if not fn.endswith(default_ext):
                 continue
             full = os.path.join(dirpath, fn)
-            rel = os.path.relpath(full, repo_root)
-            if rel in seen:
+            if not _is_inside(real_root, full):
                 continue
-            if fn in convention_names:
-                candidates.append(rel)
-                seen.add(rel)
-            else:
+            real_full = os.path.realpath(full)
+            existing = by_real.get(real_full)
+            if existing and existing[0]:
+                # Already accepted as convention; nothing better to find.
+                continue
+            is_convention = fn in convention_names
+            # Stop accepting new entries past the limit, but still allow
+            # upgrades (grep-match → convention-match) on entries already
+            # tracked so symlink-ordering doesn't trap a worse path.
+            if existing is None and len(by_real) >= limit:
+                continue
+            rel = os.path.relpath(full, real_root)
+            if is_convention:
+                by_real[real_full] = (True, rel)
+            elif existing is None:
                 try:
                     with open(full, encoding="utf-8", errors="ignore") as f:
                         if grep_pattern.search(f.read()):
-                            candidates.append(rel)
-                            seen.add(rel)
+                            by_real[real_full] = (False, rel)
                 except OSError:
                     continue
-            if len(candidates) >= limit:
-                break
-        if len(candidates) >= limit:
+        # Early exit when we have enough convention-named entries; no
+        # future visit can upgrade those. Skip when only grep matches
+        # exist since a later convention name could still upgrade.
+        if (len(by_real) >= limit
+                and all(is_conv for is_conv, _ in by_real.values())):
             break
 
-    if not candidates:
-        return f"No tests found for '{target}' under {os.path.relpath(test_root, repo_root)}"
-    out = [f"Tests for '{target}':"] + [f"  {rel}" for rel in candidates]
+    if not by_real:
+        return f"No tests found for '{target}' under {os.path.relpath(test_root, real_root)}"
+    # Convention names first, then grep matches; walk order preserved
+    # within each group via dict insertion order.
+    convention_hits = [rel for is_conv, rel in by_real.values() if is_conv]
+    grep_hits = [rel for is_conv, rel in by_real.values() if not is_conv]
+    out = [f"Tests for '{target}':"] + [f"  {rel}" for rel in convention_hits + grep_hits]
     return _truncate("\n".join(out))
 
 

--- a/src/scripts/tests/test_pipeline_helpers.py
+++ b/src/scripts/tests/test_pipeline_helpers.py
@@ -290,3 +290,83 @@ def test_pipeline_event_known_set_includes_documented_events():
     assert documented <= _KNOWN_PIPELINE_EVENTS, (
         f"Documented events not in known set: {documented - _KNOWN_PIPELINE_EVENTS}"
     )
+
+
+# _build_caps adapts the Investigator/Critic turn budgets to PR size.
+# Diff-line count is a poor proxy for investigation depth (a small typed
+# change can ripple through many files), so a generous floor is enforced.
+
+from issue_bot.main import _build_caps
+
+
+class _CapsConfig:
+    """Minimal config double for _build_caps — only the fields it reads."""
+    def __init__(self, inv_max=15, crit_max=10, inv_calls=50, crit_calls=30,
+                 inv_chars=400_000, crit_chars=200_000):
+        self.investigator_max_turns = inv_max
+        self.critic_max_turns = crit_max
+        self.investigator_max_tool_calls = inv_calls
+        self.critic_max_tool_calls = crit_calls
+        self.investigator_max_tool_output_chars = inv_chars
+        self.critic_max_tool_output_chars = crit_chars
+
+
+def test_build_caps_small_pr_hits_floor():
+    """A small PR (56 changed lines) must get the floor-10 turn budget
+    so cross-file investigation has headroom."""
+    cfg = _CapsConfig()
+    pr_files = [{"changes": 56}]
+    inv, _ = _build_caps(cfg, pr_files)
+    assert inv.max_turns == 10
+
+
+def test_build_caps_zero_diff_hits_floor():
+    """Empty PR still gets floor=10 — clamping treats min as a floor, not
+    a target."""
+    cfg = _CapsConfig()
+    inv, _ = _build_caps(cfg, [])
+    assert inv.max_turns == 10
+
+
+def test_build_caps_large_pr_hits_ceiling():
+    """A large PR (>450 changed lines) clamps at the user's ceiling."""
+    cfg = _CapsConfig(inv_max=15)
+    pr_files = [{"changes": 1000}]
+    inv, _ = _build_caps(cfg, pr_files)
+    assert inv.max_turns == 15
+
+
+def test_build_caps_low_user_ceiling_overrides_floor():
+    """A user-configured low ceiling clamps the floor — never exceeds the
+    user's stated max."""
+    cfg = _CapsConfig(inv_max=3)
+    pr_files = [{"changes": 56}]
+    inv, _ = _build_caps(cfg, pr_files)
+    assert inv.max_turns == 3
+
+
+def test_build_caps_critic_floor_is_three():
+    """Critic floor is min(3, ceiling) — always smaller than Investigator
+    since the Critic verifies a smaller surface."""
+    cfg = _CapsConfig()
+    _, crit = _build_caps(cfg, [{"changes": 0}])
+    # inv=10, crit=clamp(10//2, 3, 10) = 5
+    assert crit.max_turns == 5
+
+
+def test_build_caps_critic_low_user_ceiling_clamps_floor():
+    """If the user lowers critic_max_turns below 3, the critic floor
+    yields to the user's ceiling."""
+    cfg = _CapsConfig(crit_max=2)
+    _, crit = _build_caps(cfg, [{"changes": 0}])
+    # inv=10, crit=clamp(10//2, min(3,2)=2, 2) = 2
+    assert crit.max_turns == 2
+
+
+def test_build_caps_handles_missing_changes_field():
+    """A pr_files entry without 'changes' (defensive against GitHub API
+    quirks) must default to 0 contribution, not crash."""
+    cfg = _CapsConfig()
+    inv, _ = _build_caps(cfg, [{}, {"changes": None}, {"changes": 30}])
+    # diff_lines = 0 + 0 + 30 = 30; 30//30 = 1; clamped to floor=10
+    assert inv.max_turns == 10

--- a/src/scripts/tests/test_tools.py
+++ b/src/scripts/tests/test_tools.py
@@ -153,6 +153,15 @@ def test_find_callers_invalid_symbol(repo):
     assert "ERROR" in out
 
 
+def test_find_callers_rejects_symbol_with_trailing_newline(repo):
+    """re.fullmatch (vs re.match with $) prevents 'Foo\\n' from sneaking
+    past the identifier check — $ in non-MULTILINE mode matches before a
+    final newline."""
+    out = find_callers("Foo\n", str(repo), "src/main/scala", ".scala")
+    assert "ERROR" in out
+    assert "valid identifier" in out
+
+
 def test_find_callers_no_matches(repo):
     out = find_callers("DoesNotExistAnywhere", str(repo), "src/main/scala", ".scala")
     assert "No files reference" in out
@@ -171,6 +180,14 @@ def test_find_tests_for_symbol(repo):
 def test_find_tests_for_no_match(repo):
     out = find_tests_for("Nonexistent", str(repo), "src/main/scala", ".scala")
     assert "No tests found" in out
+
+
+def test_find_tests_for_rejects_target_with_trailing_newline(repo):
+    """re.fullmatch (vs re.match with $) rejects 'Foo\\n' so a regression
+    to re.match would be caught here, matching find_callers' protection."""
+    out = find_tests_for("Foo\n", str(repo), "src/main/scala", ".scala")
+    assert "ERROR" in out
+    assert "valid identifier" in out
 
 
 class FakeCfg:
@@ -270,3 +287,507 @@ def test_read_file_end_line_none_uses_default(repo):
     out = read_file("src/main/scala/Foo.scala", 1, None, str(repo))
     assert "case class Foo" in out
     assert "lines 1-" in out
+
+
+# grep_codebase path_glob scope semantics: a real path scopes the search;
+# extension filters and empty values keep the original whole-tree walk.
+
+
+def test_grep_codebase_path_glob_scopes_to_single_file(repo):
+    """A repo-relative file path narrows the search to that one file."""
+    out = grep_codebase("Foo", "src/main/scala/Foo.scala", str(repo),
+                        "src/main/scala", ".scala")
+    # Must actually find matches (not just the no-match scope label) AND
+    # exclude Bar.scala which would match a wider scope.
+    assert "Found " in out
+    assert "src/main/scala/Foo.scala:" in out
+    assert "Bar.scala" not in out
+
+
+def test_grep_codebase_path_glob_scopes_to_directory(repo):
+    """A repo-relative directory path narrows the walk to that subtree."""
+    # Tests live under src/test/scala — must NOT appear when scoped to src/main.
+    out = grep_codebase("Foo", "src/main/scala", str(repo),
+                        "src/main/scala", ".scala")
+    assert "Foo.scala" in out
+    assert "Bar.scala" in out
+    assert "FooTest.scala" not in out
+
+
+def test_grep_codebase_path_glob_extension_still_works(repo):
+    """Back-compat: the '.ext' shape walks src_dir scope only.
+
+    Negative control: FooTest.scala lives under src/test/scala (outside
+    src_dir) and must NOT appear, so this test fails on an impl that
+    walks the whole repo regardless of scope.
+    """
+    out = grep_codebase("Foo", ".scala", str(repo),
+                        "src/main/scala", ".scala")
+    assert "Foo.scala" in out
+    assert "Bar.scala" in out
+    assert "FooTest.scala" not in out
+
+
+def test_grep_codebase_path_glob_empty_unchanged(repo):
+    """Back-compat: empty path_glob walks src_dir with default_ext.
+
+    Negative control: same as the extension test — verifies the empty
+    case still scopes to src_dir, not the whole repo.
+    """
+    out = grep_codebase("Foo", "", str(repo),
+                        "src/main/scala", ".scala")
+    assert "Foo.scala" in out
+    assert "Bar.scala" in out
+    assert "FooTest.scala" not in out
+
+
+def test_grep_codebase_path_glob_rejects_path_traversal(repo):
+    """Path traversal must be rejected, like read_file."""
+    out = grep_codebase("Foo", "../../etc/passwd", str(repo),
+                        "src/main/scala", ".scala")
+    assert out.startswith("ERROR:")
+    assert "repo-relative" in out or "outside" in out
+
+
+def test_grep_codebase_path_glob_nonexistent_path_returns_clear_error(repo):
+    """A path that resolves outside src_dir or doesn't exist → clear error."""
+    out = grep_codebase("Foo", "src/does/not/exist", str(repo),
+                        "src/main/scala", ".scala")
+    assert out.startswith("ERROR:")
+
+
+def test_grep_codebase_scope_label_in_no_match_message(repo):
+    """The 'no matches' message should reflect the actual scope so the
+    model knows what was searched."""
+    out = grep_codebase("ZZZNoSuchPattern", "src/main/scala/Foo.scala",
+                        str(repo), "src/main/scala", ".scala")
+    assert "No matches" in out
+    assert "Foo.scala" in out
+
+
+def test_grep_codebase_path_glob_dot_alone_rejected(repo):
+    """'.' resolves to repo root (outside src_dir) — must be rejected,
+    not silently broaden the search to docs/, tests/, build artifacts."""
+    out = grep_codebase("Foo", ".", str(repo),
+                        "src/main/scala", ".scala")
+    assert out.startswith("ERROR:")
+    assert "src/main/scala" in out  # error names the required scope
+
+
+def test_grep_codebase_path_glob_parent_of_src_dir_rejected(repo):
+    """'src' is a parent of src_dir 'src/main/scala' — must be rejected.
+    Otherwise tests under src/test would leak into caller analysis."""
+    out = grep_codebase("Foo", "src", str(repo),
+                        "src/main/scala", ".scala")
+    assert out.startswith("ERROR:")
+    assert "src/main/scala" in out
+
+
+def test_grep_codebase_path_glob_sibling_of_src_dir_rejected(repo):
+    """A sibling directory (e.g., 'src/test/scala' when src_dir is
+    'src/main/scala') must be rejected."""
+    out = grep_codebase("Foo", "src/test/scala", str(repo),
+                        "src/main/scala", ".scala")
+    assert out.startswith("ERROR:")
+
+
+def test_grep_codebase_skips_symlinks_pointing_outside_repo(tmp_path):
+    """Security: a symlink inside src_dir pointing OUTSIDE the repo must
+    not have its target read. A malicious PR could plant such a symlink
+    and otherwise exfiltrate sensitive file contents into a public review."""
+    src = tmp_path / "src" / "main" / "scala"
+    src.mkdir(parents=True)
+    (src / "normal.scala").write_text("Foo = inside\n")
+    # tmp_path-scoped name so parallel pytest workers don't collide.
+    secret = tmp_path.parent / f"secret_outside_grep_{tmp_path.name}.scala"
+    try:
+        secret.write_text("Foo = SHOULD_NEVER_LEAK\n")
+        os.symlink(str(secret), str(src / "leak.scala"))
+        out = grep_codebase("Foo", "", str(tmp_path), "src/main/scala", ".scala")
+        assert "SHOULD_NEVER_LEAK" not in out
+        assert "Foo = inside" in out
+    finally:
+        secret.unlink(missing_ok=True)
+
+
+def test_find_callers_skips_symlinks_pointing_outside_repo(tmp_path):
+    """Security: same protection on the find_callers walk path."""
+    src = tmp_path / "src" / "main" / "scala"
+    src.mkdir(parents=True)
+    (src / "normal.scala").write_text("Foo = inside\n")
+    # Use a tmp_path-scoped name so parallel pytest workers don't collide.
+    secret = tmp_path.parent / f"secret_outside_callers_{tmp_path.name}.scala"
+    try:
+        secret.write_text("Foo = SHOULD_NEVER_LEAK\n")
+        os.symlink(str(secret), str(src / "leak.scala"))
+        out = find_callers("Foo", str(tmp_path), "src/main/scala", ".scala")
+        assert "SHOULD_NEVER_LEAK" not in out
+        assert "leak.scala" not in out
+        # Positive control: the legitimate file IS still found, so a
+        # regression that drops every result doesn't silently pass.
+        assert "normal.scala" in out
+    finally:
+        secret.unlink(missing_ok=True)
+
+
+def test_grep_codebase_relpath_is_clean_under_macos_tmpdir(tmp_path):
+    """On macOS, tmp resolves through /private/. Paths in output must be
+    repo-relative without '../../private/...' noise."""
+    src = tmp_path / "src" / "main" / "scala"
+    src.mkdir(parents=True)
+    (src / "X.scala").write_text("Foo\n")
+    out = grep_codebase("Foo", "", str(tmp_path), "src/main/scala", ".scala")
+    # Must contain the repo-relative form and NOT the absolute escaped form.
+    assert "src/main/scala/X.scala:" in out
+    assert "../" not in out
+    assert "/private/" not in out
+
+
+def test_find_callers_relpath_is_clean_under_macos_tmpdir(tmp_path):
+    """Same for find_callers."""
+    src = tmp_path / "src" / "main" / "scala"
+    src.mkdir(parents=True)
+    (src / "X.scala").write_text("Foo\n")
+    out = find_callers("Foo", str(tmp_path), "src/main/scala", ".scala")
+    assert "src/main/scala/X.scala" in out
+    assert "../" not in out
+    assert "/private/" not in out
+
+
+def test_grep_codebase_src_dir_escapes_repo_returns_error(tmp_path):
+    """Operator misconfig: src_dir resolves outside repo (e.g., symlinked
+    checkout). Must return a clear error rather than silent-empty."""
+    elsewhere = tmp_path.parent / "elsewhere"
+    elsewhere.mkdir()
+    (elsewhere / "X.scala").write_text("Foo\n")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    # src_dir is a symlink to outside the repo
+    os.symlink(str(elsewhere), str(repo / "src"))
+    try:
+        out = grep_codebase("Foo", "", str(repo), "src", ".scala")
+        assert out.startswith("ERROR:")
+        assert "outside" in out.lower()
+    finally:
+        # Clean up — Python pytest tmp_path will remove repo and its symlink,
+        # but the elsewhere/ dir lives at tmp_path.parent so unlink it.
+        import shutil
+        shutil.rmtree(elsewhere, ignore_errors=True)
+
+
+def test_find_callers_src_dir_escapes_repo_returns_error(tmp_path):
+    """Same as above for find_callers."""
+    elsewhere = tmp_path.parent / "elsewhere2"
+    elsewhere.mkdir()
+    (elsewhere / "X.scala").write_text("Foo\n")
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    os.symlink(str(elsewhere), str(repo / "src"))
+    try:
+        out = find_callers("Foo", str(repo), "src", ".scala")
+        assert out.startswith("ERROR:")
+        assert "outside" in out.lower()
+    finally:
+        import shutil
+        shutil.rmtree(elsewhere, ignore_errors=True)
+
+
+def test_find_callers_dedupes_in_repo_symlink(tmp_path):
+    """A symlink A.scala -> B.scala (both inside repo) must not produce
+    two file_hits entries with the same content. Otherwise ranked counts
+    are inflated and the names-only cap fills with redundant rows."""
+    src = tmp_path / "src" / "main" / "scala"
+    src.mkdir(parents=True)
+    (src / "B.scala").write_text("Foo target\n")
+    os.symlink(str(src / "B.scala"), str(src / "A.scala"))
+    out = find_callers("Foo", str(tmp_path), "src/main/scala", ".scala")
+    # Either A.scala or B.scala appears, not both — they share content.
+    appears_a = "A.scala" in out
+    appears_b = "B.scala" in out
+    assert appears_a != appears_b, (
+        f"both A and B in output (no dedup): {out}"
+    )
+
+
+def test_grep_codebase_dedupes_in_repo_symlink(tmp_path):
+    """Same dedup invariant for grep_codebase."""
+    src = tmp_path / "src" / "main" / "scala"
+    src.mkdir(parents=True)
+    (src / "B.scala").write_text("Foo here\n")
+    os.symlink(str(src / "B.scala"), str(src / "A.scala"))
+    out = grep_codebase("Foo", "", str(tmp_path), "src/main/scala", ".scala")
+    a_count = out.count("A.scala")
+    b_count = out.count("B.scala")
+    assert (a_count == 0) != (b_count == 0), (
+        f"Foo line appears under both A and B (no dedup): {out}"
+    )
+
+
+def test_grep_codebase_broken_symlink_skipped_silently(tmp_path):
+    """A broken symlink (target doesn't exist) must not crash or leak
+    error noise — silently skip and continue with other files."""
+    src = tmp_path / "src" / "main" / "scala"
+    src.mkdir(parents=True)
+    (src / "real.scala").write_text("Foo here\n")
+    os.symlink(str(tmp_path / "does_not_exist.scala"), str(src / "broken.scala"))
+    out = grep_codebase("Foo", "", str(tmp_path), "src/main/scala", ".scala")
+    # Real file is found; broken symlink doesn't appear.
+    assert "real.scala" in out
+    assert "broken.scala" not in out
+    # No error message about the broken symlink.
+    assert "ERROR" not in out
+
+
+def test_find_callers_broken_symlink_skipped_silently(tmp_path):
+    """Same for find_callers."""
+    src = tmp_path / "src" / "main" / "scala"
+    src.mkdir(parents=True)
+    (src / "real.scala").write_text("Foo\n")
+    os.symlink(str(tmp_path / "does_not_exist.scala"), str(src / "broken.scala"))
+    out = find_callers("Foo", str(tmp_path), "src/main/scala", ".scala")
+    assert "real.scala" in out
+    assert "broken.scala" not in out
+    assert not out.startswith("ERROR")
+
+
+def test_find_tests_for_skips_symlinks_pointing_outside_repo(tmp_path):
+    """Same security guarantee on find_tests_for: a planted symlink
+    inside the test tree must not have its out-of-repo target read."""
+    test = tmp_path / "src" / "test" / "scala"
+    test.mkdir(parents=True)
+    src = tmp_path / "src" / "main" / "scala"
+    src.mkdir(parents=True)
+    (test / "RealTest.scala").write_text("class RealTest { def Foo() = ()  }\n")
+    secret = tmp_path.parent / f"secret_outside_test_{tmp_path.name}.scala"
+    try:
+        secret.write_text("class SHOULD_NEVER_LEAK { Foo }\n")
+        os.symlink(str(secret), str(test / "leak.scala"))
+        out = find_tests_for("Foo", str(tmp_path), "src/main/scala", ".scala")
+        assert "SHOULD_NEVER_LEAK" not in out
+        assert "leak.scala" not in out
+        # Positive control: legitimate test file IS surfaced.
+        assert "RealTest.scala" in out
+    finally:
+        secret.unlink(missing_ok=True)
+
+
+def test_find_tests_for_test_dir_escapes_repo_returns_error(tmp_path):
+    """If the configured test dir resolves outside the repo (e.g., via a
+    symlinked checkout), return a clear error rather than walk outside."""
+    elsewhere = tmp_path.parent / "elsewhere_test"
+    elsewhere.mkdir()
+    (elsewhere / "ATest.scala").write_text("class ATest\n")
+    repo = tmp_path / "repo"
+    (repo / "src" / "main" / "scala").mkdir(parents=True)
+    os.symlink(str(elsewhere), str(repo / "src" / "test"))
+    try:
+        out = find_tests_for("A", str(repo), "src/main/scala", ".scala")
+        assert out.startswith("ERROR:")
+        assert "outside" in out.lower()
+    finally:
+        import shutil
+        shutil.rmtree(elsewhere, ignore_errors=True)
+
+
+# find_callers returns matching-line snippets so the model can locate
+# specific references without paging through the file.
+
+
+def test_find_callers_includes_line_numbers(repo):
+    """find_callers should emit 'line N:' for matching lines, not just file counts."""
+    out = find_callers("Foo", str(repo), "src/main/scala", ".scala")
+    assert "line " in out
+    # Foo.scala line 1 is 'case class Foo(x: Int)'
+    assert "case class Foo" in out
+
+
+def test_find_callers_includes_line_context(repo):
+    """The matching line text should be inlined so the model can decide
+    whether to read more without another read_file call."""
+    out = find_callers("Foo", str(repo), "src/main/scala", ".scala")
+    # Bar.scala line 1: 'import com.example.Foo'
+    assert "import com.example.Foo" in out
+    # Bar.scala line 2: 'class Bar { def use(): Foo = Foo(1) }'
+    assert "class Bar" in out
+
+
+def test_find_callers_caps_snippets_per_file(repo):
+    """A file with many references shows the first N lines plus a '...more' marker."""
+    extra = repo / "src" / "main" / "scala" / "Heavy.scala"
+    extra.write_text("\n".join(f"line{i}: Foo" for i in range(1, 11)) + "\n")
+    out = find_callers("Foo", str(repo), "src/main/scala", ".scala")
+    # Slice between the 'Heavy.scala' file row and the next file row
+    # (any subsequent line that starts with '  ' followed by a non-space).
+    heavy_start = out.index("Heavy.scala")
+    next_file = -1
+    cursor = heavy_start + 1
+    while True:
+        idx = out.find("\n  ", cursor)
+        if idx == -1:
+            break
+        if len(out) > idx + 3 and out[idx + 3] != " ":
+            next_file = idx
+            break
+        cursor = idx + 1
+    heavy_section = out[heavy_start:next_file if next_file != -1 else len(out)]
+    assert "more lines in this file" in heavy_section
+    # Pin the cap: lines 1-5 are inlined, lines 6-10 are not.
+    assert "line1: Foo" in heavy_section
+    assert "line5: Foo" in heavy_section
+    assert "line6: Foo" not in heavy_section
+    assert "line10: Foo" not in heavy_section
+
+
+def test_find_callers_counts_unchanged(repo):
+    """The (N references) suffix is preserved for the model's ranking signal."""
+    out = find_callers("Foo", str(repo), "src/main/scala", ".scala")
+    assert "references" in out or "reference" in out
+
+
+def test_find_callers_truncates_huge_lines(repo):
+    """A pathologically long matching line shouldn't blow the result-size budget."""
+    from issue_bot.tools import _MAX_SNIPPET_CHARS
+    huge = repo / "src" / "main" / "scala" / "Huge.scala"
+    huge.write_text("Foo " + ("x" * 5000) + "\n")
+    out = find_callers("Foo", str(repo), "src/main/scala", ".scala")
+    snippet_lines = [ln for ln in out.split("\n")
+                     if "Foo" in ln and ln.lstrip().startswith("line ")]
+    assert snippet_lines, "no inlined snippet found for Huge.scala"
+    # Each inlined snippet line must be bounded: 'line N: ' prefix is < 16 chars,
+    # body is capped at _MAX_SNIPPET_CHARS. Total must be well under 5000.
+    longest = max(len(ln) for ln in snippet_lines)
+    assert longest < _MAX_SNIPPET_CHARS + 32, (
+        f"snippet line not truncated: {longest} chars (cap {_MAX_SNIPPET_CHARS} + prefix)"
+    )
+
+
+def test_find_callers_ranks_by_total_occurrences_not_lines(tmp_path):
+    """A file with many same-line references must outrank a file with the
+    same number of lines but fewer references each. Per-file occurrence
+    count, not per-line, is the ranking signal."""
+    src = tmp_path / "src" / "main" / "scala"
+    src.mkdir(parents=True)
+    # Dense: 1 line × 4 refs = 4 occurrences.
+    (src / "Dense.scala").write_text("def f(a: Foo, b: Foo, c: Foo): Foo = ()\n")
+    # Sparse: 3 lines × 1 ref = 3 occurrences.
+    (src / "Sparse.scala").write_text("import Foo\nclass A\nval x: Foo = ???\nval y = 1\nval z: Foo = ???\n")
+    out = find_callers("Foo", str(tmp_path), "src/main/scala", ".scala")
+    dense_idx = out.index("Dense.scala")
+    sparse_idx = out.index("Sparse.scala")
+    assert dense_idx < sparse_idx, (
+        f"Dense.scala (4 refs on 1 line) must outrank Sparse.scala "
+        f"(3 refs on 3 lines):\n{out}"
+    )
+    assert "Dense.scala (4 references)" in out
+    assert "Sparse.scala (3 references)" in out
+
+
+def test_find_tests_for_handles_non_maven_src_dir(tmp_path):
+    """If src_dir doesn't contain 'src/main' (e.g., 'code/scala'),
+    find_tests_for must NOT walk the source tree as if it were tests."""
+    code = tmp_path / "code" / "scala"
+    code.mkdir(parents=True)
+    test = tmp_path / "src" / "test" / "scala"
+    test.mkdir(parents=True)
+    (code / "Foo.scala").write_text("class Foo\n")
+    (test / "FooTest.scala").write_text("class FooTest\n")
+    out = find_tests_for("Foo", str(tmp_path), "code/scala", ".scala")
+    assert "FooTest.scala" in out
+    # Negative control: source tree must NOT be walked as tests.
+    assert "code/scala/Foo.scala" not in out
+
+
+def test_find_tests_for_no_test_dir_when_src_dir_lacks_src_main(tmp_path):
+    """Non-Maven layout with no src/test/ either → clean error, not a
+    silent walk of the source tree."""
+    code = tmp_path / "code" / "scala"
+    code.mkdir(parents=True)
+    (code / "Foo.scala").write_text("class Foo\n")
+    out = find_tests_for("Foo", str(tmp_path), "code/scala", ".scala")
+    assert out.startswith("ERROR:")
+    assert "no test directory" in out
+
+
+def test_find_tests_for_prefers_convention_over_grep_match_on_symlink(tmp_path):
+    """When a symlink and its convention-named target share a realpath,
+    the convention-named hit must win regardless of os.walk order."""
+    test = tmp_path / "src" / "test" / "scala"
+    test.mkdir(parents=True)
+    src = tmp_path / "src" / "main" / "scala"
+    src.mkdir(parents=True)
+    # The convention-named test mentions Foo.
+    (test / "FooTest.scala").write_text("class FooTest { def Foo() = () }\n")
+    # A non-conventional name in an alphabetically-earlier dir, symlinked
+    # to the convention test (same realpath). os.walk visits 'aux/' first.
+    aux = tmp_path / "src" / "test" / "aux"
+    aux.mkdir(parents=True)
+    os.symlink(str(test / "FooTest.scala"), str(aux / "Helper.scala"))
+    out = find_tests_for("Foo", str(tmp_path), "src/main/scala", ".scala")
+    # Convention path wins.
+    assert "FooTest.scala" in out
+    # Symlinked alias does not appear (would be redundant).
+    assert "Helper.scala" not in out
+
+
+def test_grep_codebase_path_glob_symlinked_file_uses_realpath_in_label(tmp_path):
+    """When path_glob is a symlink to an in-repo file, the scope label
+    should match the realpath-relative form so it agrees with match rows."""
+    src = tmp_path / "src" / "main" / "scala"
+    src.mkdir(parents=True)
+    (src / "Real.scala").write_text("Foo here\n")
+    os.symlink(str(src / "Real.scala"), str(src / "Alias.scala"))
+    out = grep_codebase("Foo", "src/main/scala/Alias.scala", str(tmp_path),
+                        "src/main/scala", ".scala")
+    # Header and match rows agree: both refer to Real.scala (the realpath).
+    assert "src/main/scala/Real.scala" in out
+    # The symlink-as-typed name does NOT appear (would mislead the model).
+    assert "Alias.scala" not in out
+
+
+def test_grep_codebase_path_glob_absolute_path_rejected(repo):
+    """Absolute path_glob must be rejected, paralleling read_file's guard."""
+    out = grep_codebase("Foo", "/etc/passwd", str(repo),
+                        "src/main/scala", ".scala")
+    assert out.startswith("ERROR:")
+
+
+def test_iter_matches_in_file_rejects_out_of_repo_path(tmp_path):
+    """Defense-in-depth: if a future caller skips _resolve_grep_scope and
+    passes an out-of-repo path directly, the helper must yield nothing."""
+    import re
+    from issue_bot.tools import _iter_matches_in_file
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    outside = tmp_path.parent / f"outside_{tmp_path.name}.scala"
+    try:
+        outside.write_text("Foo here\n")
+        results = list(_iter_matches_in_file(
+            re.compile("Foo"), str(outside), str(repo), 50,
+        ))
+        assert results == []
+    finally:
+        outside.unlink(missing_ok=True)
+
+
+def test_find_tests_for_convention_upgrades_grep_match_past_limit(tmp_path):
+    """Past the 20-entry limit, an in-flight convention-name visit must
+    still upgrade an existing grep-match (same realpath) so symlink walk
+    order can't trap a worse path."""
+    test = tmp_path / "src" / "test" / "scala"
+    test.mkdir(parents=True)
+    src = tmp_path / "src" / "main" / "scala"
+    src.mkdir(parents=True)
+    # The real test file is convention-named, but a non-conventional
+    # symlink in an alphabetically-earlier dir points to it.
+    real_test = test / "TargetTest.scala"
+    real_test.write_text("class TargetTest { def Target() = () }\n")
+    aux = tmp_path / "src" / "test" / "aux"
+    aux.mkdir(parents=True)
+    os.symlink(str(real_test), str(aux / "Aux.scala"))
+    # Fill the dict with 20 unrelated grep-matches that all reference Target.
+    for i in range(20):
+        (test / f"Other{i}.scala").write_text("// Target reference\n")
+    out = find_tests_for("Target", str(tmp_path), "src/main/scala", ".scala")
+    # Convention-named hit wins despite ordering and limit pressure.
+    assert "TargetTest.scala" in out
+    assert "Aux.scala" not in out


### PR DESCRIPTION
## Summary

Hardens the agentic-pipeline tool surface (`tools.py`) shipped in #724 and adapts the Investigator turn floor in `main.py`. Surfaced through several rounds of adversarial review against the 3-agent pipeline. The fixes fall into two groups: tool safety (path-scope leaks, symlink escapes, dedup) and ranking/output-quality regressions in `find_callers` and `find_tests_for`. Also includes two CodeQL clear-text-logging fixes.

### What changed

- `src/scripts/issue_bot/tools.py`
  - **`grep_codebase`**: `path_glob` now accepts a repo-relative file or directory inside the configured source dir. Previously a non-extension `path_glob` was silently ignored, so a model that meant to scope a search broadened it to the whole codebase. New `_resolve_grep_scope` rejects values that resolve outside `src_dir` (parent leaks like `'src'`, sibling leaks like `'src/test/scala'`, dot-alone, path traversal). Tighter extension regex (`re.fullmatch(r"\.[A-Za-z0-9]+", ...)`) so `'../foo'` falls through to safety checks instead of being treated as an extension. Multi-dot extensions (e.g., `.d.ts`) are accepted when they match the configured `default_ext`.
  - **Symlink safety** across `grep_codebase`, `find_callers`, `find_tests_for`: new `_is_inside` helper drops symlinks whose realpath escapes the repo, and dedupes in-repo symlinks by realpath so duplicate aliases don't inflate counts. The configured `src_dir` itself is now verified to resolve inside the repo so a misconfigured symlinked checkout fails loudly rather than silently returning empty results.
  - **`find_callers`**: returns line snippets — top files get up to 5 inlined `line N: <text>` rows; remaining files name-only. Ranking counts total occurrences per file (not just matching lines) so a dense type signature like `def f(a: Foo, b: Foo): Foo` still ranks above a verbose multi-line file.
  - **`find_tests_for`**: same path-safety + symlink-skip + dedup as siblings (was missing in the prior change). Falls back to `src/test` only when the `src/main` → `src/test` substitution actually changed `src_dir` — fixes a regression where non-Maven layouts (e.g., `src_dir='code/scala'`) would walk the source tree as tests. Convention-named hits (`XTest.scala` / `XSpec.scala`) win over grep-matches for the same physical file regardless of `os.walk` order, and a convention-name visit can upgrade an existing grep-match even past the 20-entry limit.
  - Single-file `path_glob` reports the realpath-relative path in both header and match rows so the model sees one identity for symlinked files.
  - Defense-in-depth `_is_inside` check on `_iter_matches_in_file` entry.

- `src/scripts/issue_bot/main.py`
  - `_build_caps`: Investigator turn floor raised from 5 → 10. Diff-line count is a poor proxy for investigation depth — a small typed-API change can ripple through many files — so the floor is generous.
  - Two CodeQL clear-text-logging fixes: `_write_artifact` and `_load_pipeline_prompts` no longer interpolate fields the analyzer flags as taint-tracked.

- `src/scripts/tests/test_tools.py` — 27 new tests pin the new behavior: path-scope semantics with positive + negative controls, symlink-outside-repo skip with positive control on the legitimate file, in-repo symlink dedup, broken-symlink graceful skip, src_dir-as-escape-symlink error, `find_callers` ranking by total occurrences (not matching lines), `find_callers` snippet cap pinned, non-Maven `src_dir` doesn't walk source tree as tests, convention-name preference over grep-match on shared realpath including past the entry limit, single-file `path_glob` realpath-relative label, trailing-newline target rejection on `find_tests_for`, defense-in-depth `_iter_matches_in_file` rejection of out-of-repo paths, absolute path_glob rejection. Existing back-compat tests tightened with negative controls so a regression that ignores `path_glob` entirely fails them.

- `src/scripts/tests/test_pipeline_helpers.py` — 7 new `_build_caps` tests: small PR (56 changed lines) hits floor=10, empty PR hits floor, large PR clamps at user ceiling, low user ceiling overrides floor, Critic floor min(3, ceiling), missing `changes` field defaults to 0.

### Defensive choices worth calling out

- **Path scope can only narrow, never broaden**: the new `path_glob` semantics reject any path outside `src_dir` (parent, sibling, repo-root). Tests pin the negative controls so a regression that ignores scope entirely fails.
- **Symlink-outside-repo is silently skipped, not errored**: the model continues investigating in-repo files normally. Symlink-as-`src_dir` (operator misconfig) does error loudly because silent-empty would be misleading.
- **In-repo dedup is by realpath, not relpath**: a symlink and its target produce one entry, not two. Old code's relpath-keyed dedup let the same physical file appear twice when reached via different aliases.
- **Convention-name preference works under symlink chaos**: `XTest.scala` wins over a same-realpath grep-match regardless of `os.walk` order, and the upgrade can happen even after the 20-entry cap is reached.
- **`re.fullmatch` over `re.match(...$)`**: a trailing newline in `Foo\n` no longer slips through identifier validation. Symbolic argument validation in `find_callers` and `find_tests_for` is now strict.

### Out of scope

- The Investigator/Critic prompts in Secrets Manager are not in this repo. They will be updated in lockstep with this PR's merge to (1) describe the new `path_glob` path-scope capability and (2) note that `find_callers` snippets often remove the need for a follow-up `read_file`.
- Wall-clock budget interaction with the new floor=10 is not unit-tested deterministically (depends on Bedrock latency). The fast-path skip on clean PRs (no `STATUS: CONFIRMED` → skip Critic + Reporter) protects the dominant case; tail-latency on confirmed-finding small PRs will be observed in Stage 2 dry-run.
- The legacy two-phase flow is not modified.

## Test plan

- [ ] All 288 tests pass locally and in CI (`python3 -m pytest src/scripts/tests/ -q`)
- [ ] `workflow_dispatch BOT_AGENT_PIPELINE=1 dry_run=true` on PR #722 surfaces the `StateProvider.scala:124` `asInstanceOf[FrequenciesAndNumRows]` finding via `find_callers("HistogramBinned")` → `read_file(...)` and the Critic UPHOLDS it
- [ ] Same dispatch on PR #720 catches the `flatten()` finding the bot already catches today
- [ ] Same dispatch on PR #717 reduces the false-positive cluster (Critic OVERTURNs ≥ 3 of 5)
- [ ] Same dispatch on a clean PR returns "No issues found." with the clean marker
- [ ] Bot review on this PR posts a normal review (legacy two-phase flow when flag unset; agentic flow when flag set)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.