### PR TITLE
perf: cachePoint on issue invoke() and converse_with_tools messages tail

### DIFF
--- a/src/scripts/issue_bot/bedrock_client.py
+++ b/src/scripts/issue_bot/bedrock_client.py
@@ -247,7 +247,7 @@ class BedrockClient:
                 return None
             self._failures = 0
             return resp
-        except (ClientError, BotoCoreError, ValueError, ConnectionError) as e:
+        except (ClientError, BotoCoreError, ValueError, TypeError, ConnectionError) as e:
             self._failures += 1
             logger.error(f"Bedrock tool-use call failed ({self._failures}/{_CIRCUIT_BREAKER_THRESHOLD}): {e}")
             if self._failures >= _CIRCUIT_BREAKER_THRESHOLD:

--- a/src/scripts/issue_bot/bedrock_client.py
+++ b/src/scripts/issue_bot/bedrock_client.py
@@ -54,7 +54,7 @@ class BedrockClient:
         return bool(self._guardrail_id)
 
     def invoke(self, system_prompt, user_prompt, max_tokens=4096,
-               temperature=0.3, json_schema=None):
+               temperature=0.3, json_schema=None, cache_prefix=False):
         """Invoke Bedrock Converse API with guardrail on user message only.
 
         - system_prompt: Instructions + trusted context (KB, diffs, codebase).
@@ -63,11 +63,12 @@ class BedrockClient:
         - user_prompt: Untrusted user input (issue title/body, PR title/body,
             comments). When guardrail is configured, wrapped in guardContent
             so the guardrail scans it for prompt injection.
-
-        No cachePoint is set: production logs (last 30 runs / 44 calls) show
-        the cache read rate at 0% because the cached prefix includes per-PR
-        diff bytes, so the cache key never repeats. A cachePoint here would
-        only pay the 1.25x cache-write premium without ever yielding a read.
+        - cache_prefix: when True, append a cachePoint after the system block
+            so subsequent calls with the same system prefix can be served as
+            cache reads. Opt-in because legacy PR file-review callers embed
+            per-PR diff bytes in system_prompt — caching there pays the 1.25x
+            write premium with zero reuse. Issue/followup callers pass True
+            since their prefix is KB + codebase_map, stable across calls.
         """
         if self._circuit_open:
             logger.warning("Circuit breaker open, skipping Bedrock call")
@@ -85,7 +86,10 @@ class BedrockClient:
             }
 
             if system_prompt:
-                kwargs["system"] = [{"text": system_prompt}]
+                system_blocks = [{"text": system_prompt}]
+                if cache_prefix:
+                    system_blocks.append({"cachePoint": {"type": "default"}})
+                kwargs["system"] = system_blocks
 
             if json_schema:
                 kwargs["outputConfig"] = {
@@ -139,7 +143,9 @@ class BedrockClient:
         the Reporter to bound the call at the remaining wall-clock budget.
 
         No cachePoint: the Reporter (sole caller) embeds the per-PR diff
-        in its system prompt, so the cache prefix never repeats.
+        in its system prompt, so the cache prefix never repeats. invoke()'s
+        cache_prefix opt-in is not exposed here — no caller has a stable
+        prefix to cache.
         """
         if self._circuit_open:
             logger.warning("Circuit breaker open, skipping Bedrock call")
@@ -206,17 +212,17 @@ class BedrockClient:
         by the loop's commit phase to physically prevent further tool calls
         after the tool budget is exhausted.
 
-        cachePoint is set here (unlike invoke()/invoke_with_usage) because
-        Investigator and Critic share the static prefix from
-        _build_static_context — the Investigator's first turn warms a cache
-        the Critic's first turn can read. Validate via cacheReadInputTokens
-        on the Critic stage in the artifact metrics.
+        Two cachePoints: one after the system block (the static_context
+        prefix shared between Investigator and Critic), one at the tail of
+        the last message (so the growing conversation history is cached
+        turn-over-turn instead of re-priced as fresh input every turn).
         """
         if self._circuit_open:
             logger.warning("Circuit breaker open, skipping Bedrock tool-use call")
             return None
         try:
             wrapped_messages = self._wrap_first_user_for_guardrail(messages)
+            wrapped_messages = self._append_tail_cache_point(wrapped_messages)
             kwargs = {
                 "modelId": self._model_id,
                 "messages": wrapped_messages,
@@ -248,6 +254,19 @@ class BedrockClient:
                 self._circuit_open = True
                 logger.error("Circuit breaker OPEN")
             return None
+
+    def _append_tail_cache_point(self, messages):
+        """Append a cachePoint to the last message's content. Returns a new
+        list so the caller's `messages` is not mutated (cachePoints would
+        otherwise accumulate turn-over-turn)."""
+        if not messages:
+            return messages
+        last = messages[-1]
+        content = list(last.get("content") or [])
+        if content and isinstance(content[-1], dict) and "cachePoint" in content[-1]:
+            return messages
+        content.append({"cachePoint": {"type": "default"}})
+        return messages[:-1] + [{**last, "content": content}]
 
     def _wrap_first_user_for_guardrail(self, messages):
         """Wrap the first user message's text in guardContent for guardrail

--- a/src/scripts/issue_bot/main.py
+++ b/src/scripts/issue_bot/main.py
@@ -351,7 +351,7 @@ def analyze():
         prompt_id = prompts.prompt_version(tmpl)
 
     schema = FOLLOWUP_SCHEMA if is_followup else ISSUE_RESPONSE_SCHEMA
-    raw = bedrock.invoke(system_prompt, user_prompt, json_schema=schema)
+    raw = bedrock.invoke(system_prompt, user_prompt, json_schema=schema, cache_prefix=True)
 
     if raw is None:
         _write_artifact({

--- a/src/scripts/tests/test_bot.py
+++ b/src/scripts/tests/test_bot.py
@@ -650,6 +650,40 @@ class TestSplitPrompt:
             count += sum(1 for b in msg.get("content", []) if "cachePoint" in b)
         assert count <= 4
 
+    def test_converse_with_tools_handles_two_block_guardrail_composition(self):
+        """The agent loop's _build_user_content emits [{text: trusted},
+        {guardContent: untrusted}] when a guardrail is configured. The wrap
+        helper passes that through unchanged; the tail cachePoint must
+        append AFTER the guardContent without disturbing it."""
+        client = self._make_client(guardrail_id="gr-123")
+        self._mock_converse(client)
+        messages = [{
+            "role": "user",
+            "content": [
+                {"text": "diff and instructions"},
+                {"guardContent": {"text": {"text": "PR title and body"}}},
+            ],
+        }]
+        client.converse_with_tools("system", messages, tool_specs=[])
+        sent_content = client._client.converse.call_args[1]["messages"][-1]["content"]
+        assert sent_content[0] == {"text": "diff and instructions"}
+        assert sent_content[1] == {"guardContent": {"text": {"text": "PR title and body"}}}
+        assert sent_content[2] == {"cachePoint": {"type": "default"}}
+
+    def test_invoke_typeerror_increments_failure_counter(self):
+        """A malformed Bedrock response (e.g., non-iterable content) raises
+        TypeError. The circuit breaker must count it so persistent failures
+        open the breaker instead of silently retrying forever."""
+        client = self._make_client(guardrail_id="gr-123")
+        self._mock_converse(client)
+        before = client._failures
+        client.converse_with_tools(
+            "system",
+            [{"role": "user", "content": 5}],
+            tool_specs=[],
+        )
+        assert client._failures == before + 1
+
     def test_wrap_skips_when_caller_already_set_guard_content(self):
         """If the caller composed [{"text": trusted}, {"guardContent": untrusted}],
         the helper must NOT re-wrap the trusted text — that would put model-

--- a/src/scripts/tests/test_bot.py
+++ b/src/scripts/tests/test_bot.py
@@ -580,6 +580,76 @@ class TestSplitPrompt:
         system = kwargs["system"]
         assert any("cachePoint" in block for block in system)
 
+    def test_converse_with_tools_appends_tail_cache_point(self):
+        """Tail cachePoint on the last message lets the growing conversation
+        history (tool results re-sent each turn) be served as cache reads
+        on subsequent turns."""
+        client = self._make_client(guardrail_id="gr-123")
+        self._mock_converse(client)
+        client.converse_with_tools(
+            "system",
+            [{"role": "user", "content": [{"text": "investigate"}]}],
+            tool_specs=[],
+        )
+        kwargs = client._client.converse.call_args[1]
+        last_content = kwargs["messages"][-1]["content"]
+        assert last_content[-1] == {"cachePoint": {"type": "default"}}
+
+    def test_append_tail_cache_point_idempotent(self):
+        """A messages list with a trailing cachePoint must not get a second
+        one stacked on it (would exceed Bedrock's max-4 cachePoint limit
+        across many turns)."""
+        client = self._make_client()
+        messages = [{
+            "role": "user",
+            "content": [{"text": "x"}, {"cachePoint": {"type": "default"}}],
+        }]
+        out = client._append_tail_cache_point(messages)
+        assert len(out[-1]["content"]) == 2
+
+    def test_append_tail_cache_point_empty_messages(self):
+        client = self._make_client()
+        assert client._append_tail_cache_point([]) == []
+
+    def test_invoke_cache_prefix_opt_in(self):
+        """cache_prefix=True appends a cachePoint after the system block so
+        a stable prefix (issue path: KB + codebase_map) is reused across
+        calls within the TTL."""
+        client = self._make_client(guardrail_id="gr-123")
+        self._mock_converse(client)
+        client.invoke("kb + codebase_map", "issue body", cache_prefix=True)
+        kwargs = client._client.converse.call_args[1]
+        system = kwargs["system"]
+        assert system[0] == {"text": "kb + codebase_map"}
+        assert system[-1] == {"cachePoint": {"type": "default"}}
+
+    def test_invoke_default_no_cache_prefix(self):
+        """Legacy callers whose prefix varies per call (per-PR diff embedded
+        in system_prompt) must not auto-cache — would pay the 1.25x write
+        premium with zero reuse."""
+        client = self._make_client(guardrail_id="gr-123")
+        self._mock_converse(client)
+        client.invoke("system", "user")
+        kwargs = client._client.converse.call_args[1]
+        for block in kwargs.get("system", []):
+            assert "cachePoint" not in block
+
+    def test_converse_with_tools_total_cache_points_under_limit(self):
+        """Bedrock rejects requests with more than 4 cachePoints. Sum across
+        system + every message content block to catch any future addition."""
+        client = self._make_client(guardrail_id="gr-123")
+        self._mock_converse(client)
+        client.converse_with_tools(
+            "system",
+            [{"role": "user", "content": [{"text": "investigate"}]}],
+            tool_specs=[],
+        )
+        kwargs = client._client.converse.call_args[1]
+        count = sum(1 for b in kwargs.get("system", []) if "cachePoint" in b)
+        for msg in kwargs.get("messages", []):
+            count += sum(1 for b in msg.get("content", []) if "cachePoint" in b)
+        assert count <= 4
+
     def test_wrap_skips_when_caller_already_set_guard_content(self):
         """If the caller composed [{"text": trusted}, {"guardContent": untrusted}],
         the helper must NOT re-wrap the trusted text — that would put model-


### PR DESCRIPTION
## Summary

Two prompt-cache placements were missing, causing the bot to re-pay full input pricing on content that's stable across calls. This PR adds them, validated against AWS Bedrock's prompt-caching docs and bench-tested against the master baseline.

**Impact** (cold-cache 3-PR bench, vs. master): **−$0.54/review average.** Heavy PRs save more (PR #717 Investigator: $4.04 → $2.69, **−$1.35**); small PRs see ~$0.10 of overhead from the per-turn write. No recall regression — finding counts identical across the bench.

### What changed

1. **`bedrock_client.invoke()` opt-in caching for stable prefixes.** New `cache_prefix=False` parameter. When True, appends a cachePoint after the system block. Default is False so legacy PR file-review callers (which embed per-PR diff bytes in `system_prompt`) keep paying plain input pricing — caching there would only pay the 1.25× write premium with zero reuse. The issue/followup classify path (`main.py:354`) opts in: its prefix is `template + KB + codebase_map`, byte-stable across calls within the cache TTL.

2. **`converse_with_tools` tail cachePoint on `messages`.** A new `_append_tail_cache_point` helper appends a cachePoint to the last message's content on every turn. The growing conversation history (tool results re-sent on every turn) now reads from cache instead of being re-priced as fresh input. Per the Bedrock docs, the system finds the longest matching cached prefix from prior content-block boundaries (≤20 blocks lookback), so each turn N reads the prefix written through turn N-1.

3. **`TypeError` added to circuit-breaker except clause.** A malformed Bedrock response with non-iterable content blocks would have raised TypeError past the narrow except `(ClientError, BotoCoreError, ValueError, ConnectionError)` and bypassed the failure counter. Now counted.

### Why this is safe

- AWS Bedrock spec confirms `cachePoint` is a billing hint that doesn't alter inference output. Model behavior is byte-identical to master.
- Bedrock allows up to 4 cachePoints per request; this PR uses at most 2 (system + messages tail). A new test asserts `<= 4`.
- The `cache_prefix` flag defaults to False — no caller is silently opted into caching. Only one call site (`main.py:354`, the issue/followup classify) opts in, and only because its prefix is verifiably stable (KB at 437K is well under the 800K relevance-truncation cap; codebase_map is sorted by file path; no per-call interpolation).
- Tail cachePoint is appended to a fresh wire-payload list, never the caller's `messages` array — cachePoints can't accumulate turn-over-turn.
- Bench: 3 PRs (small / large / clean) dispatched on this branch vs master. Findings parity confirmed (same count, same files in 5/6 cases). Zero ValidationException across 7 dispatches.

### Files

- `src/scripts/issue_bot/bedrock_client.py` — `cache_prefix` opt-in on `invoke()`; `_append_tail_cache_point` helper called from `converse_with_tools`; `TypeError` added to except clause.
- `src/scripts/issue_bot/main.py` — issue/followup classify call passes `cache_prefix=True`.
- `src/scripts/tests/test_bot.py` — 8 new tests covering the opt-in path, idempotency, the max-4 limit, the two-block guardrail composition, and the TypeError circuit-breaker contract.

## Test plan

- [x] All 305 tests pass locally
- [x] Bench dispatch (PRs #722, #717, #727) on this branch vs. master: $0.54/review saved on average, zero recall regression, zero ValidationException

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.