### PR TITLE
perf: per-stage model_id override for Critic

### DIFF
--- a/.github/workflows/issue-bot.yml
+++ b/.github/workflows/issue-bot.yml
@@ -68,6 +68,7 @@ jobs:
           KB_S3_KEY: ${{ secrets.KB_S3_KEY }}
           BEDROCK_MODEL_ID: ${{ secrets.BEDROCK_MODEL_ID }}
           BEDROCK_REPORTER_MODEL_ID: ${{ vars.BEDROCK_REPORTER_MODEL_ID }}
+          BEDROCK_CRITIC_MODEL_ID: ${{ vars.BEDROCK_CRITIC_MODEL_ID }}
           GUARDRAIL_ID: ${{ secrets.GUARDRAIL_ID }}
           GUARDRAIL_VERSION: ${{ secrets.GUARDRAIL_VERSION }}
           SM_ISSUE_CLASSIFY_PROMPT: deequ-bot/issue-classify-prompt

--- a/src/scripts/issue_bot/agent_loop.py
+++ b/src/scripts/issue_bot/agent_loop.py
@@ -61,6 +61,7 @@ def run(
     pipeline_deadline: Optional[float] = None,
     untrusted_user_prompt: Optional[str] = None,
     commit_phase_user_prompt: Optional[str] = None,
+    model_id: Optional[str] = None,
 ):
     """Execute an agent's tool-use loop. Returns an AgentResult.
 
@@ -95,6 +96,7 @@ def run(
             _run_commit_phase(
                 bedrock_client, agent_name, system_prompt, messages,
                 commit_phase_user_prompt, tool_specs, caps, result, pipeline_deadline,
+                model_id=model_id,
             )
         result.text = _aggregate_all_assistant_text(messages)
         return result
@@ -115,6 +117,7 @@ def run(
                 messages=messages,
                 tool_specs=tool_specs,
                 max_tokens=caps.max_tokens_per_call,
+                model_id=model_id,
             )
         except Exception as e:
             logger.error("[%s turn=%d] bedrock error: %s", agent_name, turn + 1, type(e).__name__)
@@ -182,7 +185,7 @@ def _is_budget_exhaustion(reason: Optional[str]) -> bool:
 
 def _run_commit_phase(bedrock_client, agent_name, system_prompt, messages,
                       commit_phase_user_prompt, tool_specs, caps, result,
-                      pipeline_deadline):
+                      pipeline_deadline, model_id: Optional[str] = None):
     """One Bedrock turn after the loop's tool budget is exhausted, prompting
     the model to emit text only. tool_specs is kept on the request because
     Bedrock validates toolUse/toolResult content blocks in the conversation
@@ -215,6 +218,7 @@ def _run_commit_phase(bedrock_client, agent_name, system_prompt, messages,
             messages=messages,
             tool_specs=tool_specs,
             max_tokens=caps.max_tokens_per_call,
+            model_id=model_id,
         )
     except Exception as e:
         logger.error("[%s] commit phase bedrock error: %s", agent_name, type(e).__name__)

--- a/src/scripts/issue_bot/bedrock_client.py
+++ b/src/scripts/issue_bot/bedrock_client.py
@@ -207,7 +207,7 @@ class BedrockClient:
             return None, {}
 
     def converse_with_tools(self, system_prompt, messages, tool_specs,
-                             max_tokens=8000, temperature=0.3):
+                             max_tokens=8000, temperature=0.3, model_id=None):
         """One turn of Converse with optional toolConfig. Returns the raw
         response dict (or None on failure / guardrail intervention /
         circuit open).
@@ -216,10 +216,17 @@ class BedrockClient:
         by the loop's commit phase to physically prevent further tool calls
         after the tool budget is exhausted.
 
-        Two cachePoints: one after the system block (the static_context
-        prefix shared between Investigator and Critic), one at the tail of
-        the last message (so the growing conversation history is cached
+        model_id (optional): override the default model. Used to run the
+        Critic on a cheaper model (Haiku) while keeping Investigator on Opus.
+        Within one agent's loop, the model stays fixed across turns — switching
+        mid-loop would invalidate the message cache.
+
+        Two cachePoints: one after the system block, one at the tail of the
+        last message (so the growing conversation history is cached
         turn-over-turn instead of re-priced as fresh input every turn).
+        Both Opus 4.6 and Haiku 4.5 require ≥4,096 tokens before a cachePoint
+        for it to take effect; first-turn message-tail caches silently no-op
+        on small payloads but become useful once tool results accumulate.
         """
         if self._circuit_open:
             logger.warning("Circuit breaker open, skipping Bedrock tool-use call")
@@ -228,7 +235,7 @@ class BedrockClient:
             wrapped_messages = self._wrap_first_user_for_guardrail(messages)
             wrapped_messages = self._append_tail_cache_point(wrapped_messages)
             kwargs = {
-                "modelId": self._model_id,
+                "modelId": model_id or self._model_id,
                 "messages": wrapped_messages,
                 "inferenceConfig": {"maxTokens": max_tokens, "temperature": temperature},
             }

--- a/src/scripts/issue_bot/config.py
+++ b/src/scripts/issue_bot/config.py
@@ -32,6 +32,15 @@ class Config:
                 "Reporter model override active: %s (default: %s)",
                 self.reporter_model_id, self.bedrock_model_id,
             )
+        # Critic uses converse_with_tools (multi-turn loop). Override goes
+        # through agent_loop.run → converse_with_tools so the same model is
+        # used for every turn within one Critic run.
+        self.critic_model_id = (os.getenv("BEDROCK_CRITIC_MODEL_ID") or "").strip() or self.bedrock_model_id
+        if self.critic_model_id != self.bedrock_model_id:
+            logger.info(
+                "Critic model override active: %s (default: %s)",
+                self.critic_model_id, self.bedrock_model_id,
+            )
 
         self.kb_s3_bucket = os.getenv("KB_S3_BUCKET", "")
         self.kb_s3_key = os.getenv("KB_S3_KEY", "")

--- a/src/scripts/issue_bot/main.py
+++ b/src/scripts/issue_bot/main.py
@@ -918,7 +918,7 @@ def _run_agent_pipeline(*, cfg, gh, bedrock, number, title, body, html_url, item
         )
     )
     if crit_result is not None:
-        metrics["critic"] = _agent_metrics(crit_result, model_id=cfg.bedrock_model_id)
+        metrics["critic"] = _agent_metrics(crit_result, model_id=cfg.critic_model_id)
     # Unknown event = bug in a future change. Escalate with a distinct
     # reason rather than silently posting a clean review.
     if pipeline_event is not None and pipeline_event not in _KNOWN_PIPELINE_EVENTS:
@@ -1021,7 +1021,8 @@ def _build_caps(cfg, pr_files):
 
 def _build_static_context(kb_context, codebase_map, existing_feedback, incremental_diff):
     """Assemble the system-prompt suffix shared between Investigator and Critic.
-    Same prefix → cache hit on Critic's first turn."""
+    The two agents have different prompt templates rendered in front of this
+    suffix, so they don't share a Bedrock cache key — each warms its own."""
     incremental_section = ""
     if incremental_diff:
         incremental_section = (
@@ -1095,6 +1096,7 @@ def _run_critic_and_reporter(*, cfg, bedrock, tool_runner, critic_system, critic
         caps=critic_caps,
         pipeline_deadline=pipeline_deadline,
         commit_phase_user_prompt=prompts.get_pr_critic_commit_prompt() or None,
+        model_id=cfg.critic_model_id,
     )
 
     if not crit_result.text:

--- a/src/scripts/tests/test_agent_loop.py
+++ b/src/scripts/tests/test_agent_loop.py
@@ -15,13 +15,14 @@ class FakeBedrockClient:
 
     def converse_with_tools(self, system_prompt, messages, tool_specs,
                              max_tokens=8000, temperature=0.3,
-                             timeout_seconds=None):
+                             timeout_seconds=None, model_id=None):
         self.calls.append({
             "system_prompt": system_prompt,
             "messages": list(messages),
             "tool_specs": tool_specs,
             "max_tokens": max_tokens,
             "timeout_seconds": timeout_seconds,
+            "model_id": model_id,
         })
         if not self._responses:
             return None

--- a/src/scripts/tests/test_bot.py
+++ b/src/scripts/tests/test_bot.py
@@ -601,10 +601,11 @@ class TestSplitPrompt:
         assert system[0]["text"] == "instructions + diff"
         assert all("cachePoint" not in block for block in system)
 
-    def test_converse_with_tools_keeps_cache_point_for_inv_to_critic(self):
-        """converse_with_tools is the one path where caching can pay off:
-        Investigator's first turn warms a cache the Critic's first turn can
-        read (shared static prefix from _build_static_context)."""
+    def test_converse_with_tools_emits_system_cache_point(self):
+        """converse_with_tools sets a cachePoint after the system block so
+        each agent's tool-use loop reads its own cache from turn 2 onward
+        (Bedrock's prefix-match lookback turns N's input into a cache read
+        for turn N+1 within the same agent run)."""
         client = self._make_client(guardrail_id="gr-123")
         self._mock_converse(client)
         client.converse_with_tools(
@@ -615,6 +616,45 @@ class TestSplitPrompt:
         kwargs = client._client.converse.call_args[1]
         system = kwargs["system"]
         assert any("cachePoint" in block for block in system)
+
+    def test_converse_with_tools_uses_override_model_id(self):
+        """Critic can run on Haiku while Investigator stays on Opus. The
+        per-call model_id override lets a single client serve both."""
+        client = self._make_client()
+        self._mock_converse(client)
+        client.converse_with_tools(
+            "system",
+            [{"role": "user", "content": [{"text": "x"}]}],
+            tool_specs=[],
+            model_id="TEST_MODEL_ID",
+        )
+        kwargs = client._client.converse.call_args[1]
+        assert kwargs["modelId"] == "TEST_MODEL_ID"
+
+    def test_converse_with_tools_default_model_id(self):
+        client = self._make_client()
+        self._mock_converse(client)
+        client.converse_with_tools(
+            "system",
+            [{"role": "user", "content": [{"text": "x"}]}],
+            tool_specs=[],
+        )
+        kwargs = client._client.converse.call_args[1]
+        assert kwargs["modelId"] == client._model_id
+
+    def test_converse_with_tools_empty_model_id_falls_back(self):
+        """An empty-string override (e.g., from an unset GH Actions vars
+        expansion) must fall through to the client default."""
+        client = self._make_client()
+        self._mock_converse(client)
+        client.converse_with_tools(
+            "system",
+            [{"role": "user", "content": [{"text": "x"}]}],
+            tool_specs=[],
+            model_id="",
+        )
+        kwargs = client._client.converse.call_args[1]
+        assert kwargs["modelId"] == client._model_id
 
     def test_converse_with_tools_appends_tail_cache_point(self):
         """Tail cachePoint on the last message lets the growing conversation

--- a/src/scripts/tests/test_critic.py
+++ b/src/scripts/tests/test_critic.py
@@ -85,7 +85,7 @@ def _run_pipeline(tmp_path, monkeypatch, mock,
         # The fast path skips critic entirely if no CONFIRMED findings.
         def converse_side_effect(system_prompt, messages, tool_specs,
                                  max_tokens=8000, temperature=0.3,
-                                 timeout_seconds=None):
+                                 timeout_seconds=None, model_id=None):
             # Identify which agent by scanning the system prompt
             if "Investigate" in system_prompt:
                 return _bedrock_text_resp(investigator_text)
@@ -234,7 +234,7 @@ def test_investigator_max_turns_routes_to_critic_even_without_confirmed(tmp_path
 
         def converse_side_effect(system_prompt, messages, tool_specs,
                                  max_tokens=8000, temperature=0.3,
-                                 timeout_seconds=None):
+                                 timeout_seconds=None, model_id=None):
             is_critic = "Critique" in system_prompt
             commit_phase = _has_commit_marker(messages)
             call_log.append({
@@ -563,7 +563,7 @@ def test_critic_diff_truncation_on_large_diff(tmp_path, monkeypatch):
         mock_invoke.return_value = (json.dumps({"analysis": []}), {"inputTokens": 1, "outputTokens": 1, "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0})
 
         def converse(system_prompt, messages, tool_specs, max_tokens=8000,
-                     temperature=0.3, timeout_seconds=None):
+                     temperature=0.3, timeout_seconds=None, model_id=None):
             captured_messages.append({"system": system_prompt[:200], "messages": messages})
             text = (
                 "ID: C1\nSTATUS: CONFIRMED\nSEVERITY: BUG\nCOMMENT: c\nEVIDENCE: e\n"
@@ -1208,7 +1208,7 @@ def test_investigator_diff_truncation_on_large_diff(tmp_path, monkeypatch):
                                       "cacheReadInputTokens": 0, "cacheWriteInputTokens": 0})
 
         def converse(system_prompt, messages, tool_specs, max_tokens=8000,
-                     temperature=0.3, timeout_seconds=None):
+                     temperature=0.3, timeout_seconds=None, model_id=None):
             captured.append({"system": system_prompt[:80], "messages": messages})
             text = (
                 "No confirmed issues found." if "Investigate" in system_prompt


### PR DESCRIPTION
## Summary

Extends the per-stage `model_id` override pattern from #735 (Reporter→Haiku) to the Critic stage. Critic runs the multi-turn `converse_with_tools` loop, so the override flows through `agent_loop.run` → `converse_with_tools`. Within one Critic run, the model stays fixed across all turns (switching mid-loop would invalidate the message cache).

**Note**: this PR adds the *capability*. Activation is gated on the Critic-isolated replay bench, which runs separately. Variable `BEDROCK_CRITIC_MODEL_ID` stays unset in this PR; it can be set post-merge once the bench validates Haiku produces equivalent CONFIRMED/DISPROVED verdicts.

### Cost projection

Modeling against the most recent production Critic call (PR #722, post-#734 cachePoints):
- Opus Critic per call: ~$1.42 (148K cache writes + 784K cache reads + 1.3K output, all at Opus rates)
- Haiku Critic per call: ~$0.28 (same token shape, Haiku rates: $1/M input, $5/M output, $1.25/M cache write, $0.10/M cache read)

**Saving estimate: ~$1.14/Critic call** (80% reduction). Subject to bench validation.

### What changed

1. **`bedrock_client.converse_with_tools` accepts `model_id` override** (kw-only, default None).
2. **`agent_loop.run` accepts `model_id`** and threads it to both the main loop's `converse_with_tools` calls and the commit-phase call.
3. **`Config.critic_model_id`** reads `BEDROCK_CRITIC_MODEL_ID` env var, falls back to `bedrock_model_id`. Same `.strip() or default` pattern as the Reporter override.
4. **Critic dispatch in `main.py`** passes `model_id=cfg.critic_model_id`.
5. **Critic stage metrics stamp** uses `cfg.critic_model_id` so cost dashboards pick up the right per-token rate.
6. **Workflow var** `vars.BEDROCK_CRITIC_MODEL_ID` (unsensitive — model IDs are public). Same convention as `BEDROCK_REPORTER_MODEL_ID`.
7. **Docstring corrections**: removed a long-stale claim that Investigator's first turn warms the Critic's cache. The two agents render distinct prompt templates in front of `static_context`, so their cache prefixes differ — each warms its own cache. Updated `_build_static_context` and the corresponding test name + docstring.
8. **`_run_commit_phase` annotation parity** (`Optional[str]` instead of bare `model_id=None`).
9. **Cache-floor note** added to `converse_with_tools` docstring (both Opus 4.6 and Haiku 4.5 require ≥4,096 tokens before a cachePoint takes effect).

### Why this is safe

- `model_id` defaults to `None` everywhere; Haiku is opt-in via workflow variable. **Merge is no-op until the variable is set.**
- 5-angle code-review + sweep on the diff: 2 MAJOR docstring inconsistencies caught and fixed; A2 (mid-loop model switch invalidating cache) refuted (model_id is a single closure value in `run()`, never reassigned per turn).
- Investigator dispatch left untouched — only Critic gets the override.
- Falsy-fallback covered by 3 new tests: explicit override, default, empty string.

### Files

- `src/scripts/issue_bot/agent_loop.py` — `model_id` param on `run()` and `_run_commit_phase`
- `src/scripts/issue_bot/bedrock_client.py` — `model_id` kwarg on `converse_with_tools`
- `src/scripts/issue_bot/config.py` — `critic_model_id` with fallback chain
- `src/scripts/issue_bot/main.py` — Critic dispatch + metrics stamp
- `src/scripts/tests/test_agent_loop.py` — `FakeBedrockClient.converse_with_tools` signature update
- `src/scripts/tests/test_bot.py` — 3 new tests + 1 docstring/name fix
- `src/scripts/tests/test_critic.py` — 4 mock side-effect signature updates
- `.github/workflows/issue-bot.yml` — `BEDROCK_CRITIC_MODEL_ID` env mapping

## Test plan

- [x] 312/312 tests pass locally
- [ ] Critic-isolated replay bench (in progress) — must show equivalent CONFIRMED/DISPROVED verdicts before activation
- [ ] Post-merge + bench-pass: set `vars.BEDROCK_CRITIC_MODEL_ID = us.anthropic.claude-haiku-4-5-20251001-v1:0` to activate

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.