### PR TITLE
Port 2.0.21 fixes to Spark 4.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.amazon.deequ</groupId>
     <artifactId>deequ</artifactId>
-    <version>2.0.18-spark-4.1</version>
+    <version>2.0.21-spark-4.1</version>
 
     <properties>
         <maven.compiler.source>17</maven.compiler.source>

--- a/src/main/scala/com/amazon/deequ/analyzers/DuplicateRowCount.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/DuplicateRowCount.scala
@@ -51,8 +51,8 @@ case class DuplicateRowCount(columns: Seq[String], where: Option[String] = None,
       val fullColumnDuplicate = fullColumn.map { rowLevelColumn =>
         conditionColumn.map { condition =>
           when(not(condition), getRowLevelFilterTreatment(analyzerOptions).getExpression)
-            .when(rowLevelColumn > lit(1), true).otherwise(false)
-        }.getOrElse(when(rowLevelColumn > lit(1), true).otherwise(false))
+            .when(rowLevelColumn > lit(1), false).otherwise(true)
+        }.getOrElse(when(rowLevelColumn > lit(1), false).otherwise(true))
       }
       super.fromAggregationResult(result, offset, fullColumnDuplicate)
     }

--- a/src/main/scala/com/amazon/deequ/analyzers/ExactQuantile.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/ExactQuantile.scala
@@ -21,7 +21,7 @@ import com.amazon.deequ.analyzers.Analyzers.{conditionalSelection, ifNoNullsIn}
 import com.amazon.deequ.metrics.FullColumn
 import org.apache.curator.shaded.com.google.common.annotations.VisibleForTesting
 import org.apache.spark.sql.{Column, Row}
-import org.apache.spark.sql.functions.expr
+import org.apache.spark.sql.functions.{expr, lit, percentile}
 import org.apache.spark.sql.types.{DoubleType, StructType}
 
 case class ExactQuantileState(exactQuantile: Double, quantile: Double, override val fullColumn: Option[Column] = None)
@@ -45,7 +45,10 @@ case class ExactQuantile(column: String,
 extends StandardScanShareableAnalyzer[ExactQuantileState]("ExactQuantile", column)
 with FilterableAnalyzer {
   override def aggregationFunctions(): Seq[Column] = {
-    expr(s"percentile(${conditionalSelection(column, where).cast(DoubleType)}, $quantile)") :: Nil
+    // Build the percentile column directly rather than interpolating the selection into an
+    // expr(...) string: stringifying the column loses the backtick quoting and breaks
+    // column names that need escaping (e.g. one with a leading space).
+    percentile(conditionalSelection(column, where).cast(DoubleType), lit(quantile)) :: Nil
   }
 
   override def fromAggregationResult(result: Row, offset: Int): Option[ExactQuantileState] = {

--- a/src/main/scala/com/amazon/deequ/analyzers/InterquartileRange.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/InterquartileRange.scala
@@ -19,7 +19,7 @@ package com.amazon.deequ.analyzers
 import com.amazon.deequ.analyzers.Preconditions.{hasColumn, isNumeric}
 import com.amazon.deequ.analyzers.Analyzers._
 import org.apache.spark.sql.{Column, Row}
-import org.apache.spark.sql.functions.expr
+import org.apache.spark.sql.functions.{lit, percentile}
 import org.apache.spark.sql.types.{DoubleType, StructType}
 
 case class InterquartileRangeState(
@@ -61,8 +61,11 @@ case class InterquartileRange(
     conditionalSelection(column, where).cast(DoubleType)
 
   override def aggregationFunctions(): Seq[Column] = {
-    expr(s"percentile($selection, 0.25)") ::
-      expr(s"percentile($selection, 0.75)") :: Nil
+    // Build the percentile columns directly rather than interpolating `selection` into an
+    // expr(...) string: stringifying the column loses the backtick quoting and breaks
+    // column names that need escaping (e.g. one with a leading space).
+    percentile(selection, lit(0.25)) ::
+      percentile(selection, lit(0.75)) :: Nil
   }
 
   override def fromAggregationResult(

--- a/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
+++ b/src/main/scala/com/amazon/deequ/analyzers/runners/AnalysisRunner.scala
@@ -20,6 +20,7 @@ import com.amazon.deequ.analyzers._
 import com.amazon.deequ.io.DfsUtils
 import com.amazon.deequ.metrics.{DoubleMetric, Metric}
 import com.amazon.deequ.repository.{MetricsRepository, ResultKey}
+import com.amazon.deequ.utilities.ColumnUtil.escapeColumn
 import org.apache.spark.sql.Column
 import org.apache.spark.sql.functions.col
 import org.apache.spark.sql.types.StructType
@@ -409,7 +410,7 @@ object AnalysisRunner {
         // All analyzers are dataset-level (e.g. Size), no column selection needed
         data
       } else {
-        data.select(neededColumns.map(col): _*)
+        data.select(neededColumns.map(c => col(escapeColumn(c))): _*)
       }
     }
   }

--- a/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
+++ b/src/main/scala/com/amazon/deequ/profiles/ColumnProfiler.scala
@@ -450,13 +450,14 @@ object ColumnProfiler {
         analyzer.column -> metric.value.get
       }
 
+    // Key by the escaped column name, like `columns` and the other statistics maps, so that
+    // columns whose names need escaping are not dropped and resolve in typeOf(...).
     val knownTypes = schema.fields
-      .filter { column => columns.contains(column.name) }
-      .filterNot { column => predefinedTypes.contains(column.name)}
-      .filter {
-        _.dataType != StringType
-      }
-      .map { field =>
+      .map { field => (escapeColumn(field.name), field) }
+      .filter { case (name, _) => columns.contains(name) }
+      .filterNot { case (name, _) => predefinedTypes.contains(name) }
+      .filter { case (_, field) => field.dataType != StringType }
+      .map { case (name, field) =>
         val knownType = field.dataType match {
           case ShortType | LongType | IntegerType => Integral
           case DecimalType() | FloatType | DoubleType => Fractional
@@ -467,7 +468,7 @@ object ColumnProfiler {
             Unknown
         }
 
-        field.name -> knownType
+        name -> knownType
       }
       .toMap
 

--- a/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/AnalyzerTests.scala
@@ -791,6 +791,24 @@ class AnalyzerTests extends AnyWordSpec with Matchers with SparkContextSpec with
     }
   }
 
+  "Exact quantile analyzer" should {
+    "compute correct value for a column whose name needs escaping" in
+      withSparkSession { session =>
+      import session.implicits._
+      // A leading space requires backtick escaping; the column reference must survive it.
+      val df = (1 to 10).toDF(" length")
+      ExactQuantile("` length`", 0.5).calculate(df).value shouldBe Success(5.5)
+    }
+
+    "compute correct value with a where clause that contains a string literal" in
+      withSparkSession { session =>
+      import session.implicits._
+      val df = Seq(("a", 1), ("b", 2), ("a", 3), ("b", 4), ("a", 5)).toDF("item", "att1")
+      ExactQuantile("att1", 0.5, where = Some("item != 'b'")).calculate(df)
+        .value shouldBe Success(3.0)
+    }
+  }
+
   "Pearson correlation" should {
     "yield NaN for conditionally uninformative columns" in withSparkSession { sparkSession =>
       val df = getDfWithConditionallyUninformativeColumns(sparkSession)

--- a/src/test/scala/com/amazon/deequ/analyzers/DuplicateRowCountTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/DuplicateRowCountTest.scala
@@ -201,12 +201,14 @@ class DuplicateRowCountTest extends AnyWordSpec with Matchers with SparkContextS
       // Verify the check passes
       result.status shouldBe CheckStatus.Success
 
-      // Verify row-level results: true = duplicate, false = unique
+      // Verify row-level results: true = passes (not duplicate), false = fails (is duplicate)
       val rowLevelDf = VerificationResult.rowLevelResultsAsDataFrame(session, result, df)
-      val flags = rowLevelDf.select("`dup-check`").collect().map(_.getBoolean(0))
-      // 2 rows are duplicates (true), 2 rows are unique (false)
-      flags.count(_ == true) shouldBe 2
-      flags.count(_ == false) shouldBe 2
+      val rows = rowLevelDf.select("col1", "col2", "`dup-check`").collect()
+      // (a,1) appears twice -> duplicate -> false (fails)
+      // (b,2) and (c,3) appear once -> unique -> true (passes)
+      rows.filter(r => r.getString(0) == "b").foreach(r => r.getBoolean(2) shouldBe true)
+      rows.filter(r => r.getString(0) == "c").foreach(r => r.getBoolean(2) shouldBe true)
+      rows.filter(r => r.getString(0) == "a").foreach(r => r.getBoolean(2) shouldBe false)
     }
 
     "work with empty columns through VerificationSuite" in withSparkSession { session =>
@@ -257,10 +259,11 @@ class DuplicateRowCountTest extends AnyWordSpec with Matchers with SparkContextS
       val rowLevelDf = VerificationResult.rowLevelResultsAsDataFrame(session, result, df)
       rowLevelDf.columns should contain ("dup-resolved")
 
-      // Verify flags: 2 duplicates (true), 2 unique (false)
-      val flags = rowLevelDf.select("`dup-resolved`").collect().map(_.getBoolean(0))
-      flags.count(_ == true) shouldBe 2
-      flags.count(_ == false) shouldBe 2
+      // Verify flags: duplicates -> false (fails), unique -> true (passes)
+      val flags = rowLevelDf.select("col1", "`dup-resolved`").collect()
+      flags.filter(_.getString(0) == "b").foreach(_.getBoolean(1) shouldBe true)
+      flags.filter(_.getString(0) == "c").foreach(_.getBoolean(1) shouldBe true)
+      flags.filter(_.getString(0) == "a").foreach(_.getBoolean(1) shouldBe false)
     }
   }
 }

--- a/src/test/scala/com/amazon/deequ/analyzers/InterquartileRangeTest.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/InterquartileRangeTest.scala
@@ -103,6 +103,22 @@ class InterquartileRangeTest extends AnyWordSpec with Matchers
       metric.instance shouldBe "att1"
     }
 
+    "compute correct value for a column whose name needs escaping" in
+      withSparkSession { session =>
+      import session.implicits._
+      // A leading space requires backtick escaping; the column reference must survive it.
+      val df = (1 to 10).toDF(" length")
+      InterquartileRange("` length`").calculate(df).value shouldBe Success(4.5)
+    }
+
+    "compute correct value with a where clause that contains a string literal" in
+      withSparkSession { session =>
+      import session.implicits._
+      val df = Seq(("a", 1), ("b", 2), ("a", 3), ("b", 4), ("a", 5)).toDF("item", "att1")
+      InterquartileRange("att1", where = Some("item != 'b'")).calculate(df)
+        .value shouldBe Success(2.0)
+    }
+
     "throw on state merge (quantiles not algebraically mergeable)" in
       withSparkSession { session =>
       import session.implicits._

--- a/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
+++ b/src/test/scala/com/amazon/deequ/analyzers/runners/AnalysisRunnerTests.scala
@@ -532,5 +532,32 @@ class AnalysisRunnerTests extends AnyWordSpec
         assert(result.metric(mean).get.value === mean.calculate(data).value)
         assert(result.metric(minimum).get.value === minimum.calculate(data).value)
       }
+
+    "handle column pruning when column name collides with Spark function name" in
+      withSparkSession { session =>
+        import session.implicits._
+        val data = Seq(
+          ("setosa", 5),
+          ("setosa", 4),
+          ("versicolor", 6),
+          ("versicolor", 7),
+          ("virginica", 6)
+        ).toDF("flower_type", "length")
+
+        val completeness = Completeness("length")
+        val mean = Mean("length")
+        val maximum = Maximum("length")
+
+        val analysis = Analysis()
+          .addAnalyzer(completeness)
+          .addAnalyzer(mean)
+          .addAnalyzer(maximum)
+
+        val result = AnalysisRunner.run(data, analysis)
+
+        assert(result.metric(completeness).get.value.isSuccess)
+        assert(result.metric(mean).get.value.isSuccess)
+        assert(result.metric(maximum).get.value.get === 7.0)
+      }
   }
 }

--- a/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerTest.scala
+++ b/src/test/scala/com/amazon/deequ/profiles/ColumnProfilerTest.scala
@@ -572,6 +572,36 @@ class ColumnProfilerTest extends AnyWordSpec with Matchers with SparkContextSpec
       assert(histogram(NullFieldReplacement).absolute == 1)
       assert(histogram(NullFieldReplacement).ratio == 1.0 / nRows)
     }
+
+    "profile a numeric column whose name requires escaping (e.g. a leading space)" in
+      withSparkSession { session =>
+        val schema = StructType(Seq(
+          StructField("flower_type", StringType),
+          StructField(" length", IntegerType)
+        ))
+        val rows = session.sparkContext.parallelize(Seq(
+          Row("setosa", 5),
+          Row("setosa", 4),
+          Row("versicolor", 6),
+          Row("versicolor", 7),
+          Row("virginica", 6)
+        ))
+        val data = session.createDataFrame(rows, schema)
+
+        val profiles = ColumnProfiler.profile(data).profiles
+
+        // Profiles are keyed by the original (un-escaped) column name.
+        val lengthProfile = profiles(" length")
+        assert(lengthProfile.dataType == DataTypeInstances.Integral)
+        assert(lengthProfile.completeness == 1.0)
+        lengthProfile match {
+          case n: NumericColumnProfile =>
+            assert(n.maximum.contains(7.0))
+            assert(n.minimum.contains(4.0))
+          case other =>
+            fail(s"expected a NumericColumnProfile, got $other")
+        }
+      }
   }
 
   "return correct profile for the Titanic dataset" in withSparkSession { session =>


### PR DESCRIPTION
## Summary
- Cherry-pick 3 bug fixes from master (2.0.21) onto the Spark 4.1 branch
  - Fix DuplicateRowCount row-level boolean semantics (#746)
  - Backtick-escape column names in pruneColumns (#748)
  - Fix profiling of columns whose names require escaping (#752)
- Bump version to 2.0.21-spark-4.1

## Test plan
- [x] All 1227 tests pass (`mvn clean verify`)