### PR TITLE
Fix DuplicateRowCount row-level boolean semantics

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/DuplicateRowCount.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/DuplicateRowCount.scala
@@ -51,8 +51,8 @@ case class DuplicateRowCount(columns: Seq[String], where: Option[String] = None,
       val fullColumnDuplicate = fullColumn.map { rowLevelColumn =>
         conditionColumn.map { condition =>
           when(not(condition), getRowLevelFilterTreatment(analyzerOptions).getExpression)
-            .when(rowLevelColumn > lit(1), true).otherwise(false)
-        }.getOrElse(when(rowLevelColumn > lit(1), true).otherwise(false))
+            .when(rowLevelColumn > lit(1), false).otherwise(true)
+        }.getOrElse(when(rowLevelColumn > lit(1), false).otherwise(true))
       }
       super.fromAggregationResult(result, offset, fullColumnDuplicate)
     }

--- a/src/test/scala/com/amazon/deequ/analyzers/DuplicateRowCountTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/DuplicateRowCountTest.scala
@@ -201,12 +201,14 @@ class DuplicateRowCountTest extends AnyWordSpec with Matchers with SparkContextS
       // Verify the check passes
       result.status shouldBe CheckStatus.Success
 
-      // Verify row-level results: true = duplicate, false = unique
+      // Verify row-level results: true = passes (not duplicate), false = fails (is duplicate)
       val rowLevelDf = VerificationResult.rowLevelResultsAsDataFrame(session, result, df)
-      val flags = rowLevelDf.select("`dup-check`").collect().map(_.getBoolean(0))
-      // 2 rows are duplicates (true), 2 rows are unique (false)
-      flags.count(_ == true) shouldBe 2
-      flags.count(_ == false) shouldBe 2
+      val rows = rowLevelDf.select("col1", "col2", "`dup-check`").collect()
+      // (a,1) appears twice -> duplicate -> false (fails)
+      // (b,2) and (c,3) appear once -> unique -> true (passes)
+      rows.filter(r => r.getString(0) == "b").foreach(r => r.getBoolean(2) shouldBe true)
+      rows.filter(r => r.getString(0) == "c").foreach(r => r.getBoolean(2) shouldBe true)
+      rows.filter(r => r.getString(0) == "a").foreach(r => r.getBoolean(2) shouldBe false)
     }
 
     "work with empty columns through VerificationSuite" in withSparkSession { session =>
@@ -257,10 +259,11 @@ class DuplicateRowCountTest extends AnyWordSpec with Matchers with SparkContextS
       val rowLevelDf = VerificationResult.rowLevelResultsAsDataFrame(session, result, df)
       rowLevelDf.columns should contain ("dup-resolved")
 
-      // Verify flags: 2 duplicates (true), 2 unique (false)
-      val flags = rowLevelDf.select("`dup-resolved`").collect().map(_.getBoolean(0))
-      flags.count(_ == true) shouldBe 2
-      flags.count(_ == false) shouldBe 2
+      // Verify flags: duplicates -> false (fails), unique -> true (passes)
+      val flags = rowLevelDf.select("col1", "`dup-resolved`").collect()
+      flags.filter(_.getString(0) == "b").foreach(_.getBoolean(1) shouldBe true)
+      flags.filter(_.getString(0) == "c").foreach(_.getBoolean(1) shouldBe true)
+      flags.filter(_.getString(0) == "a").foreach(_.getBoolean(1) shouldBe false)
     }
   }
 }


### PR DESCRIPTION
The row-level column for DuplicateRowCount was producing true for duplicate rows and false for unique rows. This is inconsistent with the framework convention where true means the row passes the rule.

Invert the boolean so that:
- true = row is NOT a duplicate (passes)
- false = row IS a duplicate (fails)

This aligns with how other analyzers (IsComplete, Uniqueness) expose row-level results, where true indicates the row satisfies the check.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
