### PR TITLE
fix: persist full investigator narrative on every pipeline artifact

### DIFF
--- a/src/scripts/issue_bot/main.py
+++ b/src/scripts/issue_bot/main.py
@@ -950,6 +950,7 @@ def _run_agent_pipeline(*, cfg, gh, bedrock, number, title, body, html_url, item
         inline_comments=rep_inline_comments, response=response,
         metrics=_finalize_metrics(metrics, inv_result, crit_result),
         tool_trace=(inv_result.tool_trace + (crit_result.tool_trace if crit_result else [])),
+        investigator_summary=inv_result.text,
     )
 
 
@@ -1299,7 +1300,7 @@ def _write_artifact_pipeline(*, cfg, action, reason, title, html_url, number,
     if reason:
         artifact["reason"] = reason
     if investigator_summary:
-        artifact["investigator_summary"] = investigator_summary[:5000]
+        artifact["investigator_summary"] = investigator_summary
     _write_artifact(artifact)
 
 

--- a/src/scripts/tests/test_critic.py
+++ b/src/scripts/tests/test_critic.py
@@ -136,6 +136,28 @@ def test_clean_pr_fast_path_skips_critic_and_reporter(tmp_path, monkeypatch):
     assert artifact["metrics"]["critic"]["skip_reason"] == "no_confirmed_findings"
     assert artifact["metrics"]["reporter"]["skipped"] is True
     assert artifact["pipeline"] == "agentic"
+    # Investigator narrative preserved on RESPOND so a "no issues found"
+    # outcome is still auditable post-hoc.
+    assert artifact.get("investigator_summary") == investigator_notes
+
+
+def test_investigator_summary_not_truncated_on_long_narrative(tmp_path, monkeypatch):
+    """A long investigator narrative (e.g. several confirmed findings each
+    with falsification details) must be preserved end-to-end. Truncation
+    here defeats the artifact's role as a post-hoc audit log."""
+    import unittest.mock as mock
+    long_notes = "Investigator narrative for audit. " * 1000  # ~33KB
+    artifact, _, _ = _run_pipeline(
+        tmp_path, monkeypatch, mock,
+        investigator_text=long_notes,
+        critic_text="should not be called",
+        reporter_json='{"analysis": []}',
+    )
+    assert artifact["action"] == "RESPOND"
+    summary = artifact.get("investigator_summary", "")
+    # Allow for the .strip() in agent_loop's text extraction; assert the
+    # bulk of the content survives so a 5000-char or similar cap fails.
+    assert len(summary) > 30_000
 
 
 def test_confirmed_finding_triggers_critic_and_reporter(tmp_path, monkeypatch):
@@ -174,6 +196,9 @@ def test_confirmed_finding_triggers_critic_and_reporter(tmp_path, monkeypatch):
     assert mock_invoke.call_count == 1
     assert artifact["metrics"]["critic"]["skipped"] is False
     assert artifact["metrics"]["critic_overturn_rate"] == 0.0
+    # Investigator narrative preserved on RESPOND with confirmed findings.
+    assert artifact.get("investigator_summary", "").startswith("ID: C1")
+    assert "STATUS: CONFIRMED" in artifact.get("investigator_summary", "")
 
 
 def test_overturned_finding_dropped_by_reporter(tmp_path, monkeypatch):


### PR DESCRIPTION
## Summary

Two related observability gaps in the agentic pipeline artifact (#724):

1. `investigator_summary` was only populated on `ESCALATE` artifacts. On `RESPOND` (including the clean-PR fast path) the model's HYPOTHESIS / FALSIFICATION_ATTEMPT / STATUS narrative was discarded, so a "no issues found" outcome could not be audited after the fact. Diagnosing a false negative required re-dispatching the workflow.
2. The summary was truncated at 5000 chars before being written. The Investigator's max output is ~32KB (8000 tokens), so a max-length investigation lost ~85% of its reasoning. The same artifact accepts up to 100KB of `tool_trace`, so the per-field cap was inconsistent with the artifact's actual size envelope.

This PR makes the narrative always persisted and never truncated.

### What changed

- `src/scripts/issue_bot/main.py` — `_run_agent_pipeline` passes `investigator_summary=inv_result.text` to the RESPOND artifact write (was only passed on ESCALATE). `_write_artifact_pipeline` writes the field verbatim instead of `[:5000]`.
- `src/scripts/tests/test_critic.py` — two new assertions on existing tests (clean-PR fast path and confirmed-finding RESPOND path) plus a new test that pins the no-truncation behavior with a ~33KB synthetic narrative so a future cap re-introduction fails.

### Why this is safe

- The field is consumed by humans inspecting `bot_result.json` from a workflow artifact. The `act` job posts to GitHub and never reads `investigator_summary`. No on-PR behavior changes.
- Artifact size impact is bounded by the Investigator's existing `max_tokens_per_call` budget (8000 tokens ≈ 32KB) — well under the `tool_trace`'s 100KB cap and far under any GitHub Actions artifact limit.
- No additional Bedrock calls, no token-cost change, no latency change.

## Test plan

- [ ] All 289 tests pass locally and in CI (`python3 -m pytest src/scripts/tests/ -q`)
- [ ] Next agentic-pipeline dispatch produces an artifact whose `investigator_summary` matches the model's full output (verified by length and content)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.