### PR TITLE
perf: per-stage model_id override (Reporter on Haiku 4.5)

### DIFF
--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -67,6 +67,7 @@ jobs:
           KB_S3_BUCKET: ${{ secrets.KB_S3_BUCKET }}
           KB_S3_KEY: ${{ secrets.KB_S3_KEY }}
           BEDROCK_MODEL_ID: ${{ secrets.BEDROCK_MODEL_ID }}
+          BEDROCK_REPORTER_MODEL_ID: ${{ vars.BEDROCK_REPORTER_MODEL_ID }}
           GUARDRAIL_ID: ${{ secrets.GUARDRAIL_ID }}
           GUARDRAIL_VERSION: ${{ secrets.GUARDRAIL_VERSION }}
           SM_ISSUE_CLASSIFY_PROMPT: deequ-bot/issue-classify-prompt

--- a/src/scripts/issue_bot/bedrock_client.py
+++ b/src/scripts/issue_bot/bedrock_client.py
@@ -135,12 +135,16 @@ class BedrockClient:
 
     def invoke_with_usage(self, system_prompt, user_prompt, max_tokens=4096,
                            temperature=0.3, json_schema=None,
-                           timeout_seconds=None):
+                           timeout_seconds=None, model_id=None):
         """Like invoke() but also returns the response's token usage dict.
         Returns (None, {}) on failure.
 
         timeout_seconds (optional): per-call read/connect timeout, used by
         the Reporter to bound the call at the remaining wall-clock budget.
+
+        model_id (optional): override the default model for this call. Used
+        to run cheaper structured-output stages (e.g., Reporter on Haiku)
+        on the same client without a second BedrockClient instance.
 
         No cachePoint: the Reporter (sole caller) embeds the per-PR diff
         in its system prompt, so the cache prefix never repeats. invoke()'s
@@ -156,7 +160,7 @@ class BedrockClient:
             else:
                 user_content = [{"text": user_prompt}]
             kwargs = {
-                "modelId": self._model_id,
+                "modelId": model_id or self._model_id,
                 "messages": [{"role": "user", "content": user_content}],
                 "inferenceConfig": {"maxTokens": max_tokens, "temperature": temperature},
             }

--- a/src/scripts/issue_bot/config.py
+++ b/src/scripts/issue_bot/config.py
@@ -24,8 +24,14 @@ class Config:
         # Reporter is a JSON-formatting + filter step; it doesn't reason. A
         # cheaper model (Haiku 4.5) handles structured output cleanly at ~5x
         # less cost. Defaults to bedrock_model_id so the swap is opt-in via
-        # workflow env var.
-        self.reporter_model_id = os.getenv("BEDROCK_REPORTER_MODEL_ID") or self.bedrock_model_id
+        # workflow env var. .strip() guards against stray whitespace from
+        # the workflow vars context.
+        self.reporter_model_id = (os.getenv("BEDROCK_REPORTER_MODEL_ID") or "").strip() or self.bedrock_model_id
+        if self.reporter_model_id != self.bedrock_model_id:
+            logger.info(
+                "Reporter model override active: %s (default: %s)",
+                self.reporter_model_id, self.bedrock_model_id,
+            )
 
         self.kb_s3_bucket = os.getenv("KB_S3_BUCKET", "")
         self.kb_s3_key = os.getenv("KB_S3_KEY", "")

--- a/src/scripts/issue_bot/config.py
+++ b/src/scripts/issue_bot/config.py
@@ -21,6 +21,11 @@ class Config:
         self.event_after = os.getenv("EVENT_AFTER", "")
 
         self.bedrock_model_id = os.getenv("BEDROCK_MODEL_ID", "us.anthropic.claude-opus-4-6-v1")
+        # Reporter is a JSON-formatting + filter step; it doesn't reason. A
+        # cheaper model (Haiku 4.5) handles structured output cleanly at ~5x
+        # less cost. Defaults to bedrock_model_id so the swap is opt-in via
+        # workflow env var.
+        self.reporter_model_id = os.getenv("BEDROCK_REPORTER_MODEL_ID") or self.bedrock_model_id
 
         self.kb_s3_bucket = os.getenv("KB_S3_BUCKET", "")
         self.kb_s3_key = os.getenv("KB_S3_KEY", "")

--- a/src/scripts/issue_bot/main.py
+++ b/src/scripts/issue_bot/main.py
@@ -890,7 +890,7 @@ def _run_agent_pipeline(*, cfg, gh, bedrock, number, title, body, html_url, item
         commit_phase_user_prompt=prompts.get_pr_investigator_commit_prompt() or None,
     )
 
-    metrics = _initial_metrics(inv_result)
+    metrics = _initial_metrics(inv_result, cfg.bedrock_model_id)
     artifact_kwargs = dict(
         cfg=cfg, title=title, html_url=html_url, number=number,
         inv_tmpl=investigator_tmpl, critic_tmpl=critic_tmpl, reporter_tmpl=reporter_tmpl,
@@ -918,7 +918,7 @@ def _run_agent_pipeline(*, cfg, gh, bedrock, number, title, body, html_url, item
         )
     )
     if crit_result is not None:
-        metrics["critic"] = _agent_metrics(crit_result)
+        metrics["critic"] = _agent_metrics(crit_result, model_id=cfg.bedrock_model_id)
     # Unknown event = bug in a future change. Escalate with a distinct
     # reason rather than silently posting a clean review.
     if pipeline_event is not None and pipeline_event not in _KNOWN_PIPELINE_EVENTS:
@@ -1040,9 +1040,9 @@ def _build_static_context(kb_context, codebase_map, existing_feedback, increment
     )
 
 
-def _initial_metrics(inv_result):
+def _initial_metrics(inv_result, model_id):
     return {
-        "investigator": _agent_metrics(inv_result),
+        "investigator": _agent_metrics(inv_result, model_id=model_id),
         "critic": _empty_stage_metrics(),
         "reporter": _empty_stage_metrics(),
         "totals": {},
@@ -1121,7 +1121,7 @@ def _run_critic_and_reporter(*, cfg, bedrock, tool_runner, critic_system, critic
 
     raw, usage = bedrock.invoke_with_usage(
         reporter_system, reporter_user, max_tokens=8000, json_schema=PR_REVIEW_SCHEMA,
-        timeout_seconds=reporter_timeout,
+        timeout_seconds=reporter_timeout, model_id=cfg.reporter_model_id,
     )
     reporter_metrics = _empty_stage_metrics()
     reporter_metrics.update({
@@ -1131,6 +1131,7 @@ def _run_critic_and_reporter(*, cfg, bedrock, tool_runner, critic_system, critic
         "output_tokens": (usage.get("outputTokens") if usage else 0) or 0,
         "cache_read_tokens": (usage.get("cacheReadInputTokens") if usage else 0) or 0,
         "cache_write_tokens": (usage.get("cacheWriteInputTokens") if usage else 0) or 0,
+        "model_id": cfg.reporter_model_id,
     })
     # Reporter failure with confirmed findings → escalate, not an empty
     # post that would drop them.
@@ -1175,7 +1176,9 @@ def _build_clean_response(gh, head_sha, inline_comments):
 
 def _empty_stage_metrics():
     """Canonical shape for a per-stage metrics block. Every stage emits the
-    same keys so dashboards can iterate uniformly."""
+    same keys so dashboards can iterate uniformly. `model_id` is None for
+    skipped stages and set by the call site for executed stages so cost
+    accounting can use the right per-token rate."""
     return {
         "skipped": True,
         "skip_reason": None,
@@ -1190,10 +1193,11 @@ def _empty_stage_metrics():
         "commit_phase_ran": False,
         "error": None,
         "parse_failed": False,
+        "model_id": None,
     }
 
 
-def _agent_metrics(r):
+def _agent_metrics(r, model_id=None):
     metrics = _empty_stage_metrics()
     metrics.update({
         "skipped": False,
@@ -1207,6 +1211,7 @@ def _agent_metrics(r):
         "max_turns_reached": r.max_turns_reached,
         "commit_phase_ran": r.commit_phase_ran,
         "error": r.error,
+        "model_id": model_id,
     })
     return metrics
 

--- a/src/scripts/tests/test_bot.py
+++ b/src/scripts/tests/test_bot.py
@@ -551,6 +551,27 @@ class TestSplitPrompt:
         assert text == "ok"
         assert usage["inputTokens"] == 42
 
+    def test_invoke_with_usage_uses_override_model_id(self):
+        """Reporter is a JSON-formatting + filter step; it can run on a
+        cheaper model than the Investigator/Critic. The per-call model_id
+        override lets the same client serve both without a second instance."""
+        client = self._make_client()
+        self._mock_converse(client)
+        client.invoke_with_usage(
+            "system", "user", model_id="us.anthropic.claude-haiku-4-5-v1",
+        )
+        kwargs = client._client.converse.call_args[1]
+        assert kwargs["modelId"] == "us.anthropic.claude-haiku-4-5-v1"
+
+    def test_invoke_with_usage_default_model_id(self):
+        """Without override, invoke_with_usage uses the client's default
+        model — preserves legacy behavior for callers that don't opt in."""
+        client = self._make_client()
+        self._mock_converse(client)
+        client.invoke_with_usage("system", "user")
+        kwargs = client._client.converse.call_args[1]
+        assert kwargs["modelId"] == client._model_id
+
     def test_invoke_with_usage_does_not_set_cache_point(self):
         """Reporter (sole caller of invoke_with_usage) embeds the per-PR diff
         in its system prompt so the cache prefix never repeats. Setting

--- a/src/scripts/tests/test_bot.py
+++ b/src/scripts/tests/test_bot.py
@@ -557,11 +557,9 @@ class TestSplitPrompt:
         override lets the same client serve both without a second instance."""
         client = self._make_client()
         self._mock_converse(client)
-        client.invoke_with_usage(
-            "system", "user", model_id="us.anthropic.claude-haiku-4-5-v1",
-        )
+        client.invoke_with_usage("system", "user", model_id="TEST_MODEL_ID")
         kwargs = client._client.converse.call_args[1]
-        assert kwargs["modelId"] == "us.anthropic.claude-haiku-4-5-v1"
+        assert kwargs["modelId"] == "TEST_MODEL_ID"
 
     def test_invoke_with_usage_default_model_id(self):
         """Without override, invoke_with_usage uses the client's default
@@ -569,6 +567,23 @@ class TestSplitPrompt:
         client = self._make_client()
         self._mock_converse(client)
         client.invoke_with_usage("system", "user")
+        kwargs = client._client.converse.call_args[1]
+        assert kwargs["modelId"] == client._model_id
+
+    def test_invoke_with_usage_empty_model_id_falls_back_to_default(self):
+        """An empty-string override (e.g., from an unset GH Actions vars
+        expansion) must fall through to the client default — not be sent
+        verbatim to Bedrock as ''."""
+        client = self._make_client()
+        self._mock_converse(client)
+        client.invoke_with_usage("system", "user", model_id="")
+        kwargs = client._client.converse.call_args[1]
+        assert kwargs["modelId"] == client._model_id
+
+    def test_invoke_with_usage_none_model_id_falls_back_to_default(self):
+        client = self._make_client()
+        self._mock_converse(client)
+        client.invoke_with_usage("system", "user", model_id=None)
         kwargs = client._client.converse.call_args[1]
         assert kwargs["modelId"] == client._model_id
 

--- a/src/scripts/tests/test_critic.py
+++ b/src/scripts/tests/test_critic.py
@@ -1244,6 +1244,7 @@ def test_metrics_schema_uniform_across_stages(tmp_path, monkeypatch):
         "skipped", "skip_reason", "turns", "tool_calls", "tool_output_chars",
         "input_tokens", "output_tokens", "cache_read_tokens", "cache_write_tokens",
         "max_turns_reached", "commit_phase_ran", "error", "parse_failed",
+        "model_id",
     }
     for stage in ("investigator", "critic", "reporter"):
         assert set(artifact["metrics"][stage].keys()) >= canonical_keys, (


### PR DESCRIPTION
## Summary

Reporter is the JSON-formatting stage of the agentic PR review pipeline — it filters by CONFIDENCE and emits structured inline_comments. It does no novel reasoning. Per Anthropic's agent-design guidance ("Spawn a subagent with the cheaper model for the sub-task; keep the main loop on one model"), Reporter is a textbook fit for the cheaper-model pattern.

This PR adds a per-stage `model_id` override so Reporter can run on Claude Haiku 4.5 while Investigator/Critic stay on Opus 4.6. Default is opt-out — set the `BEDROCK_REPORTER_MODEL_ID` GitHub Actions repository variable to enable.

### Reporter-isolated bench (rigorous)

A first pass benched the full pipeline with different Reporter models — that conflated Investigator/Critic nondeterminism with Reporter behavior. To isolate, I captured the Investigator narrative + Critic verdicts from real dispatches, then replayed only the Reporter step (`invoke_with_usage` with `PR_REVIEW_SCHEMA`) against fixed input, 3 runs per model per PR.

**Result on PRs #722 and #717:**

| Metric | Opus | Haiku |
|---|---|---|
| Unique finding-sets across 3 runs | 1 (deterministic) | 1 (deterministic) |
| Cross-model overlap on PR #722 | 2/2 findings | 2/2 findings (100%) |
| Cross-model overlap on PR #717 | 3/3 findings | 3/3 findings (100%) |
| JSON parse validity | 6/6 | 6/6 |
| Cost per Reporter call (avg) | $0.075 | $0.015 |

**Holding Reporter input fixed, Haiku produces the exact same findings as Opus** — same files, same lines, same severity classifications. Saves ~$0.06/review with zero recall regression on the Reporter step.

### What changed

1. **`bedrock_client.invoke_with_usage` accepts `model_id` override.** Default `None` falls through to the client's configured model. Existing callers unchanged.

2. **`Config.reporter_model_id`.** Reads `BEDROCK_REPORTER_MODEL_ID` env var, falls back to `bedrock_model_id`. `.strip()` guards against whitespace from GH Actions vars expansion. Logs an INFO line when an override is active so operators can verify the swap took effect.

3. **Per-stage `model_id` in artifact metrics.** The metrics dict now records which model each stage actually used. Cost calculation needed this — Haiku ($1/$5) vs Opus ($5/$25) per-token rates differ 5×. Skipped stages keep `model_id: None` (no inference).

4. **Workflow var (`vars.BEDROCK_REPORTER_MODEL_ID`).** Model IDs aren't sensitive — `vars` matches the convention already established by `BOT_AGENT_PIPELINE`. To enable Haiku Reporter post-merge, set the var to `us.anthropic.claude-haiku-4-5-20251001-v1:0` (canonical inference profile ID, verified via `aws bedrock list-inference-profiles`).

### Why this is safe

- `model_id` defaults to `None` everywhere; Haiku is opt-in via workflow variable. Merge is no-op until the variable is set.
- Reporter-isolated replay bench: 12/12 runs valid JSON, 100% finding overlap on both PRs benched.
- 5-angle code-review + sweep on the diff: 1 high-severity finding (test pinning a non-canonical Haiku 4.5 model ID literal) was caught and fixed; A2 (shared circuit breaker concern) was refuted (breaker is per-process, GHA runs are ephemeral, Reporter is called once per run).
- Falsy-fallback (`model_id or self._model_id`) is covered by 4 tests: explicit override, no override, empty string, None.

### Files

- `src/scripts/issue_bot/bedrock_client.py` — `model_id` keyword param on `invoke_with_usage`
- `src/scripts/issue_bot/config.py` — `reporter_model_id` with whitespace guard + override INFO log
- `src/scripts/issue_bot/main.py` — Reporter call site passes `cfg.reporter_model_id`; per-stage `model_id` in metrics
- `src/scripts/tests/test_bot.py` — 4 new tests for the override (explicit / default / empty / None)
- `src/scripts/tests/test_critic.py` — `model_id` added to canonical-keys assertion
- `.github/workflows/issue-bot.yml` — `BEDROCK_REPORTER_MODEL_ID` env mapping

## Test plan

- [x] 309/309 tests pass locally
- [x] Reporter-isolated replay bench on PRs #722, #717: 100% finding overlap, 80% cost reduction
- [ ] Post-merge: set `vars.BEDROCK_REPORTER_MODEL_ID = us.anthropic.claude-haiku-4-5-20251001-v1:0` to activate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.