### PR TITLE
fix: surface commit_phase_ran in per-stage artifact metrics

### DIFF
--- a/src/scripts/issue_bot/main.py
+++ b/src/scripts/issue_bot/main.py
@@ -1187,6 +1187,7 @@ def _empty_stage_metrics():
         "cache_read_tokens": 0,
         "cache_write_tokens": 0,
         "max_turns_reached": False,
+        "commit_phase_ran": False,
         "error": None,
         "parse_failed": False,
     }
@@ -1204,6 +1205,7 @@ def _agent_metrics(r):
         "cache_read_tokens": r.cache_read_tokens,
         "cache_write_tokens": r.cache_write_tokens,
         "max_turns_reached": r.max_turns_reached,
+        "commit_phase_ran": r.commit_phase_ran,
         "error": r.error,
     })
     return metrics

--- a/src/scripts/tests/test_critic.py
+++ b/src/scripts/tests/test_critic.py
@@ -1102,7 +1102,8 @@ def test_unknown_pipeline_event_escalates_does_not_mislabel_critic(monkeypatch):
         "skipped": False, "skip_reason": "garbage_value", "turns": 0, "tool_calls": 0,
         "tool_output_chars": 0, "input_tokens": 0, "output_tokens": 0,
         "cache_read_tokens": 0, "cache_write_tokens": 0,
-        "max_turns_reached": False, "error": None, "parse_failed": False,
+        "max_turns_reached": False, "commit_phase_ran": False,
+        "error": None, "parse_failed": False,
     }
 
     def capture_artifact(payload):
@@ -1242,7 +1243,7 @@ def test_metrics_schema_uniform_across_stages(tmp_path, monkeypatch):
     canonical_keys = {
         "skipped", "skip_reason", "turns", "tool_calls", "tool_output_chars",
         "input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
-        "max_turns_reached", "error", "parse_failed",
+        "max_turns_reached", "commit_phase_ran", "error", "parse_failed",
     }
     for stage in ("investigator", "critic", "reporter"):
         assert set(artifact["metrics"][stage].keys()) >= canonical_keys, (


### PR DESCRIPTION
## Summary

Tiny observability gap from PR #732. The `AgentResult.commit_phase_ran` field is set when the loop's commit phase fires (after `max_turns` / structural-cap / wall-clock), but `_agent_metrics` was not copying it through to the per-stage metrics block in the artifact. Operators reading `bot_result.json` could not tell whether the forced commit-phase Bedrock call had run on a given dispatch.

This PR adds the field to `_empty_stage_metrics` and `_agent_metrics` so it appears alongside `max_turns_reached` in every stage's metrics. Pure observability — no behavior change.

### What changed

- `src/scripts/issue_bot/main.py` — `commit_phase_ran` added to canonical metrics shape; `_agent_metrics` copies the value from `AgentResult.commit_phase_ran`.
- `src/scripts/tests/test_critic.py` — two mock dicts updated to keep the canonical-keys contract test green.

## Test plan

- [x] All 297 tests pass locally and in CI

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.