### PR TITLE
Fix profiling of columns whose names require escaping (e.g. a leading space)

### DIFF
--- a/src/main/scala/com/amazon/deequ/analyzers/ExactQuantile.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/ExactQuantile.scala
@@ -21,7 +21,7 @@ import com.amazon.deequ.analyzers.Analyzers.{conditionalSelection, ifNoNullsIn}
 import com.amazon.deequ.metrics.FullColumn
 import org.apache.curator.shaded.com.google.common.annotations.VisibleForTesting
 import org.apache.spark.sql.{Column, Row}
-import org.apache.spark.sql.functions.expr
+import org.apache.spark.sql.functions.{expr, lit, percentile}
 import org.apache.spark.sql.types.{DoubleType, StructType}
 
 case class ExactQuantileState(exactQuantile: Double, quantile: Double, override val fullColumn: Option[Column] = None)
@@ -45,7 +45,10 @@ case class ExactQuantile(column: String,
 extends StandardScanShareableAnalyzer[ExactQuantileState]("ExactQuantile", column)
 with FilterableAnalyzer {
   override def aggregationFunctions(): Seq[Column] = {
-    expr(s"percentile(${conditionalSelection(column, where).cast(DoubleType)}, $quantile)") :: Nil
+    // Build the percentile column directly rather than interpolating the selection into an
+    // expr(...) string: stringifying the column loses the backtick quoting and breaks
+    // column names that need escaping (e.g. one with a leading space).
+    percentile(conditionalSelection(column, where).cast(DoubleType), lit(quantile)) :: Nil
   }
 
   override def fromAggregationResult(result: Row, offset: Int): Option[ExactQuantileState] = {

--- a/src/main/scala/com/amazon/deequ/analyzers/InterquartileRange.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/InterquartileRange.scala
@@ -19,7 +19,7 @@ package com.amazon.deequ.analyzers
 import com.amazon.deequ.analyzers.Preconditions.{hasColumn, isNumeric}
 import com.amazon.deequ.analyzers.Analyzers._
 import org.apache.spark.sql.{Column, Row}
-import org.apache.spark.sql.functions.expr
+import org.apache.spark.sql.functions.{lit, percentile}
 import org.apache.spark.sql.types.{DoubleType, StructType}
 
 case class InterquartileRangeState(
@@ -61,8 +61,11 @@ case class InterquartileRange(
     conditionalSelection(column, where).cast(DoubleType)
 
   override def aggregationFunctions(): Seq[Column] = {
-    expr(s"percentile($selection, 0.25)") ::
-      expr(s"percentile($selection, 0.75)") :: Nil
+    // Build the percentile columns directly rather than interpolating `selection` into an
+    // expr(...) string: stringifying the column loses the backtick quoting and breaks
+    // column names that need escaping (e.g. one with a leading space).
+    percentile(selection, lit(0.25)) ::
+      percentile(selection, lit(0.75)) :: Nil
   }
 
   override def fromAggregationResult(

--- a/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
+++ b/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
@@ -448,13 +448,14 @@ object ColumnProfiler {
         analyzer.column -> metric.value.get
       }
 
+    // Key by the escaped column name, like `columns` and the other statistics maps, so that
+    // columns whose names need escaping are not dropped and resolve in typeOf(...).
     val knownTypes = schema.fields
-      .filter { column => columns.contains(column.name) }
-      .filterNot { column => predefinedTypes.contains(column.name)}
-      .filter {
-        _.dataType != StringType
-      }
-      .map { field =>
+      .map { field => (escapeColumn(field.name), field) }
+      .filter { case (name, _) => columns.contains(name) }
+      .filterNot { case (name, _) => predefinedTypes.contains(name) }
+      .filter { case (_, field) => field.dataType != StringType }
+      .map { case (name, field) =>
         val knownType = field.dataType match {
           case ShortType | LongType | IntegerType => Integral
           case DecimalType() | FloatType | DoubleType => Fractional
@@ -465,7 +466,7 @@ object ColumnProfiler {
             Unknown
         }
 
-        field.name -> knownType
+        name -> knownType
       }
       .toMap
 

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
@@ -792,6 +792,24 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
     }
   }
 
+  "Exact quantile analyzer" should {
+    "compute correct value for a column whose name needs escaping" in
+      withSparkSession { session =>
+      import session.implicits._
+      // A leading space requires backtick escaping; the column reference must survive it.
+      val df = (1 to 10).toDF(" length")
+      ExactQuantile("` length`", 0.5).calculate(df).value shouldBe Success(5.5)
+    }
+
+    "compute correct value with a where clause that contains a string literal" in
+      withSparkSession { session =>
+      import session.implicits._
+      val df = Seq(("a", 1), ("b", 2), ("a", 3), ("b", 4), ("a", 5)).toDF("item", "att1")
+      ExactQuantile("att1", 0.5, where = Some("item != 'b'")).calculate(df)
+        .value shouldBe Success(3.0)
+    }
+  }
+
   "Pearson correlation" should {
     "yield NaN for conditionally uninformative columns" in withSparkSession { sparkSession =>
       val df = getDfWithConditionallyUninformativeColumns(sparkSession)

--- a/src/test/scala/com/amazon/deequ/analyzers/InterquartileRangeTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/InterquartileRangeTest.scala
@@ -103,6 +103,22 @@ class InterquartileRangeTest extends AnyWordSpec with Matchers
       metric.instance shouldBe "att1"
     }
 
+    "compute correct value for a column whose name needs escaping" in
+      withSparkSession { session =>
+      import session.implicits._
+      // A leading space requires backtick escaping; the column reference must survive it.
+      val df = (1 to 10).toDF(" length")
+      InterquartileRange("` length`").calculate(df).value shouldBe Success(4.5)
+    }
+
+    "compute correct value with a where clause that contains a string literal" in
+      withSparkSession { session =>
+      import session.implicits._
+      val df = Seq(("a", 1), ("b", 2), ("a", 3), ("b", 4), ("a", 5)).toDF("item", "att1")
+      InterquartileRange("att1", where = Some("item != 'b'")).calculate(df)
+        .value shouldBe Success(2.0)
+    }
+
     "throw on state merge (quantiles not algebraically mergeable)" in
       withSparkSession { session =>
       import session.implicits._

--- a/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerTest.scala
+++ b/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerTest.scala
@@ -571,6 +571,36 @@ class ColumnProfilerTest extends WordSpec with Matchers with SparkContextSpec
       assert(histogram(NullFieldReplacement).absolute == 1)
       assert(histogram(NullFieldReplacement).ratio == 1.0 / nRows)
     }
+
+    "profile a numeric column whose name requires escaping (e.g. a leading space)" in
+      withSparkSession { session =>
+        val schema = StructType(Seq(
+          StructField("flower_type", StringType),
+          StructField(" length", IntegerType)
+        ))
+        val rows = session.sparkContext.parallelize(Seq(
+          Row("setosa", 5),
+          Row("setosa", 4),
+          Row("versicolor", 6),
+          Row("versicolor", 7),
+          Row("virginica", 6)
+        ))
+        val data = session.createDataFrame(rows, schema)
+
+        val profiles = ColumnProfiler.profile(data).profiles
+
+        // Profiles are keyed by the original (un-escaped) column name.
+        val lengthProfile = profiles(" length")
+        assert(lengthProfile.dataType == DataTypeInstances.Integral)
+        assert(lengthProfile.completeness == 1.0)
+        lengthProfile match {
+          case n: NumericColumnProfile =>
+            assert(n.maximum.contains(7.0))
+            assert(n.minimum.contains(4.0))
+          case other =>
+            fail(s"expected a NumericColumnProfile, got $other")
+        }
+      }
   }
 
   "return correct profile for the Titanic dataset" in withSparkSession { session =>


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

Profiling a column whose name requires escaping (e.g. a numeric column whose name has a leading space, `` ` length` ``) fails. On the `ColumnProfilerRunner` / `ConstraintSuggestionRunner` path it surfaces as `` java.util.NoSuchElementException: key not found: ` length` ``. Two spots assume the column name needs no escaping:

- `ColumnProfiler.extractGenericStatistics` keyed the `knownTypes` map by the raw `field.name`, while `relevantColumns`, the analyzers, and the other statistics maps (`completenesses`, `approximateNumDistincts`, `inferredTypes`) are keyed by the escaped name (`escapeColumn`). The column was dropped from `knownTypes`, so the later `typeOf(...)` lookup missed and threw.
- `InterquartileRange.aggregationFunctions` interpolated the `selection` `Column` into an `expr("percentile(...)")` string; stringifying the column drops backtick quoting (and the quoting of string literals in a `WHERE` clause), so the percentile aggregation could not resolve an escaped column name.

Changes:
- Key `knownTypes` by the escaped column name, consistent with the other maps, and compute the escaped name once per field
- Build the `InterquartileRange` percentile columns programmatically (`percentile(selection, lit(0.25))`) instead of via an interpolated `expr(...)` string — same Catalyst aggregate, but keeps the column reference intact
- Add a `ColumnProfilerTest` for a numeric column named `` ` length` ``, and `InterquartileRangeTest` cases for an escaped column name and a `WHERE` clause containing a string literal (both fail before this change, pass after)
- All tests pass, including the existing `InterquartileRangeTest` Q1/Q3/IQR values (confirming the percentile result is unchanged)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
