### PR TITLE
fix: agentic pipeline architectural contract — forced commit phase, aggregate text, Critic backstop

### DIFF
--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -76,6 +76,8 @@ jobs:
           SM_PR_INVESTIGATOR_PROMPT: deequ-bot/pr-investigator-prompt
           SM_PR_CRITIC_PROMPT: deequ-bot/pr-critic-prompt
           SM_PR_REPORTER_PROMPT: deequ-bot/pr-reporter-prompt
+          SM_PR_INVESTIGATOR_COMMIT_PROMPT: deequ-bot/pr-investigator-commit-prompt
+          SM_PR_CRITIC_COMMIT_PROMPT: deequ-bot/pr-critic-commit-prompt
           SM_FOLLOWUP_PROMPT: deequ-bot/followup-prompt
           # Flip BOT_AGENT_PIPELINE to "1" to enable the 3-agent (Investigator+Critic+Reporter) pipeline.
           # When unset/empty, the legacy two-phase flow runs unchanged.

--- a/src/scripts/issue_bot/agent_loop.py
+++ b/src/scripts/issue_bot/agent_loop.py
@@ -2,8 +2,10 @@
 
 Each turn calls Bedrock with toolConfig; if stopReason is "tool_use" the
 loop executes the requested tools and continues, otherwise it returns the
-final text. Owns budget enforcement (turns, tool calls, tool output chars)
-and records each tool call in the result's tool_trace.
+final text. Owns budget enforcement (turns, tool calls, tool output chars),
+records each tool call in the result's tool_trace, and runs a forced
+no-tool commit phase when the tool budget is exhausted so the model is
+physically constrained to emit text instead of more tool calls.
 """
 import logging
 import time
@@ -31,9 +33,9 @@ class AgentCaps:
 
 @dataclass
 class AgentResult:
-    """Outcome of an agent loop run. Empty `text` means the agent had no
-    usable output and downstream stages should skip; `error` is a one-line
-    label for logs."""
+    """Outcome of an agent loop run. `text` is the full aggregated assistant
+    text across every turn so partial commits are preserved when a later
+    turn ends in tool calls. `error` is a one-line label for logs."""
     text: str = ""
     turns: int = 0
     tool_calls: int = 0
@@ -43,6 +45,7 @@ class AgentResult:
     cache_read_tokens: int = 0
     cache_write_tokens: int = 0
     max_turns_reached: bool = False
+    commit_phase_ran: bool = False
     error: Optional[str] = None
     tool_trace: List[Dict[str, Any]] = field(default_factory=list)
 
@@ -57,6 +60,7 @@ def run(
     caps: AgentCaps,
     pipeline_deadline: Optional[float] = None,
     untrusted_user_prompt: Optional[str] = None,
+    commit_phase_user_prompt: Optional[str] = None,
 ):
     """Execute an agent's tool-use loop. Returns an AgentResult.
 
@@ -64,8 +68,15 @@ def run(
     goes in a guardContent block when the client has a guardrail so model
     paraphrases of repo content don't false-trip the scanner.
 
+    commit_phase_user_prompt (optional) drives the forced no-tool turn
+    that runs when the tool budget is exhausted. The Bedrock call on that
+    turn omits toolConfig so the model is physically unable to call tools
+    and must emit text. If unset, the loop terminates without a commit
+    phase (legacy behavior).
+
     Termination: caps.max_turns / max_tool_calls / max_tool_output_chars /
-    per_tool_max_calls, or pipeline_deadline.
+    per_tool_max_calls, or pipeline_deadline. Result.text is the aggregated
+    assistant text across every turn so partial commitments are preserved.
     """
     result = AgentResult()
     messages = [{
@@ -77,17 +88,26 @@ def run(
     }]
     per_tool_calls = defaultdict(int)
 
+    def _finalize(termination_reason: Optional[str] = None):
+        if termination_reason and not result.error:
+            result.error = termination_reason
+        if commit_phase_user_prompt and _is_budget_exhaustion(termination_reason):
+            _run_commit_phase(
+                bedrock_client, agent_name, system_prompt, messages,
+                commit_phase_user_prompt, tool_specs, caps, result, pipeline_deadline,
+            )
+        result.text = _aggregate_all_assistant_text(messages)
+        return result
+
     for turn in range(max(0, caps.max_turns)):
         result.turns = turn + 1
 
         if pipeline_deadline is not None and time.monotonic() >= pipeline_deadline:
-            result.error = "pipeline wall-clock deadline reached"
-            result.text = result.text or _recover_last_assistant_text(messages)
             logger.warning(
                 "[%s turn=%d] pipeline wall-clock reached, terminating",
                 agent_name, turn + 1,
             )
-            return result
+            return _finalize("pipeline wall-clock deadline reached")
 
         try:
             resp = bedrock_client.converse_with_tools(
@@ -98,12 +118,10 @@ def run(
             )
         except Exception as e:
             logger.error("[%s turn=%d] bedrock error: %s", agent_name, turn + 1, type(e).__name__)
-            result.error = f"bedrock error: {type(e).__name__}"
-            return result
+            return _finalize(f"bedrock error: {type(e).__name__}")
 
         if resp is None:
-            result.error = "bedrock returned None (circuit-breaker or transient failure)"
-            return result
+            return _finalize("bedrock returned None (circuit-breaker or transient failure)")
 
         usage = resp.get("usage") or {}
         result.input_tokens += usage.get("inputTokens") or 0
@@ -118,43 +136,103 @@ def run(
 
         msg = resp.get("output", {}).get("message", {})
         if not msg:
-            result.error = "empty bedrock message"
-            return result
+            return _finalize("empty bedrock message")
         messages.append(msg)
 
         if resp.get("stopReason") != "tool_use":
-            result.text = _extract_text(msg)
-            return result
+            return _finalize(None)
 
         tool_results = _run_tool_calls(
             msg, agent_name, turn + 1, tool_runner, caps, result, per_tool_calls,
         )
         if not tool_results:
-            # Bedrock protocol violation: stopReason=tool_use with no toolUse
-            # blocks. We capture any accompanying text and exit; if the text
-            # happens to be parseable downstream the caller can use it.
-            result.text = _extract_text(msg)
-            result.error = "stopReason was tool_use but no toolUse blocks emitted"
-            return result
+            return _finalize("stopReason was tool_use but no toolUse blocks emitted")
 
-        # Stop before paying another Bedrock turn against exhausted budgets.
-        if (result.tool_calls >= caps.max_tool_calls
-                or result.tool_output_chars >= caps.max_tool_output_chars):
-            result.error = "structural cap hit; terminating before next turn"
-            result.text = _extract_text(msg) or (
-                f"Investigation terminated on turn {turn + 1}: structural cap reached."
-            )
-            return result
-
+        # Bedrock requires tool_use to be followed by toolResult, so we
+        # append before the cap check — otherwise commit phase inherits an
+        # unfollowed tool_use turn and the request is rejected.
         messages.append({"role": "user", "content": tool_results})
 
+        if (result.tool_calls >= caps.max_tool_calls
+                or result.tool_output_chars >= caps.max_tool_output_chars):
+            logger.info("[%s turn=%d] structural cap hit", agent_name, turn + 1)
+            return _finalize("structural cap hit; terminating before next turn")
+
     result.max_turns_reached = True
-    result.text = _recover_last_assistant_text(messages) or (
-        f"Investigation hit max_turns ({caps.max_turns}) without conclusion. "
-        f"Made {result.tool_calls} tool call(s)."
-    )
     logger.warning("[%s] max_turns (%d) reached", agent_name, caps.max_turns)
-    return result
+    return _finalize(f"max_turns ({caps.max_turns}) reached")
+
+
+_BUDGET_EXHAUSTION_REASONS = frozenset({
+    "pipeline wall-clock deadline reached",
+    "structural cap hit; terminating before next turn",
+})
+# max_turns reached is also a budget exhaustion case; we match it by
+# substring rather than exact text since the message includes the cap value.
+_BUDGET_EXHAUSTION_PREFIXES = ("max_turns",)
+
+
+def _is_budget_exhaustion(reason: Optional[str]) -> bool:
+    if not reason:
+        return False
+    if reason in _BUDGET_EXHAUSTION_REASONS:
+        return True
+    return any(reason.startswith(p) for p in _BUDGET_EXHAUSTION_PREFIXES)
+
+
+def _run_commit_phase(bedrock_client, agent_name, system_prompt, messages,
+                      commit_phase_user_prompt, tool_specs, caps, result,
+                      pipeline_deadline):
+    """One Bedrock turn after the loop's tool budget is exhausted, prompting
+    the model to emit text only. tool_specs is kept on the request because
+    Bedrock validates toolUse/toolResult content blocks in the conversation
+    history against toolConfig — omitting it would trip ValidationException
+    on any history that includes a prior tool call. Suppression of new tool
+    calls is enforced by the commit-phase user prompt, not by removing
+    toolConfig.
+    """
+    if pipeline_deadline is not None and time.monotonic() >= pipeline_deadline:
+        logger.warning(
+            "[%s] commit phase skipped: pipeline wall-clock already past",
+            agent_name,
+        )
+        return
+    # Bedrock rejects two consecutive same-role messages. Merge the commit
+    # prompt into the trailing user turn (which usually carries toolResults)
+    # instead of appending a second user message.
+    if messages and messages[-1].get("role") == "user":
+        last_content = list(messages[-1].get("content", []))
+        last_content.append({"text": commit_phase_user_prompt})
+        messages[-1] = {"role": "user", "content": last_content}
+    else:
+        messages.append({"role": "user", "content": [{"text": commit_phase_user_prompt}]})
+
+    result.commit_phase_ran = True
+
+    try:
+        resp = bedrock_client.converse_with_tools(
+            system_prompt=system_prompt,
+            messages=messages,
+            tool_specs=tool_specs,
+            max_tokens=caps.max_tokens_per_call,
+        )
+    except Exception as e:
+        logger.error("[%s] commit phase bedrock error: %s", agent_name, type(e).__name__)
+        return
+    if resp is None:
+        logger.warning("[%s] commit phase returned None", agent_name)
+        return
+
+    usage = resp.get("usage") or {}
+    result.input_tokens += usage.get("inputTokens") or 0
+    result.output_tokens += usage.get("outputTokens") or 0
+    result.cache_read_tokens += usage.get("cacheReadInputTokens") or 0
+    result.cache_write_tokens += usage.get("cacheWriteInputTokens") or 0
+
+    msg = resp.get("output", {}).get("message", {})
+    if msg:
+        messages.append(msg)
+    logger.info("[%s] commit phase emitted %d output tokens", agent_name, usage.get("outputTokens") or 0)
 
 
 def _build_user_content(trusted, untrusted, *, has_guardrail):
@@ -266,14 +344,18 @@ def _extract_text(msg):
     ).strip()
 
 
-def _recover_last_assistant_text(messages):
-    """Walk back to the most recent assistant message and extract its text.
-    Used on max_turns / wall-clock exits so partial findings aren't dropped
-    when the trailing message is the user-side toolResult."""
-    for msg in reversed(messages):
-        if msg.get("role") == "assistant":
-            return _extract_text(msg)
-    return ""
+def _aggregate_all_assistant_text(messages):
+    """Concatenate text blocks from every assistant message in order.
+    Preserves partial commitments emitted in mid-loop turns even when later
+    turns end in tool calls or the loop terminates abnormally."""
+    parts = []
+    for msg in messages:
+        if msg.get("role") != "assistant":
+            continue
+        text = _extract_text(msg)
+        if text:
+            parts.append(text)
+    return "\n\n".join(parts)
 
 
 def _summarize_args(args):

--- a/src/scripts/issue_bot/bedrock_client.py
+++ b/src/scripts/issue_bot/bedrock_client.py
@@ -198,8 +198,13 @@ class BedrockClient:
 
     def converse_with_tools(self, system_prompt, messages, tool_specs,
                              max_tokens=8000, temperature=0.3):
-        """One turn of Converse with toolConfig. Returns the raw response
-        dict (or None on failure / guardrail intervention / circuit open).
+        """One turn of Converse with optional toolConfig. Returns the raw
+        response dict (or None on failure / guardrail intervention /
+        circuit open).
+
+        Pass `tool_specs=None` (or an empty list) to omit toolConfig — used
+        by the loop's commit phase to physically prevent further tool calls
+        after the tool budget is exhausted.
 
         cachePoint is set here (unlike invoke()/invoke_with_usage) because
         Investigator and Critic share the static prefix from
@@ -216,8 +221,9 @@ class BedrockClient:
                 "modelId": self._model_id,
                 "messages": wrapped_messages,
                 "inferenceConfig": {"maxTokens": max_tokens, "temperature": temperature},
-                "toolConfig": {"tools": tool_specs},
             }
+            if tool_specs:
+                kwargs["toolConfig"] = {"tools": tool_specs}
             if system_prompt:
                 kwargs["system"] = [
                     {"text": system_prompt},

--- a/src/scripts/issue_bot/main.py
+++ b/src/scripts/issue_bot/main.py
@@ -887,6 +887,7 @@ def _run_agent_pipeline(*, cfg, gh, bedrock, number, title, body, html_url, item
         tool_specs=TOOL_SPECS, tool_runner=tool_runner,
         caps=investigator_caps,
         pipeline_deadline=pipeline_deadline,
+        commit_phase_user_prompt=prompts.get_pr_investigator_commit_prompt() or None,
     )
 
     metrics = _initial_metrics(inv_result)
@@ -912,6 +913,7 @@ def _run_agent_pipeline(*, cfg, gh, bedrock, number, title, body, html_url, item
             reporter_system=reporter_system,
             diff=diff, title=title, body=body,
             investigator_text=inv_result.text,
+            investigator_max_turns_reached=inv_result.max_turns_reached,
             pipeline_deadline=pipeline_deadline,
         )
     )
@@ -1051,6 +1053,7 @@ def _initial_metrics(inv_result):
 
 def _run_critic_and_reporter(*, cfg, bedrock, tool_runner, critic_system, critic_caps,
                               reporter_system, diff, title, body, investigator_text,
+                              investigator_max_turns_reached=False,
                               pipeline_deadline=None):
     """Run the Critic (if any CONFIRMED concerns) and then the Reporter.
 
@@ -1059,10 +1062,17 @@ def _run_critic_and_reporter(*, cfg, bedrock, tool_runner, critic_system, critic
     "no_confirmed_findings" (fast path), "critic_failed",
     "reporter_deadline_exceeded", "reporter_failed". Caller escalates on
     any non-happy-path event so confirmed findings aren't silently dropped.
+
+    The fast path fires only when the Investigator emitted no CONFIRMED
+    block AND did not hit max_turns. When the Investigator ran out of
+    budget, the Critic backstops — the absence of CONFIRMED on a budget-
+    exhausted run cannot be distinguished from a silent bail without a
+    second-pass agent investigating from scratch.
     """
     skipped_metrics = _empty_stage_metrics()
 
-    if not _has_confirmed_findings(investigator_text):
+    if (not _has_confirmed_findings(investigator_text)
+            and not investigator_max_turns_reached):
         return None, "no_confirmed_findings", [], skipped_metrics
 
     # Neutralize close-tags so a model that emits "</investigator_notes>" or
@@ -1084,6 +1094,7 @@ def _run_critic_and_reporter(*, cfg, bedrock, tool_runner, critic_system, critic
         tool_specs=TOOL_SPECS, tool_runner=tool_runner,
         caps=critic_caps,
         pipeline_deadline=pipeline_deadline,
+        commit_phase_user_prompt=prompts.get_pr_critic_commit_prompt() or None,
     )
 
     if not crit_result.text:

--- a/src/scripts/issue_bot/prompts.py
+++ b/src/scripts/issue_bot/prompts.py
@@ -76,5 +76,18 @@ def get_pr_investigator_prompt():
     return _get_prompt("PR_INVESTIGATOR_PROMPT", "SM_PR_INVESTIGATOR_PROMPT")
 
 
+def get_pr_investigator_commit_prompt():
+    """Forced-emit user prompt for the Investigator's commit phase. Sent
+    on the no-tool turn after the tool budget is exhausted. An empty
+    return disables the commit phase — the loop falls back to legacy
+    terminate-without-conclusion behavior."""
+    return _get_prompt("PR_INVESTIGATOR_COMMIT_PROMPT", "SM_PR_INVESTIGATOR_COMMIT_PROMPT")
+
+
+def get_pr_critic_commit_prompt():
+    """Forced-emit user prompt for the Critic's commit phase."""
+    return _get_prompt("PR_CRITIC_COMMIT_PROMPT", "SM_PR_CRITIC_COMMIT_PROMPT")
+
+
 def prompt_version(template):
     return hashlib.sha256(template.encode()).hexdigest()[:8]

--- a/src/scripts/tests/conftest.py
+++ b/src/scripts/tests/conftest.py
@@ -17,11 +17,15 @@ def isolate_sm_env(monkeypatch):
         "SM_PR_INVESTIGATOR_PROMPT",
         "SM_PR_CRITIC_PROMPT",
         "SM_PR_REPORTER_PROMPT",
+        "SM_PR_INVESTIGATOR_COMMIT_PROMPT",
+        "SM_PR_CRITIC_COMMIT_PROMPT",
         "SM_FOLLOWUP_PROMPT",
         "PR_FILE_REVIEW_REPORT_PROMPT",
         "PR_INVESTIGATOR_PROMPT",
         "PR_CRITIC_PROMPT",
         "PR_REPORTER_PROMPT",
+        "PR_INVESTIGATOR_COMMIT_PROMPT",
+        "PR_CRITIC_COMMIT_PROMPT",
         "BOT_AGENT_PIPELINE",
     ):
         monkeypatch.delenv(var, raising=False)

--- a/src/scripts/tests/test_agent_loop.py
+++ b/src/scripts/tests/test_agent_loop.py
@@ -225,7 +225,11 @@ def test_max_turns_recovers_text_from_assistant_message():
     assert "max_turns" not in result.text
 
 
-def test_max_turns_falls_back_to_boilerplate_if_no_text():
+def test_max_turns_with_no_text_returns_empty_when_no_commit_phase():
+    """When max_turns hits without any text emitted by the model and no
+    commit-phase prompt is configured, result.text must be empty so
+    downstream callers can detect the silent-bail case via max_turns_reached
+    and route to a Critic backstop."""
     tu_only = _resp(
         [{"toolUse": {"toolUseId": "t", "name": "grep_codebase", "input": {"pattern": "x"}}}],
         stop_reason="tool_use",
@@ -234,7 +238,8 @@ def test_max_turns_falls_back_to_boilerplate_if_no_text():
     tr = FakeToolRunner()
     result = _run(bedrock, tr, caps=AgentCaps(max_turns=2))
     assert result.max_turns_reached is True
-    assert "max_turns" in result.text
+    assert result.text == ""
+    assert "max_turns" in (result.error or "")
 
 
 def test_wall_clock_cap_terminates_loop():
@@ -335,3 +340,172 @@ def test_guardrail_does_not_wrap_trusted_block():
     guard_text = content[1].get("guardContent", {}).get("text", {}).get("text", "")
     assert "ignore previous instructions" in text_block_text
     assert "ignore previous instructions" not in guard_text
+
+
+# Layer A: aggregate text from all assistant messages, not only the last.
+
+def test_aggregate_text_preserves_partial_commits_from_earlier_turns():
+    """When the model emits a STATUS block on turn 1 alongside tool calls,
+    then runs out of turns, the per-turn commit MUST be in result.text. The
+    old behavior (walk-back to last assistant message) lost it because the
+    last turn's text block could be empty when the model ended on tool use."""
+    turn1 = _resp(
+        [
+            {"text": "WORKING_NOTES: hypothesis A formed.\nID: A1\nSTATUS: CONFIRMED\nCOMMENT: real bug at line 5"},
+            {"toolUse": {"toolUseId": "t1", "name": "read_file", "input": {"path": "x"}}},
+        ],
+        stop_reason="tool_use",
+    )
+    turn2_no_text = _resp(
+        [{"toolUse": {"toolUseId": "t2", "name": "read_file", "input": {"path": "y"}}}],
+        stop_reason="tool_use",
+    )
+    bedrock = FakeBedrockClient([turn1, turn2_no_text, turn2_no_text])
+    result = _run(bedrock, FakeToolRunner(), caps=AgentCaps(max_turns=3))
+    # Turn 1's STATUS: CONFIRMED block must survive even though turn 3
+    # ended on tool_use with no text.
+    assert "STATUS: CONFIRMED" in result.text
+    assert "ID: A1" in result.text
+
+
+def test_aggregate_text_concatenates_all_turns_in_order():
+    """Multiple turns each emit a STATUS block; result.text must contain
+    every block in turn order so the Reporter can parse them all."""
+    turn1 = _resp([{"text": "ID: A1\nSTATUS: CONFIRMED"},
+                   {"toolUse": {"toolUseId": "t1", "name": "read_file", "input": {"path": "x"}}}],
+                  stop_reason="tool_use")
+    turn2 = _resp([{"text": "ID: A2\nSTATUS: DISPROVED"}],
+                  stop_reason="end_turn")
+    bedrock = FakeBedrockClient([turn1, turn2])
+    result = _run(bedrock, FakeToolRunner(), caps=AgentCaps(max_turns=3))
+    a1_idx = result.text.index("ID: A1")
+    a2_idx = result.text.index("ID: A2")
+    assert a1_idx < a2_idx, "later turns must appear after earlier turns in result.text"
+
+
+# Layer B: forced commit phase when budget exhausted.
+
+def test_commit_phase_runs_with_prompt_when_max_turns_hit():
+    """After max_turns, the loop calls Bedrock once more with the commit-
+    phase user prompt appended to the conversation. tool_specs are kept on
+    the request so toolUse/toolResult blocks in history validate against
+    Bedrock's schema; the prompt suppresses new tool calls."""
+    tool_specs = [{"toolSpec": {"name": "read_file"}}]
+    turns_with_tools = [
+        _resp([{"toolUse": {"toolUseId": "t", "name": "read_file", "input": {"path": "x"}}}],
+              stop_reason="tool_use"),
+    ] * 2
+    commit_resp = _resp([{"text": "ID: A1\nSTATUS: UNVERIFIED\nCOMMENT: ran out of turns"}],
+                        stop_reason="end_turn")
+    bedrock = FakeBedrockClient(turns_with_tools + [commit_resp])
+    result = run(
+        bedrock_client=bedrock, agent_name="investigator",
+        system_prompt="sys", user_prompt="user",
+        tool_specs=tool_specs,
+        tool_runner=FakeToolRunner(),
+        caps=AgentCaps(max_turns=2),
+        commit_phase_user_prompt="TOOL BUDGET EXHAUSTED. Emit findings now.",
+    )
+    assert result.max_turns_reached is True
+    assert result.commit_phase_ran is True
+    last_call = bedrock.calls[-1]
+    assert last_call["tool_specs"] == tool_specs
+    last_user_msgs = [m for m in last_call["messages"] if m.get("role") == "user"]
+    last_user_text = "".join(
+        b.get("text", "") for b in last_user_msgs[-1].get("content", []) if "text" in b
+    )
+    assert "TOOL BUDGET EXHAUSTED" in last_user_text
+    assert "STATUS: UNVERIFIED" in result.text
+
+
+def test_commit_phase_skipped_when_no_prompt_configured():
+    """Without a commit_phase_user_prompt, the loop terminates without an
+    extra Bedrock call (legacy behavior, opt-in feature flag style)."""
+    turns_with_tools = [
+        _resp([{"toolUse": {"toolUseId": "t", "name": "read_file", "input": {"path": "x"}}}],
+              stop_reason="tool_use"),
+    ] * 3
+    bedrock = FakeBedrockClient(turns_with_tools)
+    result = _run(bedrock, FakeToolRunner(), caps=AgentCaps(max_turns=2))
+    assert result.max_turns_reached is True
+    assert result.commit_phase_ran is False
+    # Two turns, no commit phase, so two Bedrock calls.
+    assert len(bedrock.calls) == 2
+
+
+def test_commit_phase_runs_on_structural_cap_hit():
+    """Tool-call budget exhaustion (max_tool_calls reached) must also
+    trigger the commit phase, not just max_turns."""
+    turn = _resp(
+        [{"toolUse": {"toolUseId": "t", "name": "read_file", "input": {"path": "x"}}}],
+        stop_reason="tool_use",
+    )
+    commit_resp = _resp([{"text": "ID: A1\nSTATUS: CONFIRMED\nCOMMENT: hit cap"}],
+                        stop_reason="end_turn")
+    bedrock = FakeBedrockClient([turn, commit_resp])
+    caps = AgentCaps(max_turns=10, max_tool_calls=1)
+    result = run(
+        bedrock_client=bedrock, agent_name="investigator",
+        system_prompt="sys", user_prompt="user",
+        tool_specs=[{"toolSpec": {"name": "read_file"}}],
+        tool_runner=FakeToolRunner(),
+        caps=caps,
+        commit_phase_user_prompt="TOOL BUDGET EXHAUSTED.",
+    )
+    assert result.commit_phase_ran is True
+    assert "STATUS: CONFIRMED" in result.text
+
+
+def test_commit_phase_merges_prompt_into_trailing_user_toolresult_message():
+    """When the loop terminates after appending a user(toolResult) message,
+    the commit phase MUST merge the prompt into that message (not append
+    a second consecutive user, which Bedrock rejects)."""
+    turn = _resp(
+        [{"toolUse": {"toolUseId": "t", "name": "read_file", "input": {"path": "x"}}}],
+        stop_reason="tool_use",
+    )
+    commit_resp = _resp([{"text": "ok"}], stop_reason="end_turn")
+    bedrock = FakeBedrockClient([turn, commit_resp])
+    run(
+        bedrock_client=bedrock, agent_name="investigator",
+        system_prompt="sys", user_prompt="user",
+        tool_specs=[{"toolSpec": {"name": "read_file"}}],
+        tool_runner=FakeToolRunner(),
+        caps=AgentCaps(max_turns=1),
+        commit_phase_user_prompt="TOOL BUDGET EXHAUSTED.",
+    )
+    # Last bedrock call's messages must end in a single user message that
+    # contains both the toolResult AND the commit prompt text.
+    final_messages = bedrock.calls[-1]["messages"]
+    last = final_messages[-1]
+    assert last["role"] == "user"
+    contents = last["content"]
+    assert any("toolResult" in b for b in contents), "toolResult preserved"
+    assert any(b.get("text") == "TOOL BUDGET EXHAUSTED." for b in contents), (
+        "commit prompt merged"
+    )
+    # Strict alternation: no two consecutive user messages.
+    roles = [m.get("role") for m in final_messages]
+    for i in range(1, len(roles)):
+        assert roles[i] != roles[i - 1], (
+            f"consecutive {roles[i]} messages at index {i}: {roles}"
+        )
+
+
+def test_commit_phase_skipped_when_pipeline_deadline_past():
+    """When wall-clock is already past, the commit phase must not fire —
+    spending another Bedrock call against a dead deadline is wasted."""
+    import time
+    turns = [_resp([{"toolUse": {"toolUseId": "t", "name": "read_file", "input": {}}}],
+                   stop_reason="tool_use")] * 3
+    bedrock = FakeBedrockClient(turns)
+    result = run(
+        bedrock_client=bedrock, agent_name="investigator",
+        system_prompt="sys", user_prompt="user",
+        tool_specs=[{"toolSpec": {"name": "read_file"}}],
+        tool_runner=FakeToolRunner(),
+        caps=AgentCaps(max_turns=5),
+        commit_phase_user_prompt="TOOL BUDGET EXHAUSTED.",
+        pipeline_deadline=time.monotonic() - 1,  # deadline already past
+    )
+    assert result.commit_phase_ran is False

--- a/src/scripts/tests/test_critic.py
+++ b/src/scripts/tests/test_critic.py
@@ -160,6 +160,124 @@ def test_investigator_summary_not_truncated_on_long_narrative(tmp_path, monkeypa
     assert len(summary) > 30_000
 
 
+def test_investigator_max_turns_routes_to_critic_even_without_confirmed(tmp_path, monkeypatch):
+    """Layer C: when the Investigator hits max_turns (silent bail), the
+    fast-path MUST NOT bypass the Critic. Otherwise a budget-exhausted
+    Investigator looks identical to a clean PR from outside, and the
+    Critic — whose entire job is to catch Investigator failures — never
+    runs on the case it was specifically designed for."""
+    import unittest.mock as mock
+    _setup_pipeline_env(tmp_path, monkeypatch, event_action="opened")
+    monkeypatch.setenv("PR_INVESTIGATOR_COMMIT_PROMPT", "TOOL BUDGET EXHAUSTED. Emit STATUS blocks.")
+    monkeypatch.setenv("PR_CRITIC_COMMIT_PROMPT", "TOOL BUDGET EXHAUSTED. Emit VERDICTs.")
+    with mock.patch("issue_bot.github_client.GitHubClient.get_pr") as mock_pr, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_comments") as mock_comments, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_pr_diff") as mock_diff, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_pr_review_comments") as mock_rc, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_pr_files") as mock_files, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_codebase_map") as mock_map, \
+         mock.patch("issue_bot.github_client.GitHubClient.get_ci_status") as mock_ci, \
+         mock.patch("issue_bot.knowledge_base.KnowledgeBase.load"), \
+         mock.patch("issue_bot.knowledge_base.KnowledgeBase.build_context") as mock_kb, \
+         mock.patch("issue_bot.bedrock_client.BedrockClient.__init__", return_value=None), \
+         mock.patch("issue_bot.bedrock_client.BedrockClient.converse_with_tools") as mock_ctools, \
+         mock.patch("issue_bot.bedrock_client.BedrockClient.invoke_with_usage") as mock_invoke:
+        mock_pr.return_value = {
+            "user": {"login": "contributor"}, "title": "T", "body": "B", "state": "open",
+            "html_url": "https://github.com/x", "head": {"sha": "abc"},
+        }
+        mock_comments.return_value = []
+        mock_diff.return_value = "diff --git a/f.py b/f.py\n+x\n"
+        mock_rc.return_value = []
+        mock_files.return_value = [{"filename": "f.py", "changes": 50}]
+        mock_map.return_value = ""
+        mock_kb.return_value = ""
+        mock_ci.return_value = (True, "")
+
+        tool_use_resp = {
+            "stopReason": "tool_use",
+            "output": {"message": {"role": "assistant", "content": [
+                {"toolUse": {"toolUseId": "t", "name": "read_file", "input": {"path": "f.py"}}},
+            ]}},
+            "usage": {"inputTokens": 100, "outputTokens": 50,
+                      "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0},
+        }
+        commit_resp = {
+            "stopReason": "end_turn",
+            "output": {"message": {"role": "assistant", "content": [
+                {"text": "ID: C1\nSTATUS: UNVERIFIED\nCOMMENT: ran out of turns"},
+            ]}},
+            "usage": {"inputTokens": 100, "outputTokens": 50,
+                      "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0},
+        }
+        critic_response_text = "VERDICT: C1 | OVERTURNED | insufficient evidence at budget exhaustion"
+        critic_resp = _bedrock_text_resp(critic_response_text)
+
+        # Investigator: tool_use forever (forces max_turns), then commit phase.
+        # Critic: single end_turn with VERDICT line.
+        # Sequence: Investigator hits max_turns_reached, runs commit phase
+        # (with no tools), then Critic runs because Layer C routes to Critic
+        # despite no STATUS: CONFIRMED in investigator output.
+        call_log = []
+
+        # Investigator: track per-turn user-message text so we can detect
+        # the commit-phase turn (it merges TOOL BUDGET EXHAUSTED into the
+        # last user message) and respond with the final emit.
+        def _has_commit_marker(messages):
+            for m in messages:
+                if m.get("role") != "user":
+                    continue
+                for b in m.get("content", []):
+                    if "TOOL BUDGET EXHAUSTED" in (b.get("text") or ""):
+                        return True
+            return False
+
+        def converse_side_effect(system_prompt, messages, tool_specs,
+                                 max_tokens=8000, temperature=0.3,
+                                 timeout_seconds=None):
+            is_critic = "Critique" in system_prompt
+            commit_phase = _has_commit_marker(messages)
+            call_log.append({
+                "is_critic": is_critic,
+                "tool_specs": tool_specs,
+                "commit_phase": commit_phase,
+            })
+            if is_critic:
+                return critic_resp
+            if commit_phase:
+                return commit_resp
+            return tool_use_resp
+
+        mock_ctools.side_effect = converse_side_effect
+        # Reporter receives the commit-phase finding (UNVERIFIED) and the
+        # critic's OVERTURNED verdict. Reporter emits no inline comments
+        # (the only finding was overturned), but Reporter MUST be invoked —
+        # that proves Layer C routed past the fast-path.
+        mock_invoke.return_value = (
+            '{"analysis": []}',
+            {"inputTokens": 50, "outputTokens": 20,
+             "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0},
+        )
+
+        from issue_bot.main import analyze
+        analyze()
+        with open(str(tmp_path / "result.json")) as f:
+            artifact = json.load(f)
+
+    investigator_calls = [c for c in call_log if not c["is_critic"]]
+    critic_calls = [c for c in call_log if c["is_critic"]]
+    assert len(investigator_calls) >= 2, (
+        "Investigator should have at least one tool turn plus one commit-phase turn"
+    )
+    assert investigator_calls[-1]["commit_phase"], "last investigator call must be commit phase"
+    assert len(critic_calls) >= 1
+    # Reporter was invoked.
+    assert mock_invoke.call_count == 1
+    # Critic skip_reason is NOT no_confirmed_findings — Layer C bypassed
+    # that fast-path because the Investigator's silent-bail signal was set.
+    assert artifact["metrics"]["critic"]["skipped"] is False
+
+
 def test_confirmed_finding_triggers_critic_and_reporter(tmp_path, monkeypatch):
     import unittest.mock as mock
     investigator_notes = (


### PR DESCRIPTION
## Summary

Three architectural fixes to the 3-agent pipeline (#724) prompted by the PR #722 dry-run, where the Investigator navigated to the right files but ran out of turns mid-tool-call without ever emitting a `STATUS: CONFIRMED` block. The fast-path then silently posted "no issues found." The same pipeline that was designed to catch PR #722 produced the same outcome as the legacy bot — but with a different failure shape.

The diff fixes the contract in three places, each addressing a distinct violation:

**Layer A — aggregate all assistant text.** The previous walk-back-to-last-message recovery threw away ~99% of the model's output (artifact recorded 74 characters of a 2378-output-token run). `_aggregate_all_assistant_text` concatenates text blocks across every assistant turn so partial commitments survive when a later turn ends in tool calls.

**Layer B — forced commit phase when budget exhausted.** When `max_turns` / `max_tool_calls` / `max_tool_output_chars` is hit, the loop now appends a commit-phase user prompt and runs one more Bedrock call. The user prompt instructs the model to emit final `STATUS:` blocks (or `VERDICT:` lines for the Critic) and not call any tool. `tool_specs` is kept on the request because Bedrock validates `toolUse`/`toolResult` blocks in history against `toolConfig` — omitting it would trip ValidationException. Suppression of new tool calls is enforced by the prompt, not by removing toolConfig.

**Layer C — fast-path gates on `not max_turns_reached`.** When the Investigator hit max_turns, the absence of `STATUS: CONFIRMED` cannot be distinguished from a clean PR without running the Critic. The fast-path now requires both no confirmed findings AND not max_turns_reached. Otherwise the Critic runs as a backstop on what the Investigator did emit.

The five SM prompts (`pr-investigator-prompt`, `pr-critic-prompt`, `pr-reporter-prompt`, `pr-investigator-commit-prompt`, `pr-critic-commit-prompt`) were rewritten in lockstep based on three independent audits (Anthropic prompt-engineering best practices, external reference architectures, internal Amazon code-review systems). The convergent findings — investigator pre-filters before the critic runs, missing few-shot examples, lack of numeric confidence threshold, aggressive MUST/NEVER over-triggering on Opus 4.6, no termination criterion for type-signature changes — are addressed in v3 of each prompt. Numeric `CONFIDENCE: 1-10` was added to investigator output and the Reporter now filters at `CONFIDENCE >= 8` per AutoSDE's published rubric.

### What changed

- `src/scripts/issue_bot/agent_loop.py` — `AgentResult.commit_phase_ran` flag added. `_aggregate_all_assistant_text` replaces `_recover_last_assistant_text`. `run()` accepts `commit_phase_user_prompt` and routes terminations through `_finalize` so wall-clock, structural-cap, and max_turns paths all converge on the same aggregation + optional commit phase. `_run_commit_phase` merges the commit prompt into the trailing user message (preserving Bedrock's tool_use → toolResult sequence) and calls Converse with the same `tool_specs` to keep the message history valid.
- `src/scripts/issue_bot/bedrock_client.py` — `converse_with_tools` accepts `tool_specs=None` and omits `toolConfig` in that case (kept for future use even though commit phase keeps tool_specs to satisfy Bedrock's validation).
- `src/scripts/issue_bot/main.py` — Investigator and Critic call sites pass `commit_phase_user_prompt=prompts.get_pr_*_commit_prompt() or None`. `_run_critic_and_reporter` accepts `investigator_max_turns_reached` and uses it in the fast-path gate.
- `src/scripts/issue_bot/prompts.py` — `get_pr_investigator_commit_prompt()` and `get_pr_critic_commit_prompt()` accessors added; resolve via env-then-SM fallback chain like all other prompts.
- `.github/workflows/issue-bot.yml` — `SM_PR_INVESTIGATOR_COMMIT_PROMPT` and `SM_PR_CRITIC_COMMIT_PROMPT` env vars wired to `deequ-bot/pr-investigator-commit-prompt` and `deequ-bot/pr-critic-commit-prompt` (both already created in SM).
- `src/scripts/tests/test_agent_loop.py` — 8 new tests pin the new contracts: aggregate text from all turns, partial-commit preservation, commit-phase tool_specs handling, commit-phase prompt merge into trailing user message, no commit phase when prompt unset, commit phase on structural cap, commit phase skipped when wall-clock past, no consecutive same-role messages.
- `src/scripts/tests/test_critic.py` — 3 new tests pin Layer C: investigator max_turns routes to Critic, investigator narrative preserved on RESPOND, no truncation on long narrative.

### Defensive choices worth calling out

- **Bedrock message-sequence validity**: the commit-phase merger must keep the assistant tool_use → user toolResult sequence valid. Tests pin both the message structure and the requirement that no two consecutive same-role messages appear in the final request.
- **`max_tool_calls` reorder**: tool results are now appended to messages BEFORE the cap check, otherwise the commit phase would inherit an unfollowed tool_use turn and the request would be rejected.
- **Fail-open for missing commit prompts**: if `SM_PR_*_COMMIT_PROMPT` is unset, `prompts.get_pr_*_commit_prompt()` returns `""`, the `or None` converts to None, and `_finalize` skips the commit phase. Layers A and C still apply. Legacy fallback works.
- **`tool_specs` is kept on the commit-phase request**: omitting it would trip Bedrock's ValidationException on any history with toolUse/toolResult blocks. Suppression of new tool calls is enforced by the prompt.

## Test plan

- [x] All 297 tests pass locally and in CI (`python3 -m pytest src/scripts/tests/ -q`)
- [ ] After merge: re-dispatch on PR #722 with `BOT_AGENT_PIPELINE=1 dry_run=true`. Expected: aggregated `investigator_summary` shows STATUS blocks emitted across multiple turns; if Investigator hits max_turns, the Critic runs as backstop and either upholds the StateProvider.scala finding or overturns with a citable rationale. The artifact is now diagnosable in the worst case, no longer a 74-char boilerplate.
- [ ] Re-dispatch on PR #720 (known-correct flag) and PR #717 (false-positive cluster) to verify Layers A/B/C don't regress those baselines.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.